### PR TITLE
Baseline modeling of annotations to allow data validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "vercel": "^28.13.1",
         "vscode-telemetry": "^0.3.1",
         "xdg-app-paths": "^8.2.0",
-        "yargs": "^17.6.2"
+        "yargs": "^17.6.2",
+        "zod": "^3.20.2"
       },
       "devDependencies": {
         "@octokit/rest": "^19.0.7",
@@ -16861,6 +16862,14 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+      "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -29398,6 +29407,11 @@
         "compress-commons": "^4.1.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "zod": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+      "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -406,6 +406,7 @@
     "vercel": "^28.13.1",
     "vscode-telemetry": "^0.3.1",
     "xdg-app-paths": "^8.2.0",
-    "yargs": "^17.6.2"
+    "yargs": "^17.6.2",
+    "zod": "^3.20.2"
   }
 }

--- a/src/client/components/annotations.ts
+++ b/src/client/components/annotations.ts
@@ -1,14 +1,23 @@
 import { LitElement, css, html } from 'lit'
-import { customElement, property } from 'lit/decorators.js'
+import { customElement, property, state } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
 import { ClientMessages } from '../../constants'
-import type { ClientMessage, CellAnnotations } from '../../types'
-import { getContext } from '../utils'
+import type { ClientMessage, CellAnnotations, CellAnnotationsErrorResult } from '../../types'
+import { getContext, tryBoolean } from '../utils'
+import { CellAnnotationsSchema, AnnotationSchema } from '../../schema'
 import '@vscode/webview-ui-toolkit/dist/data-grid/index'
 
 type AnnotationsMutation = Partial<CellAnnotations>
