### PR TITLE
Support set-up by file

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -31,6 +31,7 @@ export const workspace = {
   onDidOpenNotebookDocument: vi.fn().mockReturnValue({ dispose: vi.fn() }),
   onDidSaveNotebookDocument: vi.fn().mockReturnValue({ dispose: vi.fn() }),
   fs: {
+    writeFile: vi.fn(),
     readFile: vi.fn().mockResolvedValue(Buffer.from('some wasm file')),
     stat: vi.fn().mockResolvedValue(1),
     createDirectory: vi.fn(),

--- a/src/extension/handler/utils.ts
+++ b/src/extension/handler/utils.ts
@@ -114,19 +114,20 @@ export async function waitForProjectCheckout (
          * write a runme file into the directory, so the extension knows it has
          * to open the readme file
          */
-        const fileExist = await workspace.fs.stat(Uri.joinPath(targetDirUri, fileToOpen))
-            .then(() => true, () => false)
-        if (fileExist) {
-            const enc = new TextEncoder()
-            await workspace.fs.writeFile(
-                Uri.joinPath(targetDirUri, BOOTFILE),
-                enc.encode(fileToOpen)
-            )
-            console.log(`[Runme] Created temporary bootstrap file to open ${fileToOpen}`)
-        }
+        await workspace.fs.stat(Uri.joinPath(targetDirUri, fileToOpen))
+            .then(() => writeBootstrapFile(targetDirUri, fileToOpen))
 
         cb(true)
     }, INTERVAL)
+}
+
+export async function writeBootstrapFile (targetDirUri: Uri, fileToOpen: string) {
+    const enc = new TextEncoder()
+    await workspace.fs.writeFile(
+        Uri.joinPath(targetDirUri, BOOTFILE),
+        enc.encode(fileToOpen)
+    )
+    console.log(`[Runme] Created temporary bootstrap file to open ${fileToOpen}`)
 }
 
 /**


### PR DESCRIPTION
This is an addition to https://github.com/stateful/vscode-runme/pull/159 which allows one to set up a project with an url of a single markdown file, e.g. using a gist. The url has to be as follows:

```
vscode://stateful.runme?command=setup&fileToOpen=https://raw.githubusercontent.com/stateful/vscode-runme/main/examples/k8s/README.md
```