### PR TITLE
Fix annotations not saving if file has markdown blocks

### DIFF
--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -104,12 +104,12 @@ export class Kernel implements Disposable {
           if (
             cell.kind !== NotebookCellKind.Code ||
             cell.document.uri.fsPath !== editor.notebook.uri.fsPath) {
-            break
+            continue
           }
 
           if (cell.metadata?.['runme.dev/uuid'] === undefined) {
             console.error(`[Runme] Cell with index ${cell.index} lacks uuid`)
-            break
+            continue
           }
 
           if (


### PR DESCRIPTION
If there's a non-code block before a code block, it'll break from the checking loop pre-maturely. So I think we have to use `continue` here instead.