### PR TITLE
Runner service implementation feature parity

### DIFF
--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -52,6 +52,10 @@ export async function executeRunner(
 
     const userValue = await promptUserForVariable(key, value, hasStringValue)
 
+    if(userValue === undefined) {
+      return false
+    }
+
     envs[key] = userValue
 
     /**
@@ -72,7 +76,7 @@ export async function executeRunner(
     script: {
       type: 'commands', commands
     },
-    envs: Object.entries(envs).map(([k, v]) => `${k}="${v}"`),
+    envs: Object.entries(envs).map(([k, v]) => `${k}=${v}`),
     cwd,
     tty: interactive
   })

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -122,9 +122,9 @@ export async function executeRunner(
     const taskExecution = new Task(
       { type: 'shell', name: `Runme Task (${RUNME_ID})` },
       TaskScope.Workspace,
-      cellText.length > LABEL_LIMIT
+      (cellText.length > LABEL_LIMIT
         ? `${cellText.slice(0, LABEL_LIMIT)}...`
-        : cellText,
+        : cellText) + ` (RUNME_ID: ${RUNME_ID})`,
       'exec',
       new CustomExecution(async () => program)
     )

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -23,6 +23,7 @@ import { closeTerminalByEnvID } from './task'
 import { getCommandExportExtractMatches, getShellPath, promptUserForVariable } from './utils'
 
 const LABEL_LIMIT = 15
+const BACKGROUND_TASK_HIDE_TIMEOUT = 2000
 const MIME_TYPES_WITH_CUSTOM_RENDERERS = ['text/plain']
 
 export async function executeRunner(
@@ -183,6 +184,16 @@ export async function executeRunner(
     if(program.hasExited()) {
       // unexpected early return, likely an error
       resolve(false)
+    }
+
+    if(background && interactive) {
+      setTimeout(
+        () => {
+          closeTerminalByEnvID(RUNME_ID)
+          return resolve(true)
+        },
+        BACKGROUND_TASK_HIDE_TIMEOUT
+      )
     }
   })
 }

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -17,7 +17,7 @@ import { OutputType } from '../../constants'
 import { CellOutputPayload } from '../../types'
 import { PLATFORM_OS } from '../constants'
 import { IRunner, IRunnerEnvironment } from '../runner'
-import { getAnnotations, getCmdShellSeq, replaceOutput } from '../utils'
+import { getAnnotations, getCmdSeq, getCmdShellSeq, replaceOutput } from '../utils'
 
 import { closeTerminalByEnvID } from './task'
 import { getShellPath } from './utils'
@@ -37,7 +37,7 @@ export async function executeRunner(
   const RUNME_ID = `${runningCell.fileName}:${exec.cell.index}`
 
   const cellText = exec.cell.document.getText()
-  const script = getCmdShellSeq(cellText, PLATFORM_OS)
+  const commands = getCmdSeq(cellText)
 
   const annotations = getAnnotations(exec.cell)
   const { interactive, mimeType, background } = annotations
@@ -46,7 +46,7 @@ export async function executeRunner(
     programName: getShellPath(execKey),
     environment,
     script: {
-      type: 'script', script
+      type: 'commands', commands
     },
     envs: [
       `RUNME_ID=${RUNME_ID}`
@@ -65,6 +65,8 @@ export async function executeRunner(
       output.push(Buffer.from(data))
 
       let item = new NotebookCellOutputItem(Buffer.concat(output), mime)
+
+      const script = getCmdShellSeq(cellText, PLATFORM_OS)
 
       // hacky for now, maybe inheritence is a fitting pattern
       if (script.trim().endsWith('vercel')) {

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -58,7 +58,7 @@ export async function executeRunner(
   const program = await runner.createProgramSession({
     programName: getShellPath(execKey),
     environment,
-    script: {
+    exec: {
       type: 'commands', commands
     },
     envs: Object.entries(envs).map(([k, v]) => `${k}=${v}`),

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -48,12 +48,26 @@ export async function executeRunner(
   const exportMatches = getCommandExportExtractMatches(cellText)
 
   for (const { hasStringValue, key, match, type, value } of exportMatches) {
-    if(type !== 'prompt') { continue }
+    let userValue: string
 
-    const userValue = await promptUserForVariable(key, value, hasStringValue)
+    switch(type) {
+      case 'prompt': {
+        const userInput = await promptUserForVariable(key, value, hasStringValue)
 
-    if(userValue === undefined) {
-      return false
+        if(userInput === undefined) {
+          return false
+        }
+
+        userValue = userInput
+      } break
+
+      case 'direct': {
+        userValue = value
+      } break
+
+      default: {
+        continue
+      }
     }
 
     envs[key] = userValue

--- a/src/extension/executors/task.ts
+++ b/src/extension/executors/task.ts
@@ -2,12 +2,12 @@ import path from 'node:path'
 
 import {
   Task, TextDocument, NotebookCellExecution, TaskScope, tasks,
-  window, TerminalOptions, TaskRevealKind, TaskPanelKind,
+  window, TaskRevealKind, TaskPanelKind,
   ShellExecution
 } from 'vscode'
 
 // import { ExperimentalTerminal } from "../terminal"
-import { getCmdShellSeq, getAnnotations } from '../utils'
+import { getCmdShellSeq, getAnnotations, getTerminalRunmeId } from '../utils'
 import { PLATFORM_OS, ENV_STORE } from '../constants'
 import type { Kernel } from '../kernel'
 
@@ -18,7 +18,7 @@ const BACKGROUND_TASK_HIDE_TIMEOUT = 2000
 const LABEL_LIMIT = 15
 
 export function closeTerminalByEnvID (id: string) {
-  const terminal = window.terminals.find((t) => (t.creationOptions as TerminalOptions).env?.RUNME_ID === id)
+  const terminal = window.terminals.find(t => getTerminalRunmeId(t) === id)
   if (terminal) {
     terminal.hide()
   }

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -47,14 +47,14 @@ export async function promptUserForVariable(
   key: string,
   placeHolder: string,
   hasStringValue: boolean,
-) {
+): Promise<string | undefined> {
   return await window.showInputBox({
     title: `Set Environment Variable "${key}"`,
     ignoreFocusOut: true,
     placeHolder,
     prompt: 'Your shell script wants to set some environment variables, please enter them here.',
     ...(hasStringValue ? { value: placeHolder } : {})
-  }) || ''
+  })
 }
 
 export function getCommandExportExtractMatches(
@@ -141,7 +141,7 @@ export async function retrieveShellCommand (exec: NotebookCellExecution) {
        * VS Code, see https://github.com/microsoft/vscode/issues/98098
        */
       stateEnv[key] = populateEnvVar(
-        await promptUserForVariable(key, value, hasStringValue),
+        await promptUserForVariable(key, value, hasStringValue) ?? '',
         {...process.env, ...stateEnv }
       )
     } else {

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -265,6 +265,7 @@ export class Kernel implements Disposable {
       (execKey === 'bash' || execKey === 'sh')
     ) {
       successfulCellExecution = await executeRunner(
+        this.context,
         this.runner,
         exec,
         runningCell,

--- a/src/extension/provider/background.ts
+++ b/src/extension/provider/background.ts
@@ -29,8 +29,17 @@ export class ShowTerminalProvider implements vscode.NotebookCellStatusBarItemPro
       return
     }
 
+    const terminalButtonParts = [
+      '$(terminal)',
+      'Open Terminal',
+    ]
+
+    if (pid > -1) {
+      terminalButtonParts.push(`(PID: ${pid})`)
+    }
+
     const item = new NotebookCellStatusBarItem(
-      `$(terminal) Open Terminal (PID: ${pid})`,
+      terminalButtonParts.join(' '),
       NotebookCellStatusBarAlignment.Right
     )
     item.command = 'runme.openTerminal'

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -28,7 +28,7 @@ export interface RunProgramOptions {
   args?: string[]
   cwd?: string
   envs?: string[]
-  script?:
+  exec?:
     |{
       type: 'commands'
       commands: string[]
@@ -369,7 +369,7 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
   }
 
   static runOptionsToExecuteRequest(
-    { programName, args, cwd, environment, script, tty, envs }: RunProgramOptions
+    { programName, args, cwd, environment, exec, tty, envs }: RunProgramOptions
   ): ExecuteRequest {
     if(environment && !(environment instanceof GrpcRunnerEnvironment)) {
       throw new Error('Expected gRPC environment!')
@@ -382,8 +382,8 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
       tty,
       sessionId: environment?.getSessionId(),
       programName,
-      ...script?.type === 'commands' && { commands: script.commands },
-      ...script?.type === 'script' && { script: script.script }
+      ...exec?.type === 'commands' && { commands: exec.commands },
+      ...exec?.type === 'script' && { script: exec.script }
     })
   }
 }

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -87,7 +87,7 @@ export function validateAnnotations(cell: NotebookCell): CellAnnotationsErrorRes
 
 }
 
