### PR TITLE
Render non supported languages as markdown

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -92,3 +92,11 @@ You can copy also results from the inline executed shell:
 ```sh { interactive=false }
 openssl rand -base64 32
 ```
+
+## Non-Supported Languages
+
+These are shown as simple markdown, e.g:
+
+```py { readonly=true }
+print("Hello World")
+```

--- a/src/extension/notebook.ts
+++ b/src/extension/notebook.ts
@@ -5,8 +5,9 @@ import vscode from 'vscode'
 
 import type { ParsedDocument } from '../types'
 
-import { PLATFORM_OS } from './constants'
+import executor from './executors'
 import Languages from './languages'
+import { PLATFORM_OS } from './constants'
 
 declare var globalThis: any
 
@@ -83,7 +84,8 @@ export class Serializer implements vscode.NotebookSerializer {
         acc.push(cell)
       }
 
-      if (s.lines) {
+      const isSupported = Object.keys(executor).includes(s.language || '')
+      if (s.lines && isSupported) {
         const lines = s.lines.join('\n')
         const language = s.language === 'shell' ? 'sh' : s.language
         const cell = new vscode.NotebookCellData(
@@ -106,6 +108,14 @@ export class Serializer implements vscode.NotebookSerializer {
         /**
          * code block
          */
+        acc.push(cell)
+      } else if (s.language) {
+        const cell = new vscode.NotebookCellData(
+          vscode.NotebookCellKind.Markup,
+          `\`\`\`${s.language}\n${(s.lines || []).join('\n').trim()}\n\`\`\``,
+          'markdown'
+        )
+        cell.metadata = { id: i }
         acc.push(cell)
       }
       return acc


### PR DESCRIPTION
This patch is a proposal to just have non supported languages being rendered as plain markdown, e.g.:

![Screenshot 2022-10-24 at 19 45 47](https://user-images.githubusercontent.com/731337/197670347-6d832a49-9133-4c6f-838f-b32f37def610.png)