-type AnnotationsKey = keyof CellAnnotations
+type AnnotationsKey = keyof typeof AnnotationSchema
+type Target = {
+  target: {
+    id: AnnotationsKey
+    checked: boolean
+    value: string
+    type: string
+  }
+}
 
 @customElement('edit-annotations')
 export class Annotations extends LitElement {
@@ -57,6 +66,22 @@ export class Annotations extends LitElement {
     .annotation-item::part(checked-indicator) {
       fill: var(--vscode-foreground);
     }
+
+    .error-item {
+      color: var(--vscode-errorForeground);
+    }
+
+    .has-errors, .error-container {
+      border: solid 1px var(--vscode-errorForeground);
+    }
+
+    .error-container {
+      padding:0.1rem;
+    }
+
+    .current-value-error {
+      padding: 1rem;
+    }
   `
 
   readonly #descriptions = new Map<string, string>([
@@ -71,9 +96,25 @@ export class Annotations extends LitElement {
   @property({ type: Object, reflect: true })
   annotations?: CellAnnotations
 
+  @property({ type: Object, reflect: true })
+  validationErrors?: CellAnnotationsErrorResult
+
+  @state()
+  private shouldRender: boolean = false
+
   #desc(id: string): string {
     return this.#descriptions.get(id) || id
   }
+
+  #getTargetValue(e: Target) {
+    switch (e.target.type) {
+      case 'text':
+        return e.target.value
+      default:
+        return e.target.checked.toString()
+    }
+  }
+
 
   #onChange(e: { target: { id: AnnotationsKey, checked: boolean, value: string, type: string } }) {
     if (!this.annotations || !e.target) {
@@ -82,14 +123,36 @@ export class Annotations extends LitElement {
 
     const propVal: any = { 'runme.dev/uuid': this.annotations['runme.dev/uuid'] }
     const propName = e.target.id
+    const value = this.#getTargetValue(e)
+    const targetValue = tryBoolean(value)
+
+    const parseResult = CellAnnotationsSchema.safeParse({
+      [propName]: targetValue
+    })
+
+    if (!parseResult.success) {
+      const { fieldErrors } = parseResult.error.flatten()
+      if (this.validationErrors?.errors && !this.validationErrors.errors[propName]) {
+        this.validationErrors.errors[propName] = fieldErrors[propName]
+      }
+      // Re-render the form
+      return this.shouldRender = !this.shouldRender
+    }
+
+    if (this.validationErrors?.errors && this.validationErrors.errors[propName]) {
+      delete this.validationErrors.errors[propName]
+      // Re-render the form
+      this.shouldRender = !this.shouldRender
+    }
+
     switch (e.target.type) {
       case 'text':
-        (this.annotations as any)[propName] = e.target.value
-        propVal[propName] = e.target.value
+        (this.annotations as any)[propName] = targetValue
+        propVal[propName] = targetValue
         return this.#dispatch(propVal)
       default:
-        (this.annotations as any)[e.target.id] = e.target.checked.toString()
-        propVal[propName] = e.target.checked.toString()
+        (this.annotations as any)[e.target.id] = targetValue
+        propVal[propName] = targetValue
         return this.#dispatch(propVal)
     }
   }
@@ -130,8 +193,23 @@ export class Annotations extends LitElement {
     ><b>${id}: </b>${this.#desc(id)}</vscode-text-field>`
   }
 
+  renderErrors(errorMessages: string[]) {
+    return html`<ul>
+      ${errorMessages.map((error: string) => {
+      return html`<li class="error-item">${error}</li>`
+    })}
+    </ul>`
+  }
+
+  renderCurrentValueError(value: string) {
+    return html`<p class="error-item current-value-error">
+      Received value: ${value}
+      </p>`
+  }
+
   // Render the UI as a function of component state
   render() {
+    let errorCount = 0
     if (!this.annotations) {
       return html`⚠️ Whoops! Something went wrong displaying the editing UI!`
     }
@@ -139,23 +217,43 @@ export class Annotations extends LitElement {
     const displayableAnnotations = Object.entries(this.annotations).filter(([k]) => k.indexOf('runme.dev/') < 0)
 
     const markup = displayableAnnotations.map(([key, value]) => {
-      return html`<div class="row">
+      const errors: string[] = this.validationErrors?.errors
+        ? (this.validationErrors.errors[key as keyof CellAnnotations] || []) : []
+      const originalValue = errors.length ?
+        this.validationErrors?.originalAnnotations[key as keyof CellAnnotations] : value
+      errorCount += errors.length
+      return html`<div class="row ${errors.length ? 'error-container' : ''}">
         ${when(
-          typeof value === 'boolean',
-          () => this.renderCheckbox(key, value as boolean, false),
-          () => html``
-        )}
+        typeof value === 'boolean',
+        () => this.renderCheckbox(key, value as boolean, false),
+        () => html``
+      )}
         ${when(
-          typeof value === 'string',
-          () => this.renderTextField(key, value as string, key),
-          () => html``
-        )}
+        typeof value === 'string',
+        () => this.renderTextField(key, value as string, key),
+        () => html``
+      )}
+      ${when(
+        errors.length,
+        () => this.renderErrors(errors),
+        () => html``
+      )}
+      ${when(
+        typeof value === 'boolean' && errors.length,
+        () => this.renderCurrentValueError(originalValue as string),
+        () => html``
+      )}
       </div>`
     })
 
-    return html`<section class="annotation-container">
+    return html`<section class="annotation-container ${errorCount ? 'has-errors' : ''}">
       <h4>Configure cell's execution behavior:</h4>
       ${markup}
+      ${when(
+      errorCount,
+      () => html`<p class="error-item">This configuration block contains errors, using the default values instead</p>`,
+      () => html``
+    )}
     </section>`
   }
 

