### PR TITLE
Mimic POSIX var substitution behavior

### DIFF
--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -62,6 +62,7 @@ export async function retrieveShellCommand (exec: NotebookCellExecution) {
       const expression = placeHolder.slice(2, -1)
       const expressionProcess = cp.spawn(expression, {
         cwd,
+        env: {...process.env, ...stateEnv },
         shell: true
       })
       const [isError, data] = await new Promise<[number, string]>((resolve) => {
@@ -69,6 +70,7 @@ export async function retrieveShellCommand (exec: NotebookCellExecution) {
         expressionProcess.stdout.on('data', (payload) => { data += payload.toString() })
         expressionProcess.stderr.on('data', (payload) => { data += payload.toString() })
         expressionProcess.on('close', (code) => {
+          data = data.trim()
           if (code && code > 0) {
             return resolve([code, data])
           }

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -124,6 +124,34 @@ test('can support expressions', async () => {
   expect(ENV_STORE.get('foo')).toBe('foobar')
 })
 
+test('can recall previous vars', async () => {
+  const exec1: any = {
+    cell: {
+      metadata: { executeableCode: 'export foo=$(echo "foo$BAR")' },
+      document: {
+        getText: vi.fn().mockReturnValue('export foo=$(echo "foo$BAR")'),
+        uri: { fsPath: __dirname }
+      }
+    }
+  }
+  process.env.BAR = 'bar'
+  const cellText1 = await retrieveShellCommand(exec1)
+  expect(cellText1).toBe('')
+  expect(ENV_STORE.get('foo')).toBe('foobar')
+  const exec2: any = {
+    cell: {
+      metadata: { executeableCode: 'export barfoo=$(echo "bar$foo")' },
+      document: {
+        getText: vi.fn().mockReturnValue('export barfoo=$(echo "bar$foo")'),
+        uri: { fsPath: __dirname }
+      }
+    }
+  }
+  const cellText2 = await retrieveShellCommand(exec2)
+  expect(cellText2).toBe('')
+  expect(ENV_STORE.get('barfoo')).toBe('barfoobar')
+})
+
 test('returns undefined if expression fails', async () => {
   const exec: any = {
     cell: {

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -121,7 +121,7 @@ test('can support expressions', async () => {
   process.env.BAR = 'bar'
   const cellText = await retrieveShellCommand(exec)
   expect(cellText).toBe('')
-  expect(ENV_STORE.get('foo')).toBe('foobar\n')
+  expect(ENV_STORE.get('foo')).toBe('foobar')
 })
 
 test('returns undefined if expression fails', async () => {


### PR DESCRIPTION
This will change the behavior of using `$(...)` expressions inside of exported ENV vars `export MY_VAR=$(echo 'test')`.

Old behavior inside of Runme notebook; notice gap (it's a `\n` but displayed as space by the markdown renderer) inside of MY_VAR:
```sh
$ export MY_CWD="$(pwd)"
$ export MY_VAR="$MY_CWD:$PATH"
$ echo $MY_VAR
/Users/sourishkrout/Projects/stateful/oss/runme :/Users/sourishkrout/.wasmtime/bin:/opt/homebrew/opt/libpq/bin:/Users/sourishkrout/go/bin:/Users/sourishkrout/.asdf/shims:/opt/homebrew/opt/asdf/libexec/bin:/Users/sourishkrout/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/Library/Apple/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/sourishkrout/.cache/zsh4humans/v5/fzf/bin
```

New behavior; no special endings (e.g. '\n'):
```sh
$ export MY_CWD="$(pwd)"
$ export MY_VAR="$MY_CWD:$PATH"
$ echo $MY_VAR
/Users/sourishkrout/Projects/stateful/oss/runme:/Users/sourishkrout/.wasmtime/bin:/opt/homebrew/opt/libpq/bin:/Users/sourishkrout/go/bin:/Users/sourishkrout/.asdf/shims:/opt/homebrew/opt/asdf/libexec/bin:/Users/sourishkrout/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/Library/Apple/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/sourishkrout/.cache/zsh4humans/v5/fzf/bin
```

Some tools are more tolerant than others. E.g. the PATH is sensitive and encoded strings passed into tools like `grpcurl` will fail as a result. Others are more fault-tolerant where they likely sanitize/trim previously extrapolated vars taken as input.

Whether or not this is exactly mimicking POSIX behavior it's far "less wrong" than the old behavior. Leaned on explanation from https://unix.stackexchange.com/questions/164508/why-do-newline-characters-get-lost-when-using-command-substitution/164548#164548 and specifically https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_03

This PR will also fix a bug where future var substitutions would not retain previously evaluated vars.