-function getTerminalRunmeId(t: vscode.Terminal): string|undefined {
+export function getTerminalRunmeId(t: vscode.Terminal): string|undefined {
   return (t.creationOptions as vscode.TerminalOptions).env?.RUNME_ID
     ?? /\(RUNME_ID: (.*)\)$/.exec(t.name)?.[1]
     ?? undefined

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -114,8 +114,8 @@ export function getKey(runningCell: vscode.TextDocument): keyof typeof executor 
  * treat cells like like a series of individual commands
  * which need to be executed in sequence
  */
-export function getCmdShellSeq(cellText: string, os: string): string {
-  const trimmed = cellText
+export function getCmdSeq(cellText: string): string[] {
+  return cellText
     .trimStart()
     .split('\\\n')
     .map((l) => l.trim())
@@ -138,6 +138,16 @@ export function getCmdShellSeq(cellText: string, os: string): string {
       const hasPrefix = (l.match(HASH_PREFIX_REGEXP) || []).length > 0
       return l !== '' && !hasPrefix
     })
+}
+
+/**
+ * treat cells like like a series of individual commands
+ * which need to be executed in sequence
+ *
+ * packages command sequence into single callable script
+ */
+export function getCmdShellSeq(cellText: string, os: string): string {
+  const trimmed = getCmdSeq(cellText)
     .join('; ')
 
   if (['darwin'].find((entry) => entry === os)) {

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -87,10 +87,15 @@ export function validateAnnotations(cell: NotebookCell): CellAnnotationsErrorRes
 
 }
 
+function getTerminalRunmeId(t: vscode.Terminal): string|undefined {
+  return (t.creationOptions as vscode.TerminalOptions).env?.RUNME_ID
+    ?? /\(RUNME_ID: (.*)\)$/.exec(t.name)?.[1]
+    ?? undefined
+}
+
 export function getTerminalByCell(cell: vscode.NotebookCell) {
   return vscode.window.terminals.find((t) => {
-    const taskEnv = (t.creationOptions as vscode.TerminalOptions).env || {}
-    return taskEnv.RUNME_ID === `${cell.document.fileName}:${cell.index}`
+    return getTerminalRunmeId(t) === `${cell.document.fileName}:${cell.index}`
   })
 }
 

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -22,6 +22,8 @@ vi.mock('vscode', () => ({
 
 vi.mock('../../../src/extension/utils', () => ({
   replaceOutput: vi.fn(),
+  // TODO: this should use importActual
+  getCmdSeq: vi.fn((cellText: string) => cellText.trim().split('\n').filter(x => x))
 }))
 
 beforeEach(() => {

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -1,12 +1,14 @@
 import url from 'node:url'
 
 import { window } from 'vscode'
-import { expect, vi, test, beforeEach } from 'vitest'
+import { expect, vi, test, suite, beforeEach } from 'vitest'
 
 import { ENV_STORE } from '../../../src/extension/constants'
-import { retrieveShellCommand } from '../../../src/extension/executors/utils'
+import { retrieveShellCommand, parseCommandSeq } from '../../../src/extension/executors/utils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
+vi.mock('vscode-telemetry', () => ({}))
 
 vi.mock('vscode', () => ({
   window: {
@@ -189,4 +191,68 @@ test('supports multiline exports', async () => {
   expect(ENV_STORE.get('foo')).toBe('some\nmultiline\nexport')
   expect(ENV_STORE.get('foobar')).toBe('barfoo')
   expect(window.showInputBox).toBeCalledTimes(2)
+})
+
+suite('parseCommandSeq', () => {
+  test('single-line export', async () => {
+    vi.mocked(window.showInputBox).mockImplementationOnce(async () => 'test value')
+
+    const res = await parseCommandSeq([
+      'export TEST="<placeholder>"'
+    ].join('\n'))
+
+    expect(res).toBeTruthy
+    expect(res).toHaveLength(1)
+    expect(res?.[0]).toBe('export TEST="test value"')
+  })
+
+  test('multiline export', async () => {
+    const exportLine = [
+      'export TEST="I',
+      'am',
+      'doing',
+      'well!"'
+    ].join('\n')
+
+    const res = await parseCommandSeq(exportLine)
+
+    expect(res).toBeTruthy
+    expect(res).toHaveLength(1)
+    expect(res?.[0]).toBe(exportLine)
+  })
+
+  test('exports between normal command sequences', async () => {
+    vi.mocked(window.showInputBox).mockImplementationOnce(async () => 'test value')
+
+    const cmd = [
+      'echo "Hello!"',
+      'echo "Hi!"',
+      'export TEST="<placeholder>"',
+      'echo $TEST',
+      'export TEST_MULTILINE="This',
+      'is',
+      'a',
+      'multiline',
+      'env!"',
+      'echo $TEST_MULTILINE'
+    ].join('\n')
+
+    const res = await parseCommandSeq(cmd)
+
+    expect(res).toBeTruthy()
+    expect(res).toStrictEqual([
+      'echo "Hello!"',
+      'echo "Hi!"',
+      'export TEST="test value"',
+      'echo $TEST',
+      [
+        'export TEST_MULTILINE="This',
+        'is',
+        'a',
+        'multiline',
+        'env!"',
+      ].join('\n'),
+      'echo $TEST_MULTILINE'
+    ])
+  })
 })


### PR DESCRIPTION
- [x] Run `background=true` as background tasks
- [x] User-prompts (UI) for ENV variables
- [x] Unify cmds/script prep?
- [x] Allow identification of grpc-created terminals

Needs changes in runme service:

- [x] Curl-ing img (last cell in `examples/README.md`) with notebook-native png renderer crash-hangs [#143](https://github.com/stateful/runme/issues/143)
- [x] Cat-ing LICENSE (in `examples/README.md`) does not work ~~[#144](https://github.com/stateful/runme/issues/144)~~ [#155](https://github.com/stateful/runme/issues/155)
 