### PR TITLE
Add new extension distribution with binaries

### DIFF
--- a/.github/scripts/checkRelease.js
+++ b/.github/scripts/checkRelease.js
@@ -1,0 +1,81 @@
+
+const ARCHITECTURES = {
+    x86: 'x86_64',
+    arm64: 'arm64',
+}
+
+const SUPPORTED_PLATFORMS = {
+    macOS: {
+        platform: 'darwin',
+        format: 'tar.gz',
+        architectures: [ARCHITECTURES.x86, ARCHITECTURES.arm64]
+    },
+    linux: {
+        platform: 'linux',
+        format: 'tar.gz',
+        architectures: [ARCHITECTURES.x86, ARCHITECTURES.arm64]
+    },
+    windows: {
+        platform: 'windows',
+        format: 'zip',
+        architectures: [ARCHITECTURES.x86, ARCHITECTURES.arm64]
+    }
+}
+
+export default async ({ github, context, core }) => {
+    console.log('Check release started...')
+    const repo = process.env.REPOSITORY
+    const releaseVersion = context.payload?.inputs?.releaseVersion
+    if (!repo) {
+        throw new Error('couldn\'t find a REPOSITORY environment variable')
+    }
+    if (!releaseVersion) {
+        throw new Error('couldn\'t find a release version specified')
+    }
+
+    console.log(`Checking release ${releaseVersion} for ${repo}`)
+    const params = {
+        owner: context.repo.owner,
+        repo,
+    }
+    let release
+    if (releaseVersion === 'latest') {
+        const { data } = await github.rest.repos.getLatestRelease(params)
+        release = data
+    } else {
+        const { data } = await github.rest.repos.getReleaseByTag({
+            ...params,
+            tag: releaseVersion
+        })
+        release = data
+    }
+    if (!release) {
+        throw new Error(`Release not found ${releaseVersion}`)
+    }
+
+    if (release.draft || release.prerelease) {
+        throw new Error(`The release ${releaseVersion} is not a stable release version!`)
+    }
+
+    if (!release.assets?.length) {
+        throw new Error('Could\'t find valid release assets')
+    }
+
+    // Get release assets for each platform
+    for (const [key, { platform, format, architectures }] of Object.entries(SUPPORTED_PLATFORMS)) {
+        architectures.forEach((architecture) => {
+            const assetName = `${repo}_${platform}_${architecture}.${format}`
+            const asset = release.assets.find(({ name }) => name === assetName)
+            if (!asset) {
+                console.log(`Asset not found:${assetName}, skipping`)
+            }
+            if (asset) {
+                const assetKey = `${key.toLocaleUpperCase()}_${architecture}`
+                // (e.g) DOWNLOAD_URL_LINUX_x86_64, DOWNLOAD_URL_WINDOWS_arm64
+                const downloadVariable = `DOWNLOAD_URL_${assetKey}`
+                core.exportVariable(downloadVariable, asset.browser_download_url)
+                console.log(`Exported the following variable: ${downloadVariable}`)
+            }
+        })
+    }
+}

--- a/.github/scripts/downloadAndExtract.js
+++ b/.github/scripts/downloadAndExtract.js
@@ -5,11 +5,11 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { parseArgs, promisify } from 'node:util'
 
-
 import tar from 'tar-fs'
 import unzipper from 'unzipper'
 
 const streamPipeline = promisify(pipeline)
