### PR TITLE
Allow user to determine working directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,16 @@
             "scope": "machine",
             "default": true,
             "markdownDescription": "If set to `true`, the terminal closes if task succeeds running."
+          },
+          "runme.shell.workingDirectory": {
+            "type": "string",
+            "scope": "machine",
+            "default": "Relative to Markdown File",
+            "enum": [
+              "Relative to Markdown File",
+              "Relative to Workspace Directory"
+            ],
+            "markdownDescription": "Used working directory for shell or task executions."
           }
         }
       }

--- a/src/extension/constants.ts
+++ b/src/extension/constants.ts
@@ -8,6 +8,13 @@ export const DEFAULT_ENV = {
   RUNME_TASK: 'true',
   PATH: process.env.PATH || ''
 }
+
 export const ENV_STORE = new Map<string, string>(
   Object.entries(DEFAULT_ENV)
 )
+
+export enum CWD_SETTING_OPTIONS {
+  RelativeToMarkdown = 'Relative to Markdown File',
+  RelativeToWorkspaceDir = 'Relative to Workspace Directory'
+}
+export const DEFAULT_CWD_OPTION = CWD_SETTING_OPTIONS.RelativeToMarkdown

--- a/src/extension/executors/task.ts
+++ b/src/extension/executors/task.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import cp from 'node:child_process'
 
 import {
@@ -13,6 +12,7 @@ import { ENV_STORE, PLATFORM_OS } from '../constants'
 import type { Kernel } from '../kernel'
 
 import { sh as inlineSh } from './shell'
+import { getShellWorkingDirectory } from './utils'
 
 const BACKGROUND_TASK_HIDE_TIMEOUT = 2000
 const LABEL_LIMIT = 15
@@ -31,7 +31,7 @@ async function taskExecutor(
   exec: NotebookCellExecution,
   doc: TextDocument
 ): Promise<boolean> {
-  const cwd = path.dirname(doc.uri.fsPath)
+  const cwd = getShellWorkingDirectory(exec)
   let cellText = doc.getText()
 
   /**

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -1,5 +1,8 @@
-import { NotebookCellOutput, NotebookCellExecution, NotebookCellOutputItem } from 'vscode'
+import path from 'node:path'
 
+import { NotebookCellOutput, NotebookCellExecution, NotebookCellOutputItem, workspace } from 'vscode'
+
+import { DEFAULT_CWD_OPTION, CWD_SETTING_OPTIONS } from '../constants'
 import { OutputType } from '../../constants'
 import type { CellOutput } from '../../types'
 
@@ -13,4 +16,21 @@ export function renderError (exec: NotebookCellExecution, output: string) {
       OutputType.error
     )
   ]))
+}
+
+/**
+ * Get working directory for shell or task executions
+ * @param exec NotebookCellExecution
+ * @returns the working directory to be used for shell executions based on the configuration
+ */
+export function getShellWorkingDirectory (exec: NotebookCellExecution) {
+  const config = workspace.getConfiguration('runme.shell')
+  const configSetting = config.get<CWD_SETTING_OPTIONS>('workingDirectory', DEFAULT_CWD_OPTION)
+
+  const wsd = workspace.workspaceFolders?.map((ws) => ws.uri.fsPath).shift()
+  if (configSetting === CWD_SETTING_OPTIONS.RelativeToWorkspaceDir && wsd) {
+    return wsd
+  }
+
+  return path.dirname(exec.cell.document.uri.fsPath)
 }

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, vi } from 'vitest'
+import { workspace } from 'vscode'
+
+import { getShellWorkingDirectory } from '../../../src/extension/executors/utils'
+import { CWD_SETTING_OPTIONS } from '../../../src/extension/constants'
+
+vi.mock('vscode', () => {
+  const config = new Map()
+  return {
+    workspace: {
+      config,
+      workspaceFolders: [{
+        uri: { fsPath: '/bar/foo' }
+      }, {
+        uri: { fsPath: '/foo/bar' }
+      }],
+      getConfiguration: vi.fn().mockReturnValue(config)
+    }
+  }
+})
+
+
+describe('getShellWorkingDirectory', () => {
+  const exec: any = {
+    cell: {
+      document: {
+        getText: vi.fn(),
+        uri: { fsPath: '/foo/bar/file.md' }
+      }
+    }
+  }
+
+  test('returns relative from markdown as default', () => {
+    expect(getShellWorkingDirectory(exec)).toBe('/foo/bar')
+  })
+
+  test('returns relative from workspace if set', () => {
+    // @ts-expect-error mock feature
+    workspace.config.set('workingDirectory', CWD_SETTING_OPTIONS.RelativeToWorkspaceDir)
+    expect(getShellWorkingDirectory(exec)).toBe('/bar/foo')
+  })
+})


### PR DESCRIPTION
fixes #25

The current implementation always runs tasks/shells based on the directory where the opened markdown is located. Users might however like to always work based on the working directory of the workspace. This patch allows to define this with having "Relative to Markdown" as default.