--- a/src/client/components/annotations.ts
+++ b/src/client/components/annotations.ts
@@ -132,6 +132,9 @@ export class Annotations extends LitElement {
 
     if (!parseResult.success) {
       const { fieldErrors } = parseResult.error.flatten()
+      if (this.validationErrors && !this.validationErrors?.errors) {
+        this.validationErrors.errors = {}
+      }
       if (this.validationErrors?.errors && !this.validationErrors.errors[propName]) {
         this.validationErrors.errors[propName] = fieldErrors[propName]
       }

--- a/src/client/components/annotations.ts
+++ b/src/client/components/annotations.ts
@@ -3,12 +3,12 @@ import { customElement, property } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
 import { ClientMessages } from '../../constants'
-import type { ClientMessage, NotebookCellAnnotations } from '../../types'
+import type { ClientMessage, CellAnnotations } from '../../types'
 import { getContext } from '../utils'
 import '@vscode/webview-ui-toolkit/dist/data-grid/index'
 
-type AnnotationsMutation = Partial<NotebookCellAnnotations>
-type AnnotationsKey = keyof NotebookCellAnnotations
+type AnnotationsMutation = Partial<CellAnnotations>
+type AnnotationsKey = keyof CellAnnotations
 
 @customElement('edit-annotations')
 export class Annotations extends LitElement {
@@ -69,7 +69,7 @@ export class Annotations extends LitElement {
 
   // Declare reactive properties
   @property({ type: Object, reflect: true })
-  annotations?: NotebookCellAnnotations
+  annotations?: CellAnnotations
 
   #desc(id: string): string {
     return this.#descriptions.get(id) || id
@@ -142,12 +142,12 @@ export class Annotations extends LitElement {
       return html`<div class="row">
         ${when(
           typeof value === 'boolean',
-          () => this.renderCheckbox(key, value, false),
+          () => this.renderCheckbox(key, value as boolean, false),
           () => html``
         )}
         ${when(
           typeof value === 'string',
-          () => this.renderTextField(key, value, key),
+          () => this.renderTextField(key, value as string, key),
           () => html``
         )}
       </div>`

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -51,6 +51,7 @@ export const activate: ActivationFunction = (context: RendererContext<void>) => 
         case OutputType.annotations:
           const annoElem = document.createElement('edit-annotations')
           annoElem.setAttribute('annotations', JSON.stringify(payload.output.annotations ?? []))
+          annoElem.setAttribute('validationErrors', JSON.stringify(payload.output.validationErrors ?? []))
           element.appendChild(annoElem)
           break
         case OutputType.error:

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -12,3 +12,9 @@ export function getContext () {
 export function setContext (c: RendererContext<void>) {
   context = c
 }
+
+export function tryBoolean(element: string) {
+  if (element.toLowerCase() === 'false') { return false }
+  if (element.toLowerCase() === 'true') { return true }
+  return element
+}

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -12,9 +12,3 @@ export function getContext () {
 export function setContext (c: RendererContext<void>) {
   context = c
 }
-
-export function tryBoolean(element: string) {
-  if (element.toLowerCase() === 'false') { return false }
-  if (element.toLowerCase() === 'true') { return true }
-  return element
-}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,13 +21,6 @@ export enum ClientMessages {
   mutateAnnotations = 'annotations:mutate'
 }
 
-export const METADATA_DEFAULTS = {
-  background: false,
-  interactive: true,
-  closeTerminalOnSuccess: true,
-  mimeType: 'text/plain'
-} as const
-
 // [pretty print, languageId, destination]
 export const LANGUAGES = new Map([
   ['Assembly', 'asm', 'sh'],

--- a/src/extension/provider/annotations.ts
+++ b/src/extension/provider/annotations.ts
@@ -13,7 +13,7 @@ import { OutputType } from '../../constants'
 import { CellOutputPayload } from '../../types'
 import { RunmeExtension } from '../extension'
 import { Kernel } from '../kernel'
-import { getAnnotations } from '../utils'
+import { getAnnotations, validateAnnotations } from '../utils'
 
 export class AnnotationsProvider implements NotebookCellStatusBarItemProvider {
   constructor(private readonly kernel: Kernel) {
@@ -42,6 +42,7 @@ export class AnnotationsProvider implements NotebookCellStatusBarItemProvider {
         type: OutputType.annotations,
         output: {
           annotations: getAnnotations(cell),
+          validationErrors: validateAnnotations(cell)
         },
       }
       await exec.replaceOutput([

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -5,8 +5,7 @@ import cp from 'node:child_process'
 import vscode, { FileType, Uri, workspace, NotebookDocument } from 'vscode'
 import { v5 as uuidv5 } from 'uuid'
 
-import { NotebookCellAnnotations, Serializer } from '../types'
-import { METADATA_DEFAULTS } from '../constants'
+import { CellAnnotations, CellAnnotationsSchema, Serializer } from '../types'
 
 import executor from './executors'
 import { Kernel } from './kernel'
@@ -15,14 +14,13 @@ import { ENV_STORE, DEFAULT_ENV } from './constants'
 declare var globalThis: any
 
 const HASH_PREFIX_REGEXP = /^\s*\#\s*/g
-const TRUTHY_VALUES = ['1', 'true']
 
 /**
  * Annotations are stored as subset of metadata
  */
-export function getAnnotations(cell: vscode.NotebookCell): NotebookCellAnnotations
-export function getAnnotations(metadata?: Serializer.Metadata): NotebookCellAnnotations
-export function getAnnotations(raw: unknown): NotebookCellAnnotations {
+export function getAnnotations(cell: vscode.NotebookCell): CellAnnotations
+export function getAnnotations(metadata?: Serializer.Metadata): CellAnnotations
+export function getAnnotations(raw: unknown): CellAnnotations {
   const config = vscode.workspace.getConfiguration('runme.shell')
   const metadataFromCell = raw as vscode.NotebookCell
   let metadata = raw as Serializer.Metadata
@@ -31,23 +29,26 @@ export function getAnnotations(raw: unknown): NotebookCellAnnotations {
     metadata = metadataFromCell.metadata
   }
 
-  return <NotebookCellAnnotations>{
-    background:
-      typeof metadata.background === 'string'
-        ? TRUTHY_VALUES.includes(metadata.background)
-        : METADATA_DEFAULTS.background,
-    interactive:
-      typeof metadata.interactive === 'string'
-        ? TRUTHY_VALUES.includes(metadata.interactive)
-        : config.get<boolean>('interactive', METADATA_DEFAULTS.interactive),
-    closeTerminalOnSuccess:
-      typeof metadata.closeTerminalOnSuccess === 'string'
-        ? TRUTHY_VALUES.includes(metadata.closeTerminalOnSuccess)
-        : config.get<boolean>('closeTerminalOnSuccess', METADATA_DEFAULTS.closeTerminalOnSuccess),
-    mimeType: typeof metadata.mimeType === 'string' ? metadata.mimeType : METADATA_DEFAULTS.mimeType,
-    name: metadata.name || metadata['runme.dev/name'],
-    'runme.dev/uuid': metadata['runme.dev/uuid'],
+  const preValidation = {
+    interactive: config.get<boolean>('interactive'),
+    closeTerminalOnSuccess: config.get<boolean>('closeTerminalOnSuccess'),
+    ...metadata,
+    name:
+      metadata.name ||
+      metadata['runme.dev/name'] ||
+      `Cell #${Math.random().toString().slice(2)}`,
   }
+
+  let result
+  try {
+    result = CellAnnotationsSchema.parse(preValidation)
+  } catch (err: any) {
+    const message = err.format ? JSON.stringify(err.format()) : err.message
+    console.error(`[Runme] Invalid annotations in metadata: ${message}`)
+    throw err
+  }
+
+  return result
 }
 
 export function getTerminalByCell(cell: vscode.NotebookCell) {
@@ -153,7 +154,7 @@ export async function canEditFile(
   verifyCheckedInFileFn = verifyCheckedInFile
 ): Promise<boolean> {
   const config = vscode.workspace.getConfiguration('runme.flags')
-  const disableSaveRestriction = config.get<boolean>('disableSaveRestriction', true)
+  const disableSaveRestriction = config.get<boolean>('disableSaveRestriction')
   const currentDocumentPath = notebook.uri.fsPath
   const isNewFile = notebook.isUntitled && notebook.notebookType === Kernel.type
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+const CELL_RANDOM_NAME = `Cell #${Math.random().toString().slice(2)}`
+
 const falseyBoolean = z.preprocess((subject) => {
     if (typeof subject === 'string' && subject.toLowerCase() === 'false') {
         return false
@@ -7,12 +9,26 @@ const falseyBoolean = z.preprocess((subject) => {
     return Boolean(subject)
 }, z.boolean())
 
+const boolify = (defaultValue: boolean, invalidTypeError: string = 'expected a boolean value') =>
+    z.preprocess((subject) => {
+        if (!subject) {
+            return defaultValue
+        }
+        if (typeof subject === 'string' && subject.toLowerCase() === 'false') {
+            return false
+        }
+        if (typeof subject === 'string' && subject.toLowerCase() === 'true') {
+            return true
+        }
+        return subject
+    }, z.boolean({ invalid_type_error: invalidTypeError }))
+
 export const AnnotationSchema = {
     'runme.dev/uuid': z.string().uuid().optional(),
-    background: z.boolean({ invalid_type_error: 'expected a boolean value' }).default(false),
-    interactive: z.boolean({ invalid_type_error: 'expected a boolean value' }).default(true),
-    closeTerminalOnSuccess: z.boolean({ invalid_type_error: 'expected a boolean value' }).default(true),
-    name: z.string(),
+    background: boolify(false),
+    interactive: boolify(true),
+    closeTerminalOnSuccess: boolify(true),
+    name: z.string().default(CELL_RANDOM_NAME),
     mimeType: z
         .string()
         .refine((subject) => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,11 +2,17 @@ import { z } from 'zod'
 
 const CELL_RANDOM_NAME = `Cell #${Math.random().toString().slice(2)}`
 
-const falseyBoolean = z.preprocess((subject) => {
+const falseyBoolean = (defaultValue: boolean) => z.preprocess((subject) => {
+    if (typeof subject === 'boolean') {
+        return subject
+    }
     if (typeof subject === 'string' && subject.toLowerCase() === 'false') {
         return false
     }
-    return Boolean(subject)
+    if (typeof subject === 'string' && subject.toLowerCase() === 'true') {
+        return true
+    }
+    return defaultValue
 }, z.boolean())
 
 const boolify = (defaultValue: boolean, invalidTypeError: string = 'expected a boolean value') =>
@@ -32,8 +38,8 @@ export const AnnotationSchema = {
     mimeType: z
         .string()
         .refine((subject) => {
-            const [type, subtype] = subject.split('/')
-            if (!type || !subtype) {
+            const [type, subtype, ...rest] = subject.split('/')
+            if (!type || !subtype || rest.length) {
                 return false
             }
             return true
@@ -43,9 +49,9 @@ export const AnnotationSchema = {
 
 export const SafeCellAnnotationsSchema = z.object({
     ...AnnotationSchema,
-    background: falseyBoolean.default(false),
-    interactive: falseyBoolean.default(true),
-    closeTerminalOnSuccess: falseyBoolean.default(true),
+    background: falseyBoolean(false),
+    interactive: falseyBoolean(false),
+    closeTerminalOnSuccess: falseyBoolean(true),
 })
 
 export const CellAnnotationsSchema = z.object({

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+const falseyBoolean = z.preprocess((subject) => {
+    if (typeof subject === 'string' && subject.toLowerCase() === 'false') {
+        return false
+    }
+    return Boolean(subject)
+}, z.boolean())
+
+export const AnnotationSchema = {
+    'runme.dev/uuid': z.string().uuid().optional(),
+    background: z.boolean({ invalid_type_error: 'expected a boolean value' }).default(false),
+    interactive: z.boolean({ invalid_type_error: 'expected a boolean value' }).default(true),
+    closeTerminalOnSuccess: z.boolean({ invalid_type_error: 'expected a boolean value' }).default(true),
+    name: z.string(),
+    mimeType: z
+        .string()
+        .refine((subject) => {
+            const [type, subtype] = subject.split('/')
+            if (!type || !subtype) {
+                return false
+            }
+            return true
+        }, 'mime type specification invalid format')
+        .default('text/plain')
+}
+
+export const SafeCellAnnotationsSchema = z.object({
+    ...AnnotationSchema,
+    background: falseyBoolean.default(false),
+    interactive: falseyBoolean.default(true),
+    closeTerminalOnSuccess: falseyBoolean.default(true),
+})
+
+export const CellAnnotationsSchema = z.object({
+    ...AnnotationSchema
+})

--- a/tests/extension/provider/annotations.test.ts
+++ b/tests/extension/provider/annotations.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../../src/extension/utils', () => ({
       }
     }
   }),
+  validateAnnotations: vi.fn()
 }))
 
 describe('Runme Annotations', () => {

--- a/tests/extension/schema.test.ts
+++ b/tests/extension/schema.test.ts
@@ -1,0 +1,118 @@
+import { expect, test, suite } from 'vitest'
+
+import { AnnotationSchema, SafeCellAnnotationsSchema, CellAnnotationsSchema } from '../../src/schema'
+
+const CELL_REGEX = new RegExp('(Cell #)[0-9]+')
+
+suite('AnnotationSchema', () => {
+    suite('mimeType', () => {
+        test('should fail for an invalid mime-type', () => {
+            ['invalid', 'text/', 'invalid/mime/type'].forEach((mimeType) => {
+                const parseResult = AnnotationSchema.mimeType.safeParse(mimeType)
+                expect(parseResult.success).toBeFalsy()
+                expect(!parseResult.success && parseResult.error.flatten().formErrors).toStrictEqual([
+                    'mime type specification invalid format'
+                ])
+            })
+
+        })
+
+        test('should accept a valid mime-type', () => {
+            ['text/plain', 'text/x-json', 'application/xml', 'image/png'].forEach((mimeType) => {
+                const parseResult = AnnotationSchema.mimeType.safeParse(mimeType)
+                expect(parseResult.success).toBeTruthy()
+                expect(parseResult.success && parseResult.data).toStrictEqual(mimeType)
+            })
+        })
+    })
+
+    suite('name', () => {
+        test('it should add a default name when empty', () => {
+            const parseResult = AnnotationSchema.name.safeParse(undefined)
+            expect(parseResult.success).toBeTruthy()
+            expect(parseResult.success && CELL_REGEX.test(parseResult.data)).toBeTruthy()
+        })
+
+        test('it should fail for null value', () => {
+            const parseResult = AnnotationSchema.name.safeParse(null)
+            expect(parseResult.success).toBeFalsy()
+            expect(!parseResult.success && parseResult.error.flatten().formErrors).toStrictEqual([
+                'Expected string, received null'
+            ])
+        })
+
+        test('it should accept an empty string', () => {
+            const parseResult = AnnotationSchema.name.safeParse('')
+            expect(parseResult.success).toBeTruthy()
+        })
+    })
+
+    suite('SafeCellAnnotationsSchema', () => {
+        test('Should add safe defaults for invalid values', () => {
+            const expectedOutput = {
+                background: false,
+                interactive: false,
+                closeTerminalOnSuccess: true
+            }
+            const parseResult = SafeCellAnnotationsSchema.safeParse(
+                {
+                    background: 'invalid',
+                    interactive: 'invalid',
+                    closeTerminalOnSuccess: 'invalid'
+                }
+            )
+
+            expect(parseResult.success).toBeTruthy()
+            if (parseResult.success) {
+                for (const [key, value] of Object.entries(expectedOutput)) {
+                    expect(parseResult.data[key]).toStrictEqual(value)
+                }
+            }
+        })
+
+        test('Should generate safe default values', () => {
+            const parseResult = SafeCellAnnotationsSchema.safeParse({})
+            expect(parseResult.success).toBeTruthy()
+            if (parseResult.success) {
+                const { background, closeTerminalOnSuccess, interactive, mimeType, name } = parseResult.data
+                expect(background).toBeFalsy()
+                expect(closeTerminalOnSuccess).toBeTruthy()
+                expect(interactive).toBeFalsy()
+                expect(mimeType).toStrictEqual('text/plain')
+                expect(CELL_REGEX.test(name)).toBeTruthy()
+            }
+        })
+    })
+
+    suite('CellAnnotationsSchema', () => {
+        test('Should fail for invalid values', () => {
+            const input = {
+                background: 'invalid',
+                interactive: 'invalid',
+                closeTerminalOnSuccess: 'invalid'
+            }
+            const parseResult = CellAnnotationsSchema.safeParse(input)
+
+            expect(parseResult.success).toBeFalsy()
+            if (!parseResult.success) {
+                const { fieldErrors } = parseResult.error.flatten()
+                for (const key in input) {
+                    expect(fieldErrors[key]).toStrictEqual(['expected a boolean value'])
+                }
+            }
+        })
+
+        test('Should generate safe default values', () => {
+            const parseResult = SafeCellAnnotationsSchema.safeParse({})
+            expect(parseResult.success).toBeTruthy()
+            if (parseResult.success) {
+                const { background, closeTerminalOnSuccess, interactive, mimeType, name } = parseResult.data
+                expect(background).toBeFalsy()
+                expect(closeTerminalOnSuccess).toBeTruthy()
+                expect(interactive).toBeFalsy()
+                expect(mimeType).toStrictEqual('text/plain')
+                expect(CELL_REGEX.test(name)).toBeTruthy()
+            }
+        })
+    })
+})

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -13,7 +13,7 @@ import {
   hashDocumentUri,
 } from '../../src/extension/utils'
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
-import { NotebookCellAnnotations } from '../../src/types'
+import { CellAnnotations } from '../../src/types'
 
 vi.mock('vscode', () => ({
   default: {
@@ -250,7 +250,7 @@ suite('#getAnnotations', () => {
   test('should have sane defaults', () => {
     const d = getAnnotations({ name: 'command-123', 'runme.dev/uuid': '48d86c43-84a4-469d-8c78-963513b0f9d0' })
     expect(d).toStrictEqual(
-      <NotebookCellAnnotations>{
+      <CellAnnotations>{
         background: false,
         closeTerminalOnSuccess: false,
         interactive: false,
@@ -275,7 +275,6 @@ suite('#getAnnotations', () => {
       interactive: false,
       mimeType: 'text/plain',
       name: 'echo-hello',
-      'runme.dev/uuid': undefined,
     })
   })
 })


### PR DESCRIPTION
Unfinished. What's left:

- [x] Validate serialization and handle errors appropriate
- [x] Form-level validation in Annotations UI
- [x] Testing

Error handling mechanism:
The original PR throws an error when finding invalid values. The latest version introduces safe defaults so that the Notebook can be opened (it fallbacks to the annotation's default values). The idea is that the user can still run the code block while seeing an error message that the configuration values are using the wrong data. This gives the user to fix the issue and save it. We are also displaying validation messages on the editing experience.

<img width="1058" alt="Screenshot 2023-02-14 at 12 57 11 PM" src="https://user-images.githubusercontent.com/4001529/218819405-0e516db8-65a2-4ec0-a5d1-40349abb768a.png">
<img width="1067" alt="Screenshot 2023-02-14 at 12 58 54 PM" src="https://user-images.githubusercontent.com/4001529/218819408-4839ec38-118f-420b-a468-17910e2e045d.png">



https://user-images.githubusercontent.com/4001529/218818809-3efca890-6b9b-4ec7-bf45-1e078c3b3c2f.mp4


