### PR TITLE
Lower bundle size

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,4 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/*.tsbuildinfo
+node_modules

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,11 +2,16 @@
 .vscode-test/**
 out/test/**
 src/**
+.github
 .gitignore
+.next
+.wdio-vscode-service
 vsc-extension-quickstart.md
 **/tsconfig.json
 **/.eslintrc.json
 **/*.map
 **/*.ts
 **/*.tsbuildinfo
-node_modules
+**/node_modules
+tests
+coverage

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -52,7 +52,7 @@ const extensionConfig: Configuration = {
   entry: {
     extension: path.resolve(__dirname, 'src', 'extension', 'index.ts'),
   },
-  externals: ['vscode', 'vercel', '@vercel/client', 'keyv'],
+  externals: ['vscode'],
   output: {
     path: path.resolve(__dirname, 'out'),
     libraryTarget: 'commonjs2',


### PR DESCRIPTION
Do we still have to include `node_modules` in packaging?

I believe in the past we kept the `node_modules` because of the web component stuff, no?