### PR TITLE
Experience when creating a new markdown file

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -45,3 +45,16 @@ export const env = {
   },
   openExternal: vi.fn()
 }
+
+export enum NotebookCellKind {
+  Markup = 1,
+  Code = 2
+}
+
+export class NotebookCellData {
+  constructor (public markup: any, public content: string, public language: string) {}
+}
+
+export class NotebookData {
+  constructor (public data: any) {}
+}

--- a/src/extension/notebook.ts
+++ b/src/extension/notebook.ts
@@ -16,13 +16,13 @@ const DEFAULT_LANG_ID = 'text'
 const LANGUAGES_WITH_INDENTATION = ['html', 'tsx', 'ts', 'js']
 
 export class Serializer implements NotebookSerializer {
-  private fileContent?: string
-  private readonly ready: Promise<Error | void>
-  private readonly languages: Languages
+  // private fileContent?: string
+  readonly #ready: Promise<Error | void>
+  readonly #languages: Languages
 
   constructor(private context: ExtensionContext) {
-    this.languages = Languages.fromContext(this.context)
-    this.ready = this.#initWasm()
+    this.#languages = Languages.fromContext(this.context)
+    this.#ready = this.#initWasm()
   }
 
   async #initWasm () {
@@ -39,7 +39,7 @@ export class Serializer implements NotebookSerializer {
   }
 
   public async deserializeNotebook(content: Uint8Array): Promise<NotebookData> {
-    const err = await this.ready
+    const err = await this.#ready
 
     const md = content.toString()
     const doc = globalThis.GetDocument(md) as ParsedDocument
@@ -55,14 +55,14 @@ export class Serializer implements NotebookSerializer {
 
     let snippets = doc.document ?? []
     if (snippets.length === 0) {
-      return this.#printCell('⚠️ __Error__: no cells found!')
+      return this.#printCell('_💡 double click on this cell to start editing..._')
     }
 
     try {
       snippets = await Promise.all(snippets.map(s => {
         const content = s.content
         if (content && s.language === undefined) {
-          return this.languages.guess(content, PLATFORM_OS).then(guessed => {
+          return this.#languages.guess(content, PLATFORM_OS).then(guessed => {
             s.language = guessed
             return s
           })

--- a/tests/extension/__snapshots__/notebook.test.ts.snap
+++ b/tests/extension/__snapshots__/notebook.test.ts.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1
+
+exports[`should encourage to edit cell when none was found 1`] = `
+NotebookData {
+  "data": [
+    NotebookCellData {
+      "content": "_💡 double click on this cell to start editing..._",
+      "language": "markdown",
+      "markup": 1,
+    },
+  ],
+}
+`;
+
+exports[`should show error 1`] = `
+NotebookData {
+  "data": [
+    NotebookCellData {
+      "content": "⚠️ __Error__: document could not be loaded
+<small>ups</small>.<p>Please report bug at https://github.com/stateful/vscode-runme/issues or let us know on Discord (https://discord.gg/BQm8zRCBUY)</p>",
+      "language": "markdown",
+      "markup": 1,
+    },
+  ],
+}
+`;

--- a/tests/extension/notebook.test.ts
+++ b/tests/extension/notebook.test.ts
@@ -1,0 +1,34 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { Serializer } from '../../src/extension/notebook.js'
+
+vi.mock('vscode')
+
+const webAssemblyInstantiateOrig = WebAssembly.instantiate.bind(WebAssembly)
+beforeEach(() => {
+  WebAssembly.instantiate = vi.fn() as any
+})
+
+test('should show error', async () => {
+  globalThis.Go = class {}
+  globalThis.GetDocument = vi.fn()
+  vi.mocked(WebAssembly.instantiate).mockRejectedValue(new Error('ups'))
+  const context: any = { extensionUri: { fsPath: '/foo/bar' } }
+  const serializer = new Serializer(context)
+  const cells = await serializer.deserializeNotebook(new Uint8Array())
+  expect(cells).toMatchSnapshot()
+})
+
+test('should encourage to edit cell when none was found', async () => {
+  globalThis.Go = class { run () {} }
+  globalThis.GetDocument = vi.fn().mockReturnValue({})
+  vi.mocked(WebAssembly.instantiate).mockResolvedValue({ run: vi.fn() } as any)
+  const context: any = { extensionUri: { fsPath: '/foo/bar' } }
+  const serializer = new Serializer(context)
+  const cells = await serializer.deserializeNotebook(new Uint8Array())
+  expect(cells).toMatchSnapshot()
+})
+
+afterEach(() => {
+  WebAssembly.instantiate = webAssemblyInstantiateOrig
+})

--- a/vitest.conf.ts
+++ b/vitest.conf.ts
@@ -14,10 +14,10 @@ export default defineConfig({
     coverage: {
       enabled: true,
       exclude: ['**/build/**', '**/__fixtures__/**', '**/*.test.ts'],
-      statements: 38,
-      branches: 90,
-      functions: 33,
-      lines: 38
+      statements: 42,
+      branches: 91,
+      functions: 35,
+      lines: 42
     }
   }
 })


### PR DESCRIPTION
If a developer creates a new markdown file, e.g. a `README.md`, the current experience will show a warning message saying that no cells were found without anything actionable to do.

<img width="1079" alt="Screenshot 2022-11-03 at 12 12 25" src="https://user-images.githubusercontent.com/731337/199813190-acb6ac28-6cb4-45f6-9385-2f95c5627e45.png">

Suggestion: instead show an empty notebook with the ability to edit and create cells.