### PR TITLE
options to open runme as text editor and text-edit md as runme

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -41,6 +41,10 @@ export const commands = {
   registerCommand: vi.fn()
 }
 
+export enum ViewColumn  {
+  Beside = 'Beside'
+}
+
 export const env = {
   clipboard: {
     writeText: vi.fn()

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -32,7 +32,9 @@ export const terminal = {
 export const window = {
   showWarningMessage: vi.fn(),
   showInformationMessage: vi.fn(),
-  createTerminal: vi.fn().mockReturnValue(terminal)
+  createTerminal: vi.fn().mockReturnValue(terminal),
+  showNotebookDocument: vi.fn(),
+  showTextDocument: vi.fn()
 }
 
 export const commands = {

--- a/assets/runme-logo-dark.svg
+++ b/assets/runme-logo-dark.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 1H2C1.44772 1 1 1.44772 1 2V16C1 16.5523 1.44772 17 2 17H16C16.5523 17 17 16.5523 17 16V2C17 1.44772 16.5523 1 16 1Z" stroke="white" stroke-width="0.5"/>
+<path d="M6 11.9842V6.00137C6 5.92847 12 8.92125 12 8.9928C12 9.06434 6 12.0776 6 11.9842Z" fill="white" stroke="white" stroke-width="0.5"/>
+</svg>

--- a/assets/runme-logo-light.svg
+++ b/assets/runme-logo-light.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 1H2C1.44772 1 1 1.44772 1 2V16C1 16.5523 1.44772 17 2 17H16C16.5523 17 17 16.5523 17 16V2C17 1.44772 16.5523 1 16 1Z" stroke="black" stroke-width="0.5"/>
+<path d="M6 11.9842V6.00137C6 5.92847 12 8.92125 12 8.9928C12 9.06434 6 12.0776 6 11.9842Z" fill="black" stroke="black" stroke-width="0.5"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -102,7 +102,12 @@
         {
           "command": "runme.openAsRunmeNotebook",
           "when": "false"
+        },
+        {
+          "command": "runme.openSplitViewAsMarkdownText",
+          "when": "false"
         }
+
       ],
       "editor/title": [
         {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       {
         "command": "runme.openSplitViewAsMarkdownText",
         "category": "Runme",
-        "title": "Open runme notebook as default markdown",
+        "title": "Open runme notebook as text editor",
         "icon": "$(markdown)"
       }
     ],
@@ -110,13 +110,6 @@
           "when": "resourceLangId == markdown && notebookType == runme",
           "command": "runme.openSplitViewAsMarkdownText",
           "group": "navigation"
-        }
-      ],
-      "editor/context": [
-        {
-          "command": "runme.openSplitViewAsMarkdownText",
-          "group": "navigation",
-          "when": "resourceLangId == markdown && notebookType == runme"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       {
         "command": "runme.openAsRunmeNotebook",
         "category": "Runme",
-        "title": "Open markdown as runme",
+        "title": "Open markdown as Runme",
         "icon": {
           "light": "assets/runme-logo-light.svg",
           "dark": "assets/runme-logo-dark.svg"
@@ -89,7 +89,7 @@
       {
         "command": "runme.openSplitViewAsMarkdownText",
         "category": "Runme",
-        "title": "Open runme notebook as text editor",
+        "title": "Open Runme notebook in text editor",
         "icon": "$(markdown)"
       }
     ],
@@ -97,6 +97,10 @@
       "commandPalette": [
         {
           "command": "runme.openTerminal",
+          "when": "false"
+        }, 
+        {
+          "command": "runme.openAsRunmeNotebook",
           "when": "false"
         }
       ],
@@ -107,7 +111,7 @@
           "group": "navigation"
         },
         {
-          "when": "resourceLangId == markdown && notebookType == runme",
+          "when": "notebookType == runme",
           "command": "runme.openSplitViewAsMarkdownText",
           "group": "navigation"
         }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   ],
   "activationEvents": [
     "onNotebook:runme",
-    "onRenderer:runme-renderer"
+    "onRenderer:runme-renderer",
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -70,6 +71,26 @@
         "command": "runme.resetEnv",
         "category": "Runme",
         "title": "Reset Environment Variables for current VS Code session"
+      },
+      {
+        "command": "runme.resetEnv",
+        "category": "Runme",
+        "title": "Reset Environment Variables for current VS Code session"
+      },
+      {
+        "command": "runme.openAsRunmeNotebook",
+        "category": "Runme",
+        "title": "Open markdown as runme",
+        "icon": {
+          "light": "assets/runme-logo-light.svg",
+          "dark": "assets/runme-logo-dark.svg"
+        }
+      },
+      {
+        "command": "runme.openSplitViewAsMarkdownText",
+        "category": "Runme",
+        "title": "Open runme notebook as default markdown",
+        "icon": "$(markdown)"
       }
     ],
     "menus": {
@@ -77,6 +98,25 @@
         {
           "command": "runme.openTerminal",
           "when": "false"
+        }
+      ],
+      "editor/title": [
+        {
+          "when": "resourceLangId == markdown && !notebookType",
+          "command": "runme.openAsRunmeNotebook",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == markdown && notebookType == runme",
+          "command": "runme.openSplitViewAsMarkdownText",
+          "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "runme.openSplitViewAsMarkdownText",
+          "group": "navigation",
+          "when": "resourceLangId == markdown && notebookType == runme"
         }
       ]
     },

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { NotebookCell, Uri, window, env, NotebookDocument, TextDocument } from 'vscode'
+import { NotebookCell, Uri, window, env, NotebookDocument, TextDocument, ViewColumn } from 'vscode'
 
 import { CliProvider } from '../provider/cli'
 import { getTerminalByCell } from '../utils'
@@ -34,12 +34,12 @@ export async function runCLICommand (cell: NotebookCell) {
 }
 export function openAsRunmeNotebook (doc: NotebookDocument) {
   window.showNotebookDocument(doc, {
-    viewColumn: 2
+    viewColumn: ViewColumn.Beside
   })
 }
 
 export function openSplitViewAsMarkdownText (doc: TextDocument) {
   window.showTextDocument(doc, {
-    viewColumn: 2
+    viewColumn: ViewColumn.Beside
   })
 }

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { NotebookCell, Uri, window, env } from 'vscode'
+import vscode, { NotebookCell, Uri, window, env, NotebookDocument, TextDocument } from 'vscode'
 
 import { CliProvider } from '../provider/cli'
 import { getTerminalByCell } from '../utils'
@@ -31,4 +31,15 @@ export async function runCLICommand (cell: NotebookCell) {
   const term = window.createTerminal(`CLI: ${cliName}`)
   term.show(false)
   term.sendText(`runme run ${cliName} --chdir="${path.dirname(cell.document.uri.fsPath)}"`)
+}
+export function openAsRunmeNotebook (doc: NotebookDocument) {
+  vscode.window.showNotebookDocument(doc, {
+    viewColumn: vscode.ViewColumn.Beside
+  })
+}
+
+export function openSplitViewAsMarkdownText (doc: TextDocument) {
+  vscode.window.showTextDocument(doc, {
+    viewColumn: vscode.ViewColumn.Beside
+  })
 }

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import vscode, { NotebookCell, Uri, window, env, NotebookDocument, TextDocument } from 'vscode'
+import { NotebookCell, Uri, window, env, NotebookDocument, TextDocument } from 'vscode'
 
 import { CliProvider } from '../provider/cli'
 import { getTerminalByCell } from '../utils'
@@ -33,13 +33,13 @@ export async function runCLICommand (cell: NotebookCell) {
   term.sendText(`runme run ${cliName} --chdir="${path.dirname(cell.document.uri.fsPath)}"`)
 }
 export function openAsRunmeNotebook (doc: NotebookDocument) {
-  vscode.window.showNotebookDocument(doc, {
-    viewColumn: vscode.ViewColumn.Beside
+  window.showNotebookDocument(doc, {
+    viewColumn: 2
   })
 }
 
 export function openSplitViewAsMarkdownText (doc: TextDocument) {
-  vscode.window.showTextDocument(doc, {
-    viewColumn: vscode.ViewColumn.Beside
+  window.showTextDocument(doc, {
+    viewColumn: 2
   })
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -9,7 +9,21 @@ import { PidStatusProvider } from './provider/pid'
 import { CopyProvider } from './provider/copy'
 import { resetEnv } from './utils'
 import { CliProvider } from './provider/cli'
-import { openTerminal, runCLICommand, copyCellToClipboard } from './commands'
+import { 
+  openTerminal, 
+  runCLICommand, 
+  copyCellToClipboard, 
+  openAsRunmeNotebook, 
+  openSplitViewAsMarkdownText 
+} from './commands'
+
+export function activate(context: ExtensionContext) {
+  context.subscriptions.push(
+    commands.registerCommand('runme.openSplitViewAsMarkdownText', openSplitViewAsMarkdownText),
+    commands.registerCommand('runme.openAsRunmeNotebook', openAsRunmeNotebook),
+  )
+}
+export function deactivate() {}
 
 export class RunmeExtension {
   async initialise (context: ExtensionContext) {
@@ -27,6 +41,7 @@ export class RunmeExtension {
           outputCollapsed: true,
         },
       }),
+
       notebooks.registerNotebookCellStatusBarItemProvider('runme', new ShowTerminalProvider()),
       notebooks.registerNotebookCellStatusBarItemProvider('runme', new PidStatusProvider()),
       notebooks.registerNotebookCellStatusBarItemProvider('runme', new CliProvider()),
@@ -35,7 +50,9 @@ export class RunmeExtension {
       commands.registerCommand('runme.resetEnv', resetEnv),
       commands.registerCommand('runme.openTerminal', openTerminal),
       commands.registerCommand('runme.runCliCommand', runCLICommand),
-      commands.registerCommand('runme.copyCellToClipboard', copyCellToClipboard)
+      commands.registerCommand('runme.copyCellToClipboard', copyCellToClipboard),
+      commands.registerCommand('runme.openSplitViewAsMarkdownText', openSplitViewAsMarkdownText),
+      commands.registerCommand('runme.openAsRunmeNotebook', openAsRunmeNotebook),
     )
   }
 }

--- a/tests/extension/commands/index.test.ts
+++ b/tests/extension/commands/index.test.ts
@@ -2,10 +2,17 @@ import { beforeEach, expect, test, vi } from 'vitest'
 import {
   window, env,
   // @ts-expect-error mock feature
-  terminal
+  terminal,
+  NotebookDocument,
+  TextDocument
 } from 'vscode'
 
-import { openTerminal, copyCellToClipboard, runCLICommand } from '../../../src/extension/commands'
+import { 
+  openTerminal,
+  copyCellToClipboard, 
+  runCLICommand, 
+  openAsRunmeNotebook, 
+  openSplitViewAsMarkdownText } from '../../../src/extension/commands'
 import { getTerminalByCell } from '../../../src/extension/utils'
 import { CliProvider } from '../../../src/extension/provider/cli'
 
@@ -59,4 +66,14 @@ test('runCLICommand if CLI is installed', async () => {
   expect(window.createTerminal).toBeCalledWith('CLI: foobar')
   expect(terminal.show).toBeCalledTimes(1)
   expect(terminal.sendText).toBeCalledWith('runme run foobar --chdir="/foo"')
+})
+
+test('open markdown as runme notebook', (file: NotebookDocument) => {
+  openAsRunmeNotebook(file)
+  expect(window.showNotebookDocument).toBeCalledWith(file, { viewColumn: 2})
+})
+
+test('open runme notebook in text editor', (file: TextDocument) => {
+  openSplitViewAsMarkdownText(file)
+  expect(window.showTextDocument).toBeCalledWith(file, { viewColumn: 2})
 })

--- a/tests/extension/commands/index.test.ts
+++ b/tests/extension/commands/index.test.ts
@@ -4,7 +4,8 @@ import {
   // @ts-expect-error mock feature
   terminal,
   NotebookDocument,
-  TextDocument
+  TextDocument,
+  ViewColumn,  
 } from 'vscode'
 
 import { 
@@ -70,10 +71,10 @@ test('runCLICommand if CLI is installed', async () => {
 
 test('open markdown as Runme notebook', (file: NotebookDocument) => {
   openAsRunmeNotebook(file)
-  expect(window.showNotebookDocument).toBeCalledWith(file, { viewColumn: 2})
+  expect(window.showNotebookDocument).toBeCalledWith(file, { viewColumn: ViewColumn.Beside})
 })
 
 test('open Runme notebook in text editor', (file: TextDocument) => {
   openSplitViewAsMarkdownText(file)
-  expect(window.showTextDocument).toBeCalledWith(file, { viewColumn: 2})
+  expect(window.showTextDocument).toBeCalledWith(file, {viewColumn: ViewColumn.Beside})
 })

--- a/tests/extension/commands/index.test.ts
+++ b/tests/extension/commands/index.test.ts
@@ -68,12 +68,12 @@ test('runCLICommand if CLI is installed', async () => {
   expect(terminal.sendText).toBeCalledWith('runme run foobar --chdir="/foo"')
 })
 
-test('open markdown as runme notebook', (file: NotebookDocument) => {
+test('open markdown as Runme notebook', (file: NotebookDocument) => {
   openAsRunmeNotebook(file)
   expect(window.showNotebookDocument).toBeCalledWith(file, { viewColumn: 2})
 })
 
-test('open runme notebook in text editor', (file: TextDocument) => {
+test('open Runme notebook in text editor', (file: TextDocument) => {
   openSplitViewAsMarkdownText(file)
   expect(window.showTextDocument).toBeCalledWith(file, { viewColumn: 2})
 })

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -1,15 +1,10 @@
 import { test, expect, vi } from 'vitest'
 import { notebooks, workspace, commands } from 'vscode'
 
-import { RunmeExtension, activate } from '../../src/extension/extension'
+import { RunmeExtension } from '../../src/extension/extension'
 
 vi.mock('vscode')
 
-test('activate extension', () => {
-  const context: any = { subscriptions: [], extensionUri: { fsPath: '/foo/bar' } }
-  activate(context)
-  expect(commands.registerCommand).toBeCalledTimes(2)
-})
 
 test('initialises all providers', async () => {
   const context: any = { subscriptions: [], extensionUri: { fsPath: '/foo/bar' } }
@@ -17,5 +12,5 @@ test('initialises all providers', async () => {
   await ext.initialise(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(5)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(8)
+  expect(commands.registerCommand).toBeCalledTimes(6)
 })

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -1,9 +1,15 @@
 import { test, expect, vi } from 'vitest'
 import { notebooks, workspace, commands } from 'vscode'
 
-import { RunmeExtension } from '../../src/extension/extension'
+import { RunmeExtension, activate } from '../../src/extension/extension'
 
 vi.mock('vscode')
+
+test('activate extension', () => {
+  const context: any = { subscriptions: [], extensionUri: { fsPath: '/foo/bar' } }
+  activate(context)
+  expect(commands.registerCommand).toBeCalledTimes(8) //2 from activate and 6 from RunmeExtension class intialise
+})
 
 test('initialises all providers', async () => {
   const context: any = { subscriptions: [], extensionUri: { fsPath: '/foo/bar' } }

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -11,5 +11,5 @@ test('initialises all providers', async () => {
   await ext.initialise(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(5)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(4)
+  expect(commands.registerCommand).toBeCalledTimes(6)
 })

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -8,7 +8,7 @@ vi.mock('vscode')
 test('activate extension', () => {
   const context: any = { subscriptions: [], extensionUri: { fsPath: '/foo/bar' } }
   activate(context)
-  expect(commands.registerCommand).toBeCalledTimes(8) //2 from activate and 6 from RunmeExtension class intialise
+  expect(commands.registerCommand).toBeCalledTimes(2)
 })
 
 test('initialises all providers', async () => {
@@ -17,5 +17,5 @@ test('initialises all providers', async () => {
   await ext.initialise(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(5)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(6)
+  expect(commands.registerCommand).toBeCalledTimes(8)
 })


### PR DESCRIPTION
addresses https://github.com/stateful/vscode-runme/issues/51
![openwith-editor-menu-v2](https://user-images.githubusercontent.com/63378463/201971566-70f084bf-dba0-4d25-afff-4711c942fb40.gif)


<img width="1413" alt="Screen Shot 2022-11-15 at 8 17 41 AM" src="https://user-images.githubusercontent.com/63378463/201971504-b6cee4ce-2563-42c5-9103-c036d8ea61ac.png">

<img width="697" alt="Screen Shot 2022-11-15 at 8 17 48 AM" src="https://user-images.githubusercontent.com/63378463/201971502-c1fa675a-dca9-457d-99d3-7c8fa48058dd.png">
