### PR TITLE
More improvements to export statements

### DIFF
--- a/src/extension/executors/task.ts
+++ b/src/extension/executors/task.ts
@@ -1,5 +1,4 @@
 import path from 'node:path'
-import cp from 'node:child_process'
 
 import {
   Task, TextDocument, NotebookCellExecution, TaskScope, tasks,
@@ -8,16 +7,15 @@ import {
 } from 'vscode'
 
 // import { ExperimentalTerminal } from "../terminal"
-import { populateEnvVar, getExecutionProperty, getCmdShellSeq, } from '../utils'
-import { ENV_STORE, PLATFORM_OS } from '../constants'
+import { getExecutionProperty, getCmdShellSeq } from '../utils'
+import { PLATFORM_OS, ENV_STORE } from '../constants'
 import type { Kernel } from '../kernel'
 
+import { retrieveShellCommand } from './utils'
 import { sh as inlineSh } from './shell'
 
 const BACKGROUND_TASK_HIDE_TIMEOUT = 2000
 const LABEL_LIMIT = 15
-const EXPORT_EXTRACT_REGEX = /(\n*)export \w+=(("(.|\n)+(?="))|(.+(?=\n)))/gi
-const EXPORT_REGEX = /(\n*)export \w+=/gi
 
 export function closeTerminalByEnvID (id: string) {
   const terminal = window.terminals.find((t) => (t.creationOptions as TerminalOptions).env?.RUNME_ID === id)
@@ -32,87 +30,12 @@ async function taskExecutor(
   doc: TextDocument
 ): Promise<boolean> {
   const cwd = path.dirname(doc.uri.fsPath)
-  let cellText = doc.getText()
-
-  /**
-   * find export commands
-   */
-  const rawText = doc.getText()
-  const isSingleLine = (rawText.match(EXPORT_REGEX) || []).length <= 1
-  const lines: string[] = isSingleLine ? [rawText] : rawText.split('\n')
-  const exportMatches: string[] = []
-  for (const l of lines) {
-    const code = l.endsWith('\n') ? l : `${l}\n`
-    const exps = (code.match(EXPORT_EXTRACT_REGEX) || [])
-      .map((m) => m.trim())
-    exportMatches.push(...exps)
+  const cellText = await retrieveShellCommand(exec)
+  if (!cellText) {
+    return false
   }
+
   const stateEnv = Object.fromEntries(ENV_STORE)
-  for (const e of exportMatches) {
-    const [key, ph] = e.slice('export '.length).split('=')
-    const hasStringValue = ph.startsWith('"')
-    const placeHolder = hasStringValue ? ph.slice(1) : ph
-
-    if (placeHolder.startsWith('$(') && placeHolder.endsWith(')')) {
-      /**
-       * evaluate expression
-       */
-      const expression = placeHolder.slice(2, -1)
-      const expressionProcess = cp.spawn(expression, {
-        cwd,
-        shell: true
-      })
-      const [isError, data] = await new Promise<[number, string]>((resolve) => {
-        let data = ''
-        expressionProcess.stdout.on('data', (payload) => { data += payload.toString() })
-        expressionProcess.stderr.on('data', (payload) => { data += payload.toString() })
-        expressionProcess.on('close', (code) => {
-          if (code && code > 0) {
-            return resolve([code, data])
-          }
-
-          return resolve([0, data])
-        })
-      })
-
-      if (isError) {
-        window.showErrorMessage(`Failed to evaluate expression "${expression}": ${data}`)
-        return false
-      }
-
-      stateEnv[key] = data
-    } else {
-      /**
-       * ask user for value
-       */
-      stateEnv[key] = populateEnvVar(await window.showInputBox({
-        title: `Set Environment Variable "${key}"`,
-        ignoreFocusOut: true,
-        placeHolder,
-        prompt: 'Your shell script wants to set some environment variables, please enter them here.',
-        ...(hasStringValue ? { value: placeHolder } : {})
-      }) || '', {...process.env, ...stateEnv })
-    }
-
-    /**
-     * we don't want to run these exports anymore as we already stored
-     * them in our extension state
-     */
-    cellText = cellText.replace(
-      /**
-       * In case of `export foo="bar", our match includes the preceeding '"' but not
-       * the ending one. To properly cut out the line from the script we need to add
-       * it back again.
-       */
-      e + (hasStringValue ? '"' : ''),
-      ''
-    )
-
-    /**
-     * persist env variable in memory
-     */
-    ENV_STORE.set(key, stateEnv[key])
-  }
 
   const RUNME_ID = `${doc.fileName}:${exec.cell.index}`
   const env = {

--- a/src/extension/executors/task.ts
+++ b/src/extension/executors/task.ts
@@ -31,7 +31,7 @@ async function taskExecutor(
 ): Promise<boolean> {
   const cwd = path.dirname(doc.uri.fsPath)
   const cellText = await retrieveShellCommand(exec)
-  if (!cellText) {
+  if (typeof cellText !== 'string') {
     return false
   }
 

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -1,7 +1,14 @@
-import { NotebookCellOutput, NotebookCellExecution, NotebookCellOutputItem } from 'vscode'
+import cp from 'node:child_process'
+import path from 'node:path'
 
+import { NotebookCellOutput, NotebookCellExecution, NotebookCellOutputItem, window } from 'vscode'
+
+import { ENV_STORE } from '../constants'
 import { OutputType } from '../../constants'
 import type { CellOutput } from '../../types'
+
+const ENV_VAR_REGEXP = /(\$\w+)/g
+const EXPORT_EXTRACT_REGEX = /(\n*)export \w+=(("(.|\n)+(?="))|('.+(?='))|(.+(?=\n)))/gi
 
 export function renderError (exec: NotebookCellExecution, output: string) {
   return exec.replaceOutput(new NotebookCellOutput([
@@ -13,4 +20,105 @@ export function renderError (exec: NotebookCellExecution, output: string) {
       OutputType.error
     )
   ]))
+}
+
+export function populateEnvVar (value: string, env = process.env) {
+  for (const m of value.match(ENV_VAR_REGEXP) || []) {
+    const envVar = m.slice(1) // slice out '$'
+    value = value.replace(m, env[envVar] || '')
+  }
+
+  return value
+}
+
+/**
+ * Helper method to parse the shell code and runs the following operations:
+ *   - fetches environment variable exports and puts them into ENV_STORE
+ *   - runs embedded shell scripts for exports, e.g. `exports=$(echo "foobar")`
+ *
+ * @param exec NotebookCellExecution
+ * @returns cell text if all operation to retrieve the cell text could be executed, undefined otherwise
+ */
+export async function retrieveShellCommand (exec: NotebookCellExecution) {
+  let cellText = exec.cell.document.getText()
+  const cwd = path.dirname(exec.cell.document.uri.fsPath)
+  const rawText = exec.cell.document.getText()
+  const lines: string[] = rawText.split('\n').filter(Boolean)
+  const exportMatches: string[] = []
+
+  for (const l of lines) {
+    const code = `${l}\n` // attach a new line so we can match the end of the value
+    const exps = (code.match(EXPORT_EXTRACT_REGEX) || [])
+      .map((m) => m.trim())
+    exportMatches.push(...exps)
+  }
+
+  const stateEnv = Object.fromEntries(ENV_STORE)
+  for (const e of exportMatches) {
+    const [key, ph] = e.slice('export '.length).split('=')
+    const hasStringValue = ph.startsWith('"') || ph.startsWith('\'')
+    const quoteChar = ph[0]
+    const placeHolder = hasStringValue ? ph.slice(1) : ph
+
+    if (placeHolder.startsWith('$(') && placeHolder.endsWith(')')) {
+      /**
+       * evaluate expression
+       */
+      const expression = placeHolder.slice(2, -1)
+      const expressionProcess = cp.spawn(expression, {
+        cwd,
+        shell: true
+      })
+      const [isError, data] = await new Promise<[number, string]>((resolve) => {
+        let data = ''
+        expressionProcess.stdout.on('data', (payload) => { data += payload.toString() })
+        expressionProcess.stderr.on('data', (payload) => { data += payload.toString() })
+        expressionProcess.on('close', (code) => {
+          if (code && code > 0) {
+            return resolve([code, data])
+          }
+
+          return resolve([0, data])
+        })
+      })
+
+      if (isError) {
+        window.showErrorMessage(`Failed to evaluate expression "${expression}": ${data}`)
+        return undefined
+      }
+
+      stateEnv[key] = data
+    } else {
+      /**
+       * ask user for value
+       */
+      stateEnv[key] = populateEnvVar(await window.showInputBox({
+        title: `Set Environment Variable "${key}"`,
+        ignoreFocusOut: true,
+        placeHolder,
+        prompt: 'Your shell script wants to set some environment variables, please enter them here.',
+        ...(hasStringValue ? { value: placeHolder } : {})
+      }) || '', {...process.env, ...stateEnv })
+    }
+
+    /**
+     * we don't want to run these exports anymore as we already stored
+     * them in our extension state
+     */
+    cellText = cellText.replace(
+      /**
+       * In case of `export foo="bar", our match includes the preceeding '"' but not
+       * the ending one. To properly cut out the line from the script we need to add
+       * it back again.
+       */
+      e + (hasStringValue ? quoteChar : ''),
+      ''
+    )
+
+    /**
+     * persist env variable in memory
+     */
+    ENV_STORE.set(key, stateEnv[key])
+  }
+  return cellText
 }

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -8,6 +8,9 @@ import { OutputType } from '../../constants'
 import type { CellOutput } from '../../types'
 
 const ENV_VAR_REGEXP = /(\$\w+)/g
+/**
+ * for understanding post into https://jex.im/regulex/
+ */
 const EXPORT_EXTRACT_REGEX = /(\n*)export \w+=(("[^"]*")|('[^']*')|(.+(?=(\n|;))))/gim
 
 export function renderError (exec: NotebookCellExecution, output: string) {

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -83,9 +83,10 @@ export async function retrieveShellCommand (exec: NotebookCellExecution) {
       }
 
       stateEnv[key] = data
-    } else {
+    } else if (!placeHolder.includes('\n')) {
       /**
-       * ask user for value
+       * ask user for value only if placeholder has no new line as this would be absorbed by
+       * VS Code, see https://github.com/microsoft/vscode/issues/98098
        */
       stateEnv[key] = populateEnvVar(await window.showInputBox({
         title: `Set Environment Variable "${key}"`,
@@ -94,6 +95,8 @@ export async function retrieveShellCommand (exec: NotebookCellExecution) {
         prompt: 'Your shell script wants to set some environment variables, please enter them here.',
         ...(hasStringValue ? { value: placeHolder } : {})
       }) || '', {...process.env, ...stateEnv })
+    } else {
+      stateEnv[key] = populateEnvVar(placeHolder)
     }
 
     /**

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -5,7 +5,6 @@ import { CONFIGURATION_SHELL_DEFAULTS } from '../constants'
 import executor from './executors'
 import { ENV_STORE, DEFAULT_ENV } from './constants'
 
-const ENV_VAR_REGEXP = /(\$\w+)/g
 const HASH_PREFIX_REGEXP = /^\s*\#\s*/g
 
 export function getExecutionProperty (property: keyof typeof CONFIGURATION_SHELL_DEFAULTS, cell: vscode.NotebookCell) {
@@ -27,15 +26,6 @@ export function getTerminalByCell (cell: vscode.NotebookCell) {
     const taskEnv = (t.creationOptions as vscode.TerminalOptions).env || {}
     return taskEnv.RUNME_ID === `${cell.document.fileName}:${cell.index}`
   })
-}
-
-export function populateEnvVar (value: string, env = process.env) {
-  for (const m of value.match(ENV_VAR_REGEXP) || []) {
-    const envVar = m.slice(1) // slice out '$'
-    value = value.replace(m, env[envVar] || '')
-  }
-
-  return value
 }
 
 export function resetEnv () {

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -1,0 +1,104 @@
+import url from 'node:url'
+
+import { window } from 'vscode'
+import { expect, vi, test, beforeEach } from 'vitest'
+
+import { ENV_STORE } from '../../../src/extension/constants'
+import { retrieveShellCommand } from '../../../src/extension/executors/utils'
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
+vi.mock('vscode', () => ({
+  window: {
+    showInputBox: vi.fn(),
+    showErrorMessage: vi.fn()
+  },
+  workspace: {
+    getConfiguration: vi.fn()
+  }
+}))
+
+beforeEach(() => {
+  vi.mocked(window.showInputBox).mockClear()
+  vi.mocked(window.showErrorMessage).mockClear()
+})
+
+test('should support export without quotes', async () => {
+  const exec: any = { cell: { document: {
+    getText: vi.fn().mockReturnValue('export foo=bar'),
+    uri: { fsPath: __dirname }
+  }}}
+  vi.mocked(window.showInputBox).mockResolvedValue('barValue')
+  const cellText = await retrieveShellCommand(exec)
+  expect(cellText).toBe('')
+  expect(ENV_STORE.get('foo')).toBe('barValue')
+  expect(vi.mocked(window.showInputBox).mock.calls[0][0]?.placeHolder).toBe('bar')
+  expect(vi.mocked(window.showInputBox).mock.calls[0][0]?.value).toBe(undefined)
+})
+
+test('should populate value if quotes are used', async () => {
+  const exec: any = { cell: { document: {
+    getText: vi.fn().mockReturnValue('export foo="bar"'),
+    uri: { fsPath: __dirname }
+  }}}
+  vi.mocked(window.showInputBox).mockResolvedValue('barValue')
+  const cellText = await retrieveShellCommand(exec)
+  expect(cellText).toBe('')
+  expect(ENV_STORE.get('foo')).toBe('barValue')
+  expect(vi.mocked(window.showInputBox).mock.calls[0][0]?.placeHolder).toBe('bar')
+  expect(vi.mocked(window.showInputBox).mock.calls[0][0]?.value).toBe('bar')
+})
+
+test('can support single quotes', async () => {
+  const exec: any = { cell: { document: {
+    getText: vi.fn().mockReturnValue('export foo=\'bar\''),
+    uri: { fsPath: __dirname }
+  }}}
+  vi.mocked(window.showInputBox).mockResolvedValue('barValue')
+  const cellText = await retrieveShellCommand(exec)
+  expect(cellText).toBe('')
+  expect(ENV_STORE.get('foo')).toBe('barValue')
+  expect(vi.mocked(window.showInputBox).mock.calls[0][0]?.placeHolder).toBe('bar')
+  expect(vi.mocked(window.showInputBox).mock.calls[0][0]?.value).toBe('bar')
+})
+
+test('can handle new lines before and after', async () => {
+  const exec: any = { cell: { document: {
+    getText: vi.fn().mockReturnValue('\n\nexport foo=bar\n'),
+    uri: { fsPath: __dirname }
+  }}}
+  const cellText = await retrieveShellCommand(exec)
+  expect(cellText).toBe('\n\n\n')
+})
+
+test('can populate pre-existing envs', async () => {
+  const exec: any = { cell: { document: {
+    getText: vi.fn().mockReturnValue('export foo="foo$BARloo"'),
+    uri: { fsPath: __dirname }
+  }}}
+  process.env.BAR = 'rab'
+  vi.mocked(window.showInputBox).mockResolvedValue('foo$BAR')
+  const cellText = await retrieveShellCommand(exec)
+  expect(cellText).toBe('')
+  expect(ENV_STORE.get('foo')).toBe('foorab')
+})
+
+test('can support expressions', async () => {
+  const exec: any = { cell: { document: {
+    getText: vi.fn().mockReturnValue('export foo=$(echo "foo$BAR")'),
+    uri: { fsPath: __dirname }
+  }}}
+  process.env.BAR = 'bar'
+  const cellText = await retrieveShellCommand(exec)
+  expect(cellText).toBe('')
+  expect(ENV_STORE.get('foo')).toBe('foobar\n')
+})
+
+test('returns undefined if expression fails', async () => {
+  const exec: any = { cell: { document: {
+    getText: vi.fn().mockReturnValue('export foo=$(FAIL)'),
+    uri: { fsPath: __dirname }
+  }}}
+  expect(await retrieveShellCommand(exec)).toBeUndefined()
+  expect(window.showErrorMessage).toBeCalledTimes(1)
+})

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -114,4 +114,5 @@ test('supports multiline exports', async () => {
   expect(ENV_STORE.get('bar')).toBe('foo')
   expect(ENV_STORE.get('foo')).toBe('some\nmultiline\nexport')
   expect(ENV_STORE.get('foobar')).toBe('barfoo')
+  expect(window.showInputBox).toBeCalledTimes(2)
 })

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -68,7 +68,7 @@ test('can handle new lines before and after', async () => {
     uri: { fsPath: __dirname }
   }}}
   const cellText = await retrieveShellCommand(exec)
-  expect(cellText).toBe('\n\n\n')
+  expect(cellText).toBe('\n')
 })
 
 test('can populate pre-existing envs', async () => {
@@ -101,4 +101,17 @@ test('returns undefined if expression fails', async () => {
   }}}
   expect(await retrieveShellCommand(exec)).toBeUndefined()
   expect(window.showErrorMessage).toBeCalledTimes(1)
+})
+
+test('supports multiline exports', async () => {
+  const exec: any = { cell: { document: {
+    getText: vi.fn().mockReturnValue('export bar=foo\nexport foo="some\nmultiline\nexport"\nexport foobar="barfoo"'),
+    uri: { fsPath: __dirname }
+  }}}
+  vi.mocked(window.showInputBox).mockImplementation(({ value, placeHolder }: any) => value || placeHolder)
+  const cellText = await retrieveShellCommand(exec)
+  expect(cellText).toBe('')
+  expect(ENV_STORE.get('bar')).toBe('foo')
+  expect(ENV_STORE.get('foo')).toBe('some\nmultiline\nexport')
+  expect(ENV_STORE.get('foobar')).toBe('barfoo')
 })

--- a/tests/extension/utilts.test.ts
+++ b/tests/extension/utilts.test.ts
@@ -4,7 +4,6 @@ import { expect, vi, test, beforeAll, afterAll, suite } from 'vitest'
 import {
   getExecutionProperty,
   getTerminalByCell,
-  populateEnvVar,
   resetEnv,
   getKey,
   getCmdShellSeq,
@@ -49,13 +48,6 @@ test('getTerminalByCell', () => {
     .toBe(undefined)
   expect(getTerminalByCell({ document: { fileName: 'foobar' }, index: 123} as any))
     .not.toBe(undefined)
-})
-
-test('populateEnvVar', () => {
-  expect(populateEnvVar(
-    'export PATH="/foo/$BAR/$LOO:$PATH:/$FOO"',
-    { PATH: '/usr/bin', FOO: 'foo', BAR: 'bar' }
-  )).toBe('export PATH="/foo/bar/:/usr/bin:/foo"')
 })
 
 test('resetEnv', () => {


### PR DESCRIPTION
fixes #32

This patch includes:
- moving code into utils file for better testability
- unit test coverage for handling export lines in shell code
- support exports with single quotes (e.g. `export Foo='bar'`)