+const VALID_FORMATS = ['zip', 'tar']
 const SCHEMA = {
     downloadUrl: {
         type: 'string',
@@ -61,7 +61,7 @@ const cleanCliDownload = async (cliDownloadFolder) => {
 }
 
 const downloadBinary = async (downloadUrl, type, binaryDestination, binaryName) => {
-    if (!['zip', 'tar'].includes(type)) {
+    if (!VALID_FORMATS.includes(type)) {
         throw new Error(`Invalid type ${type}, it must be zip or tar file`)
     }
 
@@ -72,7 +72,7 @@ const downloadBinary = async (downloadUrl, type, binaryDestination, binaryName) 
     if (!binaryName) {
         throw new Error('Missing binary name')
     }
-    
+
     const cliFilePath = path.resolve(binaryDestination)
     await cleanCliDownload(cliFilePath)
     await fsp.mkdir(cliFilePath, { recursive: true })

--- a/.github/scripts/downloadAndExtract.js
+++ b/.github/scripts/downloadAndExtract.js
@@ -1,0 +1,125 @@
+import { pipeline, Readable } from 'node:stream'
+import fsp from 'node:fs/promises'
+import zlib from 'node:zlib'
+import path from 'node:path'
+import fs from 'node:fs'
+import { parseArgs, promisify } from 'node:util'
+
+
+import tar from 'tar-fs'
+import unzipper from 'unzipper'
+
+const streamPipeline = promisify(pipeline)
+const SCHEMA = {
+    downloadUrl: {
+        type: 'string',
+        short: 'd',
+        description: 'Binary file Download URL'
+    },
+    type: {
+        type: 'string',
+        short: 'f',
+        default: 'tar',
+        description: 'The compressed file format (zip, tar)'
+    },
+    binaryDestination: {
+        type: 'string',
+        short: 'b',
+        default: 'bin',
+        description: 'The destination binary folder (defaults to bin)'
+    },
+    binaryName: {
+        type: 'string',
+        short: 'n',
+        default: 'runme',
+        description: 'The distributed binary name (defaults to runme)'
+    }
+}
+
+const displayToolHelp = () => {
+    console.log('Tool usage')
+    for (const [, { short, description }] of Object.entries(SCHEMA)) {
+        console.log(`-${short}:${description}`)
+    }
+}
+
+const cleanCliDownload = async (cliDownloadFolder) => {
+    if (
+        !await fsp.stat(cliDownloadFolder)
+            .then((val) => val.isDirectory())
+            .catch(() => false)
+    ) {
+        console.info("No CLI Download folder found, nothing to do!")
+        return
+    }
+
+    console.info("🗑️ Cleaning CLI Download folder...")
+
+    await fsp.rm(cliDownloadFolder, { recursive: true, force: true })
+
+    console.info("✅ CLI Download folder cleared!")
+}
+
+const downloadBinary = async (downloadUrl, type, binaryDestination, binaryName) => {
+    if (!['zip', 'tar'].includes(type)) {
+        throw new Error(`Invalid type ${type}, it must be zip or tar file`)
+    }
+
+    if (!downloadUrl) {
+        throw new Error('Missing a download URL')
+    }
+
+    if (!binaryName) {
+        throw new Error('Missing binary name')
+    }
+    
+    const cliFilePath = path.resolve(binaryDestination)
+    await cleanCliDownload(cliFilePath)
+    await fsp.mkdir(cliFilePath, { recursive: true })
+    console.log(`Checking binary destination path: ${cliFilePath}`)
+    console.log(`Downloading binary ${downloadUrl}`)
+    const res = await fetch(downloadUrl)
+    if (type === 'tar') {
+        console.log('Extracting tar file')
+        await streamPipeline(res.body, zlib.createGunzip(), tar.extract(cliFilePath, {
+            ignore: (name) => path.basename(name) !== binaryName
+        }))
+    } else {
+        console.log('Extracting zip file')
+        const stream = Readable.from(res.body).pipe(unzipper.Parse())
+
+        stream.on('entry', (entry) => {
+            const fileName = entry.path
+            const type = entry.type
+            if (type === 'File' && path.extname(fileName) === '.exe') {
+                const execStream = entry.pipe(fs.createWriteStream(path.join(cliFilePath, binaryName)))
+                // workaround for github actions, which will throw an error if you
+                // try to write directly to an `exe` file
+                execStream.on('close', async () => {
+                    await fsp.rename(
+                        path.join(cliFilePath, binaryName),
+                        path.join(cliFilePath, `${binaryName}.exe`)
+                    )
+                })
+            }
+        })
+
+        // wait for stream to close
+        await new Promise((res, rej) => {
+            stream.on('close', res)
+            stream.on('error', (err) => rej(err))
+        })
+    }
+    console.log(`✅ Successfully downloaded and unpacked CLI executable file to ${cliFilePath}`)
+}
+
+const { values: { downloadUrl, type, binaryDestination, binaryName } } = parseArgs({
+    options: SCHEMA
+})
+
+try {
+    await downloadBinary(downloadUrl, type, binaryDestination, binaryName)
+} catch (error) {
+    displayToolHelp()
+    throw error
+}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -46,10 +46,6 @@ jobs:
   prepareRelease:
     name: Prepare release
     runs-on: ubuntu-latest
-    env:
-      REPOSITORY: runme
-      BINARY_PATH: .bin
-      DOWNLOAD_PATH: downloads
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -456,5 +452,3 @@ jobs:
         if: failure()
         with:
           timeout: "300000"
-
-

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,460 @@
+name: Release extension with new runme binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "Runme release version"
+        required: true
+        type: string
+        default: latest
+      releaseType:
+        description: "Release Type"
+        required: true
+        type: choice
+        default: "patch"
+        options:
+          - patch
+          - minor
+          - major
+      releaseChannel:
+        description: "Release Channel"
+        required: true
+        type: choice
+        default: stable
+        options:
+          - stable
+          - edge
+      publishMarketplace:
+        description: "Publish on Visual Studio Marketplace?"
+        required: true
+        type: choice
+        default: "yes"
+        options:
+          - "yes"
+          - "no"
+      publishOpenVSX:
+        description: "Publish on Open VSX Registry?"
+        required: true
+        type: choice
+        default: "yes"
+        options:
+          - "yes"
+          - "no"
+
+jobs:
+  prepareRelease:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    env:
+      REPOSITORY: runme
+      BINARY_PATH: .bin
+      DOWNLOAD_PATH: downloads
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Install Dependencies
+        run: npm install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_DOWNLOAD_CLI: true
+      
+      - name: Build Package (Edge)
+        run: npm run build:dev
+        env:
+          NODE_ENV: development
+          INSTRUMENTATION_KEY: ${{ secrets.INSTRUMENTATION_KEY }}
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+
+      - name: Build Package (Stable)
+        run: npm run build:prod
+        env:
+          NODE_ENV: production
+          INSTRUMENTATION_KEY: ${{ secrets.INSTRUMENTATION_KEY }}
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+      
+      - name: Run Tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: npm test
+          options: "-screen 0 1600x1200x24"
+      
+      - name: Set Extension Name
+        run: |
+          EXTENSION_NAME=$(node -p 'require("./package.json").name')
+          echo "EXTENSION_NAME=${EXTENSION_NAME}" >> $GITHUB_ENV
+
+      - name: Get stable releases
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+              const { default: checkRelease } = await import('${{ github.workspace }}/.github/scripts/checkRelease.js')
+              await checkRelease({ github, context, core })
+      
+      - name: Create Changelog
+        run: |
+          git log $(git describe --tags --abbrev=0)..HEAD --oneline &> ${{ github.workspace }}-CHANGELOG.txt
+          cat ${{ github.workspace }}-CHANGELOG.txt
+      
+      - name: Setup Git
+        run: |
+          git config --global user.name "stateful-wombot"
+          git config --global user.email "christian+github-bot@stateful.com"
+
+      - name: Get Current Version Number
+        run: |
+          CURRENT_VERSION=$(cat package.json | jq .version | cut -d'"' -f 2)
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+      
+      - name: Compile New Version (Edge)
+        run: |
+          RELEASE_VERSION=$(npx semver $CURRENT_VERSION -i pre${{ github.event.inputs.releaseType }} --preid edge)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "Bump to $RELEASE_VERSION"
+        if: ${{ github.event.inputs.releaseChannel == 'edge' && !contains(env.CURRENT_VERSION, 'edge') }}
+      
+      - name: Compile New Version (Edge)
+        run: |
+          RELEASE_VERSION=$(npx semver $CURRENT_VERSION -i prerelease)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "Bump to $RELEASE_VERSION"
+        if: ${{ github.event.inputs.releaseChannel == 'edge' && contains(env.CURRENT_VERSION, 'edge') }}
+      
+      - name: Compile New Version (Stable)
+        run: |
+          RELEASE_VERSION=$(npx semver $CURRENT_VERSION -i github.event.inputs.releaseType)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "Bump to $RELEASE_VERSION"
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+
+      - name: Tag Check
+        id: tag_check
+        run: |
+          GET_API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/git/ref/tags/v${RELEASE_VERSION}"
+          http_status_code=$(curl -LI $GET_API_URL -o /dev/null -w '%{http_code}\n' -s \
+            -H "Authorization: token ${GITHUB_TOKEN}")
+          if [ "$http_status_code" -ne "404" ] ; then
+            echo "exists_tag=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists_tag=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Version Package
+        if: steps.tag_check.outputs.exists_tag == 'false'
+        run: |
+          npm version $RELEASE_VERSION
+          git tag -a $RELEASE_VERSION -m "$RELEASE_VERSION"
+      
+      # Update Edge version
+      - name: Update edge version
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: node .github/scripts/updateEdgeVersion.js
+
+      # Linux X86
+      - name: Package Extension Linux x86_64 (Edge)
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: npx vsce package -t linux-x64 --pre-release --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-linux-x64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_LINUX_x86_64 }}
+          TYPE: 'tar'
+      
+      - name: Package Extension Linux x86_64 (Stable)
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+        run: npx vsce package $RELEASE_VERSION -t linux-x64 --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-linux-x64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_LINUX_x86_64 }}
+          TYPE: 'tar'
+      
+      # Linux arm64
+      - name: Package Linux arm64 (Edge)
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: npx vsce package -t linux-arm64 --pre-release --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-linux-arm64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_LINUX_arm64 }}
+          TYPE: 'tar'
+
+      - name: Package Linux arm64 (Stable)
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+        run: npx vsce package $RELEASE_VERSION -t linux-arm64 --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-linux-arm64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_LINUX_arm64 }}
+          TYPE: 'tar'
+
+      # MacOS x86_64      
+      - name: Package MacOS x86_64 (Edge)
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: npx vsce package -t darwin-x64 --pre-release --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-darwin-x64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_MACOS_x86_64 }}
+          TYPE: 'tar'
+      
+      - name: Package MacOS x86_64 (Stable)
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+        run: npx vsce package $RELEASE_VERSION -t darwin-x64 --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-darwin-x64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_MACOS_x86_64 }}
+          TYPE: 'tar'
+      
+      # MacOS arm64 
+      - name: Package MacOS arm64 (Edge)
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: npx vsce package -t darwin-arm64 --pre-release --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-darwin-arm64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_MACOS_arm64 }}
+          TYPE: 'tar'
+
+      - name: Package MacOS arm64 (Stable)
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+        run: npx vsce package $RELEASE_VERSION -t darwin-arm64 --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-darwin-arm64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_MACOS_arm64 }}
+          TYPE: 'tar'
+
+      # Windows x64
+      - name: Package Windows x64 (Edge)
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: npx vsce package -t win32-x64 --pre-release --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-win32-x64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_WINDOWS_x86_64 }}
+          TYPE: 'zip'
+      
+      - name: Package Windows x64 (Stable)
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+        run: npx vsce package $RELEASE_VERSION -t win32-x64 --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-win32-x64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_WINDOWS_x86_64 }}
+          TYPE: 'zip'
+      
+      # Windows arm64
+      - name: Package Windows arm64 (Edge)
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: npx vsce package -t win32-arm64 --pre-release --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-win32-arm64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_WINDOWS_arm64 }}
+          TYPE: 'zip'
+
+      - name: Package Windows arm64 (Stable)
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+        run: npx vsce package $RELEASE_VERSION -t win32-arm64 --no-yarn --no-git-tag-version --no-update-package-json -o "./${{ env.EXTENSION_NAME }}-win32-arm64-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        env:
+          DOWNLOAD_URL: ${{ env.DOWNLOAD_URL_WINDOWS_arm64 }}
+          TYPE: 'zip'
+
+      # Distribute
+
+      # Visual Studio Marketplace
+
+      # Linux X86
+      - name: Publish to Visual Studio Marketplace Linux X86 (Edge)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-linux-x64-$RELEASE_VERSION.vsix" --pre-release --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+      
+      - name: Publish to Visual Studio Marketplace Linux X86 (Stable)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-linux-x64-$RELEASE_VERSION.vsix" --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+      
+      # Linux arm64
+      - name: Publish to Visual Studio Marketplace Linux arm64 (Edge)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-linux-arm64-$RELEASE_VERSION.vsix" --pre-release --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+      
+      - name: Publish to Visual Studio Marketplace Linux arm64 (Stable)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-linux-arm64-$RELEASE_VERSION.vsix" --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+      
+
+      # MacOS x86_64
+      - name: Publish to Visual Studio Marketplace MacOS x86_64 (Edge)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-darwin-x64-$RELEASE_VERSION.vsix" --pre-release --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+      
+      - name: Publish to Visual Studio Marketplace MacOS x86_64 (Stable)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-darwin-x64-$RELEASE_VERSION.vsix" --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+    
+
+      # MacOS arm64
+      - name: Publish to Visual Studio Marketplace MacOS arm64 (Edge)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-darwin-arm64-$RELEASE_VERSION.vsix" --pre-release --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+      
+      - name: Publish to Visual Studio Marketplace MacOS arm64 (Stable)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-darwin-arm64-$RELEASE_VERSION.vsix" --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+    
+
+      # Windows x64
+      - name: Publish to Visual Studio Marketplace Windows x64 (Edge)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-win32-x64-$RELEASE_VERSION.vsix" --pre-release --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+      
+      - name: Publish to Visual Studio Marketplace MacOS x64 (Stable)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-win32-x64-$RELEASE_VERSION.vsix" --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+
+      # Windows arm64
+      - name: Publish to Visual Studio Marketplace Windows arm64 (Edge)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-win32-arm64-$RELEASE_VERSION.vsix" --pre-release --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+      
+      - name: Publish to Visual Studio Marketplace Windows arm64 (Stable)
+        run: npx vsce publish --packagePath "./$EXTENSION_NAME-win32-arm64-$RELEASE_VERSION.vsix" --no-yarn --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+    
+
+      # VSX Registry
+
+      # Linux X86
+      - name: Publish to Open VSX Registry Linux X86 (Edge)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+        with:
+          preRelease: true
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-linux-x64-${{ env.RELEASE_VERSION }}.vsix
+
+      - name: Publish to Open VSX Registry Linux X86 (Stable)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+        with:
+          preRelease: false
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-linux-x64-${{ env.RELEASE_VERSION }}.vsix
+      # Linux arm64
+      - name: Publish to Open VSX Registry Linux arm64 (Edge)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+        with:
+          preRelease: true
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-linux-arm64-${{ env.RELEASE_VERSION }}.vsix
+
+      - name: Publish to Open VSX Registry Linux arm64 (Stable)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+        with:
+          preRelease: false
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-linux-arm64-${{ env.RELEASE_VERSION }}.vsix
+      # MacOS x86_64
+      - name: Publish to Open VSX Registry MacOS x86_64 (Edge)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+        with:
+          preRelease: true
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-darwin-x64-${{ env.RELEASE_VERSION }}.vsix
+
+      - name: Publish to Open VSX Registry MacOS x86_64 (Stable)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+        with:
+          preRelease: false
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-darwin-x64-${{ env.RELEASE_VERSION }}.vsix
+      # MacOS arm64
+      - name: Publish to Open VSX Registry MacOS arm64 (Edge)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+        with:
+          preRelease: true
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-darwin-arm64-${{ env.RELEASE_VERSION }}.vsix
+
+      - name: Publish to Open VSX Registry MacOS arm64 (Stable)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+        with:
+          preRelease: false
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-darwin-arm64-${{ env.RELEASE_VERSION }}.vsix
+      # Windows x64
+      - name: Publish to Open VSX Registry Windows x64 (Edge)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+        with:
+          preRelease: true
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-win32-x64-${{ env.RELEASE_VERSION }}.vsix
+
+      - name: Publish to Open VSX Registry Windows x64 (Stable)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+        with:
+          preRelease: false
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-win32-x64-${{ env.RELEASE_VERSION }}.vsix
+      # Windows arm64
+      - name: Publish to Open VSX Registry Windows arm64 (Edge)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+        with:
+          preRelease: true
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-win32-arm64-${{ env.RELEASE_VERSION }}.vsix
+
+      - name: Publish to Open VSX Registry Windows arm64 (Stable)
+        uses: HaaLeo/publish-vscode-extension@v1
+        timeout-minutes: 20
+        continue-on-error: true
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+        with:
+          preRelease: false
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./${{ env.EXTENSION_NAME }}-win32-arm64-${{ env.RELEASE_VERSION }}.vsix
+
+      # Release
+      - name: Push Tags
+        continue-on-error: true
+        run: |
+          git log -1 --stat
+          git push origin main --tags
+      - run: |
+          export GIT_TAG=$(git describe --tags --abbrev=0)
+          echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
+
+      - name: GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "./runme-*"
+          bodyFile: ${{ github.workspace }}-CHANGELOG.txt
+          tag: ${{ env.GIT_TAG }}
+          prerelease: ${{ github.event.inputs.releaseChannel == 'edge' }}
+      
+      - name: 🐛 Debug Build
+        uses: stateful/vscode-server-action@v1
+        if: failure()
+        with:
+          timeout: "300000"
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "ts-loader": "^9.4.2",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4",
+        "unzipper": "^0.10.11",
         "vitest": "^0.29.1",
         "vscode-uri": "^3.0.7",
         "wdio-vscode-service": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -386,7 +386,9 @@
     "test:lint:fix": "eslint src tests --ext ts --fix",
     "test:unit": "vitest -c ./vitest.conf.ts",
     "test:e2e": "wdio run ./tests/e2e/wdio.conf.ts",
-    "watch": "npm run build:dev -- --watch"
+    "watch": "npm run build:dev -- --watch",
+    "vscode:prepublish": "npm run prepare-binary",
+    "prepare-binary": "node .github/scripts/downloadAndExtract.js -d $DOWNLOAD_URL -f $TYPE -b bin -n runme"
   },
   "devDependencies": {
     "@octokit/rest": "^19.0.7",
@@ -420,6 +422,7 @@
     "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
+    "unzipper": "^0.10.11",
     "vitest": "^0.29.1",
     "vscode-uri": "^3.0.7",
     "wdio-vscode-service": "^5.0.0",


### PR DESCRIPTION
Introducing a new GitHub action for distributing the extension with the new Runme binaries.

Operating System Support Matrix:

- Linux ARM64, X64
- MacOS (Darwin ARM64, X64)
- Windows (win32-X64, win32-arm64)

It supports specific runme versions or use latest as default, non stable and draft releases are **not** supported

<img width="362" alt="Screenshot 2023-02-28 at 12 00 38 PM" src="https://user-images.githubusercontent.com/4001529/221938518-487a3737-afdf-4366-80ec-d41b61f5bf20.png">
