### PR TITLE
Open in Runme

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -32,7 +32,9 @@ export const workspace = {
   onDidSaveNotebookDocument: vi.fn().mockReturnValue({ dispose: vi.fn() }),
   fs: {
     readFile: vi.fn().mockResolvedValue(Buffer.from('some wasm file')),
-    stat: vi.fn().mockResolvedValue(1)
+    stat: vi.fn().mockResolvedValue(1),
+    createDirectory: vi.fn(),
+    delete: vi.fn()
   },
   workspaceFolders: [
     {
@@ -59,18 +61,22 @@ export const workspace = {
 
 export const terminal = {
   show: vi.fn(),
-  sendText: vi.fn()
+  sendText: vi.fn(),
+  dispose: vi.fn()
 }
 
 export const window = {
   showWarningMessage: vi.fn(),
   showInformationMessage: vi.fn(),
+  showErrorMessage: vi.fn(),
   createTerminal: vi.fn().mockReturnValue(terminal),
   showNotebookDocument: vi.fn(),
   showTextDocument: vi.fn(),
   onDidChangeActiveNotebookEditor: vi.fn().mockReturnValue({ dispose: vi.fn() }),
   registerTreeDataProvider: vi.fn(),
-  onDidCloseTerminal: vi.fn()
+  registerUriHandler: vi.fn(),
+  onDidCloseTerminal: vi.fn(),
+  withProgress: vi.fn()
 }
 
 export const tasks = {
@@ -173,4 +179,8 @@ export class NotebookCellOutput {
   metadata?: { [key: string]: any }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(items: NotebookCellOutputItem[], metadata?: { [key: string]: any }) {}
+}
+
+export const ProgressLocation = {
+  Window: 1
 }

--- a/package.json
+++ b/package.json
@@ -240,6 +240,17 @@
             "scope": "machine",
             "default": false,
             "markdownDescription": "If set to `true`, the notebook serialization will use the GRPC interface (experimental)."
+          },
+          "runme.checkout.projectDir": {
+            "type": "string",
+            "scope": "machine",
+            "markdownDescription": "Directory to which Runme should clone new projects into."
+          },
+          "runme.checkout.timeout": {
+            "type": "number",
+            "scope": "machine",
+            "default": 60000,
+            "markdownDescription": "Timeout until Runme will cancel the clone process."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "build": "run-s build:dev",
     "build:dev": "webpack --mode development --node-env development",
     "build:prod": "webpack --mode production --node-env production",
-    "bundle": "vsce package --pre-release --npm --no-git-tag-version --no-update-package-json -o \"./runme-$npm_package_version.vsix\"",
+    "bundle": "vsce package --pre-release --no-git-tag-version --no-update-package-json -o \"./runme-$npm_package_version.vsix\"",
     "download:wasm": "node .github/scripts/downloadWasm.js",
     "esmify": "echo '{ \"type\": \"module\" }' >> ./out/package.json",
     "postinstall": "run-s postinstall:*",

--- a/src/extension/constants.ts
+++ b/src/extension/constants.ts
@@ -11,3 +11,5 @@ export const DEFAULT_ENV = {
 export const ENV_STORE = new Map<string, string>(
   Object.entries(DEFAULT_ENV)
 )
+
+export const BOOTFILE = '.rumme'

--- a/src/extension/constants.ts
+++ b/src/extension/constants.ts
@@ -12,4 +12,4 @@ export const ENV_STORE = new Map<string, string>(
   Object.entries(DEFAULT_ENV)
 )
 
-export const BOOTFILE = '.rumme'
+export const BOOTFILE = '.runme'

--- a/src/extension/constants.ts
+++ b/src/extension/constants.ts
@@ -12,4 +12,4 @@ export const ENV_STORE = new Map<string, string>(
   Object.entries(DEFAULT_ENV)
 )
 
-export const BOOTFILE = '.runme'
+export const BOOTFILE = '.runme_bootstrap'

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -1,5 +1,5 @@
 
-import { workspace, notebooks, commands, ExtensionContext, tasks, window } from 'vscode'
+import { workspace, notebooks, commands, ExtensionContext, tasks, window, Uri } from 'vscode'
 import { TelemetryReporter } from 'vscode-telemetry'
 
 import { Kernel } from './kernel'
@@ -21,6 +21,7 @@ import {
 import { WasmSerializer, GrpcSerializer } from './serializer'
 import { RunmeLauncherProvider } from './provider/launcher'
 import { RunmeUriHandler } from './handler/uri'
+import { BOOTFILE } from './constants'
 
 export class RunmeExtension {
   async initialize(context: ExtensionContext) {
@@ -77,6 +78,17 @@ export class RunmeExtension {
     !hasPsuedoTerminalExperimentEnabled
       ? context.subscriptions.push(notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new CliProvider()))
       : tasks.registerTaskProvider(RunmeTaskProvider.id, new RunmeTaskProvider(context))
+
+    if (workspace.workspaceFolders?.length && workspace.workspaceFolders[0]) {
+      const startupFileUri = Uri.joinPath(workspace.workspaceFolders[0].uri, BOOTFILE)
+      const hasStartupFile = await workspace.fs.stat(startupFileUri).then(() => true, () => false)
+      if (hasStartupFile) {
+        const bootFile = new TextDecoder().decode(await workspace.fs.readFile(startupFileUri))
+        const bootFileUri = Uri.joinPath(workspace.workspaceFolders[0].uri, bootFile)
+        await workspace.fs.delete(startupFileUri)
+        await commands.executeCommand('vscode.open', bootFileUri)
+      }
+    }
   }
 
   static registerCommand(command: string, callback: (...args: any[]) => any, thisArg?: any) {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -20,6 +20,7 @@ import {
 } from './commands'
 import { WasmSerializer, GrpcSerializer } from './serializer'
 import { RunmeLauncherProvider } from './provider/launcher'
+import { RunmeUriHandler } from './handler/uri'
 
 export class RunmeExtension {
   async initialize(context: ExtensionContext) {
@@ -27,6 +28,7 @@ export class RunmeExtension {
     const grpcSerializer = kernel.hasExperimentEnabled('grpcSerializer')
     const serializer = grpcSerializer ? new GrpcSerializer(context) : new WasmSerializer(context)
     const treeViewer = new RunmeLauncherProvider(getDefaultWorkspace())
+    const uriHandler = new RunmeUriHandler()
 
     context.subscriptions.push(
       kernel,
@@ -60,7 +62,12 @@ export class RunmeExtension {
        */
       window.registerTreeDataProvider('runme.launcher', treeViewer),
       commands.registerCommand('runme.collapseTreeView', treeViewer.collapseAll.bind(treeViewer)),
-      commands.registerCommand('runme.expandTreeView', treeViewer.expandAll.bind(treeViewer))
+      commands.registerCommand('runme.expandTreeView', treeViewer.expandAll.bind(treeViewer)),
+
+      /**
+       * Uri handler
+       */
+      window.registerUriHandler(uriHandler)
     )
 
     /**

--- a/src/extension/handler/uri.ts
+++ b/src/extension/handler/uri.ts
@@ -1,0 +1,51 @@
+import { UriHandler, window, Uri, ProgressLocation, commands } from 'vscode'
+import { dir } from 'tmp-promise'
+
+let NEXT_TERM_ID = 0
+
+export class RunmeUriHandler implements UriHandler {
+    async handleUri (uri: Uri) {
+        const params = new URLSearchParams(uri.query)
+        const command = params.get('command') || 'unknown'
+
+        if (command === 'setup') {
+            await this._setupProject(params.get('repository'))
+            return
+        }
+
+        window.showErrorMessage(`Couldn't recognise command "${command}"`)
+    }
+
+    private async _setupProject (repository: string | null = 'git@github.com:stateful/vscode-issue-explorer.git') {
+        if (!repository) {
+            return window.showErrorMessage('No project to setup was provided in the url')
+        }
+
+        const targetDir = (await dir()).path
+        const terminal = window.createTerminal(`Runme Terminal #${NEXT_TERM_ID++}`, '/bin/sh')
+        terminal.show(true)
+        window.showInformationMessage('Setting up a new project using Runme...')
+        return window.withProgress({
+            location: ProgressLocation.Window,
+            cancellable: false,
+            title: `Setting up project from repository ${repository}`
+        }, async (progress) => {
+            progress.report({ increment: 0, message: 'Cloning repository...' })
+            terminal.sendText(`git clone ${repository} ${targetDir}`)
+            await new Promise((resolve) => setTimeout(resolve, 10000))
+
+            progress.report({ increment: 50, message: 'Opening project...' })
+            await commands.executeCommand('vscode.openFolder', Uri.parse(targetDir), {
+                forceNewWindow: true
+            })
+            // await new Promise((resolve) => setTimeout(resolve, 2000))
+            // terminal.sendText(`code ${targetDir}`)
+            // await new Promise((resolve) => setTimeout(resolve, 5000))
+            // terminal.sendText(`code ${targetDir} ${targetDir}/README.md`)
+            await new Promise((resolve) => setTimeout(resolve, 2000))
+
+            progress.report({ increment: 100 })
+            // terminal.dispose()
+        })
+    }
+}

--- a/src/extension/handler/uri.ts
+++ b/src/extension/handler/uri.ts
@@ -70,6 +70,7 @@ export class RunmeUriHandler implements UriHandler {
         }
 
         progress.report({ increment: 50, message: 'Opening project...' })
+        console.log(`[Runme] Attempt to open folder ${targetDirUri.fsPath}`)
         await commands.executeCommand('vscode.openFolder', Uri.parse(targetDirUri.fsPath), {
             forceNewWindow: true
         })

--- a/src/extension/handler/utils.ts
+++ b/src/extension/handler/utils.ts
@@ -132,19 +132,20 @@ export async function waitForProjectCheckout (
 /**
  * verify repository url has the right format and get suggested name from provided repository url
  */
-const DOT_GIT_ANNEX_LENGTH = '.git'.length
+const DOT_GIT_ANNEX = '.git'
+const DOT_GIT_ANNEX_LENGTH = DOT_GIT_ANNEX.length
 export function getSuggestedProjectName (repository: string) {
     /**
      * for "git@provider.com:org/project.git"
      */
-    if (repository.startsWith('git@') && repository.endsWith('.git') && repository.split(':').length === 2) {
+    if (repository.startsWith('git@') && repository.endsWith(DOT_GIT_ANNEX) && repository.split(':').length === 2) {
         return repository.slice(0, -DOT_GIT_ANNEX_LENGTH).split(':')[1]
     }
 
     /**
      * for "https://provider.com/org/project.git"
      */
-    if (repository.startsWith('http') && repository.endsWith('.git')) {
+    if (repository.startsWith('http') && repository.endsWith(DOT_GIT_ANNEX)) {
         return repository.split('/').slice(-2).join('/').slice(0, -DOT_GIT_ANNEX_LENGTH)
     }
 

--- a/src/extension/handler/utils.ts
+++ b/src/extension/handler/utils.ts
@@ -94,13 +94,20 @@ export async function waitForProjectCheckout (
         return cb(false)
     }, Math.max(config.get('timeout') || 0, MINIMAL_TIMEOUT))
     const i = setInterval(async () => {
-        const dirEntries = await workspace.fs.readDirectory(targetDirUri)
+        const dirEntries = await workspace.fs.readDirectory(targetDirUri).then((res) => res, (err) => {
+            console.error(`[Runme] Failed to fetch directory ${targetDir}: ${err.message}`)
+            return []
+        })
+
         /**
          * wait until directory has more files than only a ".git"
          */
         if (dirEntries.length <= 1) {
             return
         }
+
+        clearTimeout(t)
+        clearInterval(i)
         console.log(`[Runme] Successfully cloned repository to ${targetDir}`)
 
         /**
@@ -118,8 +125,6 @@ export async function waitForProjectCheckout (
             console.log(`[Runme] Created temporary bootstrap file to open ${fileToOpen}`)
         }
 
-        clearTimeout(t)
-        clearInterval(i)
         cb(true)
     }, INTERVAL)
 }

--- a/src/extension/handler/utils.ts
+++ b/src/extension/handler/utils.ts
@@ -94,9 +94,6 @@ export async function waitForProjectCheckout (
         return cb(false)
     }, Math.max(config.get('timeout') || 0, MINIMAL_TIMEOUT))
     const i = setInterval(async () => {
-        clearTimeout(t)
-        clearInterval(i)
-
         const dirEntries = await workspace.fs.readDirectory(targetDirUri)
         /**
          * wait until directory has more files than only a ".git"
@@ -104,6 +101,7 @@ export async function waitForProjectCheckout (
         if (dirEntries.length <= 1) {
             return
         }
+        console.log(`[Runme] Successfully cloned repository to ${targetDir}`)
 
         /**
          * write a runme file into the directory, so the extension knows it has
@@ -117,8 +115,11 @@ export async function waitForProjectCheckout (
                 Uri.joinPath(targetDirUri, BOOTFILE),
                 enc.encode(fileToOpen)
             )
+            console.log(`[Runme] Created temporary bootstrap file to open ${fileToOpen}`)
         }
 
+        clearTimeout(t)
+        clearInterval(i)
         cb(true)
     }, INTERVAL)
 }

--- a/src/extension/handler/utils.ts
+++ b/src/extension/handler/utils.ts
@@ -1,0 +1,120 @@
+import { workspace, window, Uri } from 'vscode'
+import { dir } from 'tmp-promise'
+
+import { BOOTFILE } from '../constants'
+
+const config = workspace.getConfiguration('runme.checkout')
+const INTERVAL = 500
+const MINIMAL_TIMEOUT = 10 * 1000
+const DEFAULT_START_FILE = 'README.md'
+
+/**
+ * Get the project directory from the settings object.
+ *
+ * If none is set up, the directory will be a temporary directory.
+ *
+ * If the set up directory doesn't exist, it will ask whether to create it and if not
+ * we return `null` meaning we should cancel the checkout operation.
+ *
+ * @returns `vscode.Uri` with target directory to check out the project to
+ *          `null` if the user doesn't want to create the directory, here we should cancel the operation
+ */
+export async function getProjectDir () {
+    const projectDirPath: string | undefined = config.get('projectDir')
+
+    if (!projectDirPath) {
+        return Uri.parse((await dir()).path)
+    }
+
+    const projectDir = Uri.parse(projectDirPath)
+    const isExisting = await workspace.fs.stat(projectDir)
+        .then(() => true, () => false)
+    if (isExisting) {
+        return projectDir
+    }
+
+    const createDir = (await window.showInformationMessage(
+        `A project directory (${projectDir}) was set up but doesn't exist. ` +
+        'Do you want to create it?',
+        'Yes', 'No'
+    )) === 'Yes'
+
+    if (!createDir) {
+        return null
+    }
+
+    await workspace.fs.createDirectory(projectDir)
+    return projectDir
+}
+
+/**
+ * Create the name of the target directory to checkout a project to
+ * @param targetDir Uri of the base directory (received by calling `getProjectDir`)
+ * @param suggestedName name of the directory to check the project into, e.g. "org/projectName"
+ * @param index index which increases if directory name exists (e.g. "foobar_1")
+ * @returns a string with the name of the target directory
+ */
+export async function getTargetDirName (targetDir: Uri, suggestedName: string, index = 0): Promise<string> {
+    /**
+     * for now let's expect a suggested name mimicking the format "<org>/<project>"
+     */
+    if (suggestedName.split('/').length !== 2) {
+        throw new Error(`Invalid project directory suggestion: ${suggestedName}`)
+    }
+
+    /**
+     * create org directory
+     */
+    const [orgName] = suggestedName.split('/')
+    const orgDir = Uri.joinPath(targetDir, orgName)
+    const isOrgDirExisting = await workspace.fs.stat(orgDir).then(() => true, () => false)
+    if (!isOrgDirExisting) {
+        await workspace.fs.createDirectory(orgDir)
+    }
+
+    const amendedSuggestedName = !index ? suggestedName: `${suggestedName}_${index}`
+    const fullTargetDir = Uri.joinPath(targetDir, amendedSuggestedName)
+    const isExisting = await workspace.fs.stat(fullTargetDir).then(() => true, () => false)
+    if (isExisting) {
+        return getTargetDirName(targetDir, suggestedName, ++index)
+    }
+
+    return amendedSuggestedName
+}
+
+export async function waitForProjectCheckout (
+    targetDir: string,
+    repository: string,
+    cb: (success: boolean) => void
+) {
+    const targetDirUri = Uri.parse(targetDir)
+    const t = setTimeout(() => {
+        clearInterval(i)
+        window.showErrorMessage(`Timed out cloning repository ${repository}`)
+        return cb(false)
+    }, Math.max(config.get('timeout') || 0, MINIMAL_TIMEOUT))
+    const i = setInterval(async () => {
+        const dirEntries = await workspace.fs.readDirectory(targetDirUri)
+        /**
+         * wait until directory has more files than only a ".git"
+         */
+        if (dirEntries.length <= 1) {
+            return
+        }
+
+        /**
+         * write a runme file into the directory, so the extension knows it has
+         * to open the readme file
+         */
+        const fileExist = await workspace.fs.stat(Uri.joinPath(targetDirUri, DEFAULT_START_FILE))
+            .then(() => true, () => false)
+        if (fileExist) {
+            const enc = new TextEncoder()
+            await workspace.fs.writeFile(Uri.joinPath(targetDirUri, BOOTFILE), enc.encode(DEFAULT_START_FILE))
+        }
+
+        clearTimeout(t)
+        clearInterval(i)
+        cb(true)
+    }, INTERVAL)
+}

--- a/src/extension/handler/utils.ts
+++ b/src/extension/handler/utils.ts
@@ -118,3 +118,22 @@ export async function waitForProjectCheckout (
         cb(true)
     }, INTERVAL)
 }
+
+/**
+ * get suggested name from provided repository url
+ */
+export function getSuggestedProjectName (repository: string) {
+    /**
+     * verify repository url has the right format,
+     * e.g. currently we only support "git@provider.com:org/project.git"
+     */
+    if (!repository.startsWith('git@') || !repository.endsWith('.git') || repository.split(':').length !== 2) {
+        window.showErrorMessage(
+            'Invalid git url, expected following format "git@provider.com:org/project.git",' +
+            ` received "${repository}"`
+        )
+        return
+    }
+
+    return repository.slice(0, -4).split(':')[1]
+}

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -18,4 +18,9 @@ test('initializes all providers', async () => {
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
   expect(commands.registerCommand).toBeCalledTimes(12)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
+  expect(window.registerUriHandler).toBeCalledTimes(1)
+
+  expect(commands.executeCommand).toBeCalledWith('vscode.open', '/foo/bar')
+  expect(workspace.fs.stat).toBeCalledWith('/foo/bar')
+  expect(workspace.fs.delete).toBeCalledWith('/foo/bar')
 })

--- a/tests/extension/handler/uri.test.ts
+++ b/tests/extension/handler/uri.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+// @ts-expect-error mock feature
+import { commands, window, Uri, terminal } from 'vscode'
+
+import { RunmeUriHandler } from '../../../src/extension/handler/uri'
+import {
+    getProjectDir, waitForProjectCheckout, getSuggestedProjectName
+} from '../../../src/extension/handler/utils'
+
+vi.mock('vscode')
+vi.mock('vscode-telemetry')
+vi.mock('../../../src/extension/handler/utils', () => ({
+    getProjectDir: vi.fn(),
+    getTargetDirName: vi.fn(),
+    waitForProjectCheckout: vi.fn(),
+    getSuggestedProjectName: vi.fn()
+}))
+
+describe('RunmeUriHandler', () => {
+    beforeEach(() => {
+        vi.mocked(window.showErrorMessage).mockClear()
+        vi.mocked(window.showInformationMessage).mockClear()
+    })
+
+    describe('handleUri', async () => {
+        let handler: RunmeUriHandler
+
+        beforeEach(() => {
+            handler = new RunmeUriHandler()
+            handler['_setupProject'] = vi.fn()
+        })
+
+        it('should fail if no command was found', async () => {
+            vi.mocked(Uri.parse).mockReturnValue({ query: {} } as any)
+            expect(await handler.handleUri(Uri.parse('vscode://stateful.runme?foo=bar')))
+                .toBe(undefined)
+            expect(window.showErrorMessage).toBeCalledWith('No query parameter "command" provided')
+        })
+
+        it('should fail if no command was recognised', async () => {
+            vi.mocked(Uri.parse).mockReturnValue({ query: { command: 'foobar' } } as any)
+            expect(await handler.handleUri(Uri.parse('vscode://stateful.runme?foo=bar')))
+                .toBe(undefined)
+            expect(window.showErrorMessage).toBeCalledWith('Couldn\'t recognise command "foobar"')
+        })
+
+        it('runs _setupProject if command was "setup"', async () => {
+            vi.mocked(Uri.parse).mockReturnValue({ query: {
+                command: 'setup',
+                repository: 'git@github.com:/foo/bar'
+            }} as any)
+            await handler.handleUri(Uri.parse('vscode://stateful.runme?foo=bar'))
+            expect(handler['_setupProject']).toBeCalledWith('git@github.com:/foo/bar')
+        })
+    })
+
+    describe('_setupProject', () => {
+        let handler: RunmeUriHandler
+
+        beforeEach(() => {
+            handler = new RunmeUriHandler()
+        })
+
+        it('doesn not do anything if repository was not provided', async () => {
+            await handler['_setupProject']()
+            expect(window.showErrorMessage)
+                .toBeCalledWith('No project to setup was provided in the url')
+            expect(window.showInformationMessage).toHaveBeenCalledTimes(0)
+        })
+
+        it('should not run if project dir or suggested name can not be identified', async () => {
+            await handler['_setupProject']('foo')
+            expect(window.showInformationMessage).toHaveBeenCalledTimes(0)
+            vi.mocked(getProjectDir).mockResolvedValueOnce('foobar' as any)
+            await handler['_setupProject']('foo')
+            expect(window.showInformationMessage).toHaveBeenCalledTimes(0)
+            vi.mocked(getProjectDir).mockResolvedValueOnce('foobar' as any)
+            vi.mocked(getSuggestedProjectName).mockResolvedValueOnce('stateful/runme')
+            await handler['_setupProject']('foo')
+            expect(window.showInformationMessage).toHaveBeenCalledTimes(1)
+            expect(window.withProgress).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('_cloneProject', () => {
+        let handler: RunmeUriHandler
+        const progress = { report: vi.fn() }
+
+        beforeEach(() => {
+            handler = new RunmeUriHandler()
+            progress.report.mockClear()
+            terminal.dispose.mockClear()
+        })
+
+        it('should return false if waitForProjectCheckout fails', async () => {
+            vi.mocked(waitForProjectCheckout).mockImplementation(
+                async (_, __, resolve) => resolve(false))
+            await handler['_cloneProject'](progress, { fsPath: '/bar/foo' } as any, '/foo/bar')
+            expect(terminal.sendText).toBeCalledWith('git clone /foo/bar /bar/foo')
+            expect(terminal.dispose).toBeCalledTimes(1)
+            expect(progress.report).toBeCalledTimes(1)
+        })
+
+        it('should finish clone process', async () => {
+            vi.mocked(waitForProjectCheckout).mockImplementation(
+                async (_, __, resolve) => resolve(true))
+            await handler['_cloneProject'](progress, { fsPath: '/bar/foo' } as any, '/foo/bar')
+            expect(progress.report).toBeCalledWith({ increment: 100 })
+            expect(terminal.dispose).toBeCalledTimes(1)
+            expect(commands.executeCommand).toBeCalledWith(
+                'vscode.openFolder',
+                {
+                    query: {
+                        command: 'setup',
+                        repository: 'git@github.com:/foo/bar'
+                    }
+                },
+                { forceNewWindow: true }
+            )
+        })
+    })
+})

--- a/tests/extension/handler/utils.test.ts
+++ b/tests/extension/handler/utils.test.ts
@@ -77,6 +77,11 @@ describe('getSuggestedProjectName', () => {
             .toBe('org/project')
     })
 
+    it('should parse name correctly', () => {
+        expect(getSuggestedProjectName('https://provider.com/org/project.git'))
+            .toBe('org/project')
+    })
+
     it('should fail if format is not correct', () => {
         expect(getSuggestedProjectName('foobar')).toBe(undefined)
         expect(window.showErrorMessage).toBeCalledTimes(1)

--- a/tests/extension/handler/utils.test.ts
+++ b/tests/extension/handler/utils.test.ts
@@ -1,0 +1,84 @@
+import path from 'node:path'
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Uri, workspace, window } from 'vscode'
+
+import {
+    getProjectDir, getTargetDirName, getSuggestedProjectName
+} from '../../../src/extension/handler/utils'
+
+vi.mocked(Uri.parse).mockImplementation((input: any) => input)
+vi.mocked(Uri.joinPath).mockImplementation(
+    (base: any, ...input: string[]) => path.join('/some/path', ...input) as any)
+vi.mock('vscode')
+vi.mock('tmp-promise', () => ({
+    dir: vi.fn().mockResolvedValue({ path: '/tmp/dir' })
+}))
+
+const config = workspace.getConfiguration()
+
+beforeEach(() => {
+    vi.mocked(workspace.fs.createDirectory).mockClear()
+})
+
+describe('getProjectDir', () => {
+    it('should use a tmp dir if config is not set', async () => {
+        expect(await getProjectDir()).toBe('/tmp/dir')
+    })
+
+    it('should return project dir if existing', async () => {
+        config.set('projectDir', 'foobar')
+        vi.mocked(Uri.parse).mockReturnValue('foobar' as any)
+        vi.mocked(workspace.fs.stat).mockResolvedValueOnce({} as any)
+        expect(await getProjectDir()).toBe('foobar')
+    })
+
+    it('should return null if user does not want to create new project dir', async () => {
+        config.set('projectDir', 'foobar')
+        vi.mocked(window.showInformationMessage).mockResolvedValue('No' as any)
+        vi.mocked(workspace.fs.stat).mockRejectedValueOnce(new Error(''))
+        expect(await getProjectDir()).toBe(null)
+    })
+
+    it('should create directory if approved', async () => {
+        config.set('projectDir', 'foobar')
+        vi.mocked(window.showInformationMessage).mockResolvedValue('Yes' as any)
+        vi.mocked(workspace.fs.stat).mockRejectedValueOnce(new Error(''))
+        expect(await getProjectDir()).toBe('foobar')
+        expect(workspace.fs.createDirectory).toBeCalledTimes(1)
+    })
+})
+
+describe('getTargetDirName', () => {
+    it('should throw if provided name does not match expected format', async () => {
+        await expect(() => getTargetDirName({} as any, 'foobar')).rejects
+            .toThrow('Invalid project directory suggestion: foobar')
+    })
+
+    it('creates org dir if needed and returns right target dir', async () => {
+        vi.mocked(workspace.fs.stat).mockImplementation(async (param: any) => {
+            if (param === '/some/path/stateful') {
+                throw new Error('ups')
+            }
+            if (param === '/some/path/stateful/runme_10') {
+                throw new Error('ups')
+            }
+            return {} as any
+        })
+        expect(await getTargetDirName({} as any, 'stateful/runme'))
+            .toBe('stateful/runme_10')
+        expect(workspace.fs.createDirectory).toBeCalledWith('/some/path/stateful')
+    })
+})
+
+describe('getSuggestedProjectName', () => {
+    it('should parse name correctly', () => {
+        expect(getSuggestedProjectName('git@provider.com:org/project.git'))
+            .toBe('org/project')
+    })
+
+    it('should fail if format is not correct', () => {
+        expect(getSuggestedProjectName('foobar')).toBe(undefined)
+        expect(window.showErrorMessage).toBeCalledTimes(1)
+    })
+})


### PR DESCRIPTION
This patch adds a uri handler that would allow us to have a link like `vscode://stateful.runme?command=setup&repository=git@github.com:webdriverio/webdriverio.git` anywhere to have users check out a project locally with Runme. An initial POC looks like this:

![boot](https://user-images.githubusercontent.com/731337/214995343-2d6378fd-65f7-42af-b32c-24d4c390cb8f.gif)

If users don't have Runme installed the following message will be displayed and allows users to immediately get started:

<img width="322" alt="Screenshot 2023-01-31 at 13 17 10" src="https://user-images.githubusercontent.com/731337/215848216-c807b62c-8fde-45b8-be33-a8270f54647c.png">
