### PR TITLE
Make sure dev won't accidentally bleed into releases

### DIFF
--- a/.github/scripts/downloadWasm.js
+++ b/.github/scripts/downloadWasm.js
@@ -47,7 +47,7 @@ async function downloadWasm (token) {
   const releases = await octokit.repos.listReleases({ owner, repo })
   const release = wasmReleaseDefined
     ? releases.data.find((r) => r.tag_name === process.env.RUNME_VERSION)
-    : releases.data[0]
+    : releases.data.filter(r => r.prerelease === false)[0]
 
   if (wasmReleaseDefined && !release) {
     throw new Error(


### PR DESCRIPTION
As we ramping up to get authoring/editing out the door we need a transitionary period where both exist. Want to me sure no accidents happen in the release pipeline etc.