### PR TITLE
Allow to display images and other mime types

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -126,9 +126,15 @@ openssl rand -base64 32
 
 ## Non-Supported Languages
 
-These are shown as simple markdown, e.g:
+These are shown as simple markdowns, e.g:
 
 ```py { readonly=true }
 def hello():
     print("Hello World")
+```
+
+## Curl an image
+
+```sh { interactive=false, mimeType=image/png }
+curl https://lever-client-logos.s3.us-west-2.amazonaws.com/a8ff9b1f-f313-4632-b90f-1f7ae7ee807f-1638388150933.png 2>/dev/null
 ```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,6 @@
  */
 
 export enum OutputType {
-  shell = 'stateful.runme/shell-stdout',
   vercel = 'stateful.runme/vercel-stdout',
   deno = 'stateful.runme/deno-stdout',
   outputItems = 'stateful.runme/output-items',

--- a/src/extension/executors/deno/deploy.ts
+++ b/src/extension/executors/deno/deploy.ts
@@ -5,7 +5,7 @@ import { OutputType, ClientMessages } from '../../../constants'
 import { ENV_STORE, DENO_ACCESS_TOKEN_KEY, DENO_PROJECT_NAME_KEY } from '../../constants'
 import { API } from '../../../utils/deno/api'
 import type { Kernel } from '../../kernel'
-import type { CellOutput, ClientMessage } from '../../../types'
+import type { CellOutputPayload, ClientMessage } from '../../../types'
 
 export async function deploy (
   this: Kernel,
@@ -28,7 +28,7 @@ export async function deploy (
      */
     exec.replaceOutput(new NotebookCellOutput([
       NotebookCellOutputItem.json(
-        <CellOutput<OutputType.deno>>{ type: OutputType.deno }, OutputType.deno)
+        <CellOutputPayload<OutputType.deno>>{ type: OutputType.deno }, OutputType.deno)
     ], { deno: { deploy: true } }))
 
     const start = new Date()

--- a/src/extension/executors/shell.ts
+++ b/src/extension/executors/shell.ts
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process'
 import { NotebookCellOutput, NotebookCellOutputItem, NotebookCellExecution } from 'vscode'
 
 import { OutputType } from '../../constants'
-import type { CellOutput } from '../../types'
+import type { CellOutputPayload } from '../../types'
 import type { Kernel } from '../kernel'
 
 async function shellExecutor(
@@ -20,21 +20,27 @@ async function shellExecutor(
     postScript = `${postScript} --prod`
     process.env['vercelProd'] = 'false'
   }
-  const outputItems: string[] = []
+  const outputItems: Buffer[] = []
   const child = spawn(postScript, { cwd, shell: true, env })
   console.log(`[Runme] Started process on pid ${child.pid}`)
   /**
    * this needs more work / specification
    */
-  const contentType = exec.cell.metadata.attributes?.['output']
+  const mime = exec.cell.metadata.attributes?.mimeType || 'text/plain' as const
   const id = exec.cell.metadata['id']
 
   /**
    * handle output for stdout and stderr
    */
-  function handleOutput(data: any) {
-    outputItems.push(data.toString().trim())
-    let item = NotebookCellOutputItem.stdout(outputItems.join('\n'))
+  function handleOutput(data: Buffer) {
+    outputItems.push(data)
+    let item = NotebookCellOutputItem.json(<CellOutputPayload<OutputType.outputItems>>{
+      type: OutputType.outputItems,
+      output: {
+        content: Buffer.concat(outputItems).toString('base64'),
+        mime
+      }
+    }, OutputType.outputItems)
 
     // hacky for now, maybe inheritence is a fitting pattern
     if (script.trim().endsWith('vercel')) {
@@ -46,39 +52,23 @@ async function shellExecutor(
 
       const status = (states.find((s) =>
         outputItems.find(
-          (oi) => oi.toLocaleLowerCase().indexOf(s.toLocaleLowerCase()) > -1
+          (oi) => oi.toString().toLocaleLowerCase().indexOf(s.toLocaleLowerCase()) > -1
         )
       ) || 'pending').replaceAll('Completing', 'complete')
       // should get this from API instead
       const projectName = env['PROJECT_NAME']
 
-      const json = <CellOutput<OutputType.vercel>>{
+      const json = <CellOutputPayload<OutputType.vercel>>{
         type: OutputType.vercel,
-        output: { outputItems, payload: { status, projectName, id, prod } }
+        output: {
+          outputItems: outputItems.map((oi) => oi.toString()),
+          payload: { status, projectName, id, prod }
+        }
       }
       console.log(JSON.stringify(json))
-      return exec.replaceOutput(new NotebookCellOutput([
-        NotebookCellOutputItem.json(json, OutputType.vercel)
-      ]))
+      item = NotebookCellOutputItem.json(json, OutputType.vercel)
     }
-
-    switch (contentType) {
-      case 'application/json':
-      item = NotebookCellOutputItem.json(<CellOutput<OutputType.shell>>{
-        type: contentType,
-        output: outputItems.join('\n')
-      }, contentType)
-    }
-
-    exec.replaceOutput([
-      new NotebookCellOutput([ item ]),
-      new NotebookCellOutput([
-        NotebookCellOutputItem.json(<CellOutput<OutputType.outputItems>>{
-          type: OutputType.outputItems,
-          output: outputItems.join('\n')
-        }, OutputType.outputItems)
-      ])
-    ])
+    exec.replaceOutput([new NotebookCellOutput([ item ])])
   }
 
   child.stdout.on('data', handleOutput)

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -5,7 +5,7 @@ import { NotebookCellOutput, NotebookCellExecution, NotebookCellOutputItem, wind
 
 import { ENV_STORE } from '../constants'
 import { OutputType } from '../../constants'
-import type { CellOutput } from '../../types'
+import type { CellOutputPayload } from '../../types'
 
 const ENV_VAR_REGEXP = /(\$\w+)/g
 /**
@@ -16,7 +16,7 @@ const EXPORT_EXTRACT_REGEX = /(\n*)export \w+=(("[^"]*")|('[^']*')|(.+(?=(\n|;))
 export function renderError (exec: NotebookCellExecution, output: string) {
   return exec.replaceOutput(new NotebookCellOutput([
     NotebookCellOutputItem.json(
-      <CellOutput<OutputType.error>>{
+      <CellOutputPayload<OutputType.error>>{
         type: OutputType.error,
         output
       },

--- a/src/extension/executors/vercel/deploy.ts
+++ b/src/extension/executors/vercel/deploy.ts
@@ -9,7 +9,7 @@ import { TextDocument, NotebookCellOutput, NotebookCellOutputItem, NotebookCellE
 import { renderError } from '../utils'
 import { OutputType } from '../../../constants'
 import type { Kernel } from '../../kernel'
-import type { CellOutput } from '../../../types'
+import type { CellOutputPayload } from '../../../types'
 
 import { listTeams, getUser, getProject, getProjects, createProject, cancelDeployment, VercelProject } from './api'
 import { getAuthToken, quickPick, updateGitIgnore, createVercelFile } from './utils'
@@ -148,7 +148,7 @@ export async function deploy (
 
       deploymentId = event.payload.id
       exec.replaceOutput(new NotebookCellOutput([
-        NotebookCellOutputItem.json(<CellOutput<OutputType.vercel>>{
+        NotebookCellOutputItem.json(<CellOutputPayload<OutputType.vercel>>{
           type: OutputType.vercel,
           output: event
         }, OutputType.vercel)
@@ -160,7 +160,7 @@ export async function deploy (
     }
   } catch (err: any) {
     exec.replaceOutput(new NotebookCellOutput([
-      NotebookCellOutputItem.json(<CellOutput<OutputType.error>>{
+      NotebookCellOutputItem.json(<CellOutputPayload<OutputType.error>>{
         type: OutputType.error,
         output: err.message
       }, OutputType.error)

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,10 +34,16 @@ export namespace WasmLib {
   }
 }
 
-export interface CellOutput<T extends OutputType> {
+interface ICellOutput<T extends OutputType> {
   type: T
   output: Payload[T]
 }
+
+export type CellOutputPayload<T extends OutputType> = T extends any
+    ? ICellOutput<T>
+    : never
+
+export type CellOutput = CellOutputPayload<OutputType>
 
 interface DenoPayload {
   deployed?: boolean
@@ -47,14 +53,13 @@ interface DenoPayload {
 
 interface Payload {
   [OutputType.error]: string
-  [OutputType.shell]: string
   [OutputType.deno]?: DenoPayload
   [OutputType.vercel]: {
     type: string
     payload?: any
     outputItems: string[]
   }
-  [OutputType.outputItems]: string
+  [OutputType.outputItems]: OutputItemsPayload
 }
 
 export interface ClientMessage <T extends ClientMessages> {
@@ -73,4 +78,9 @@ export interface ClientMessagePayload {
   }
   [ClientMessages.infoMessage]: string
   [ClientMessages.errorMessage]: string
+}
+
+export interface OutputItemsPayload {
+  content: string
+  mime: string
 }


### PR DESCRIPTION
This patch allows to define a certain mime output type. Currently it will display an image if the mime type starts with `image/`. Others can be added. It makes our shell output cell component a bit more flexible.

__Demo:__

![image](https://user-images.githubusercontent.com/731337/202832125-1db84d2d-e014-4aa3-91d6-d61bf3c62ebb.gif)
