### PR TITLE
Improve path configuration/resolution

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -16,10 +17,35 @@ export const notebooks = {
   }),
 }
 
-export const Uri = {
-  joinPath: vi.fn().mockReturnValue('/foo/bar'),
-  parse: vi.fn((uri: string) => URI.parse(uri)),
-  file: vi.fn().mockReturnValue('')
+
+export class Uri extends URI {
+  // private constructor (private filePath: string) { }
+
+  // static file = vi.fn((filePath: string): Uri => {
+  //   return new Uri(filePath)
+  // })
+
+  // static joinPath = vi.fn((uri: Uri, ...segments: string[]): Uri => {
+  //   return new Uri(path.join(uri.fsPath, ...segments))
+  // })
+
+  // static parse = vi.fn((uri: string) => {
+  //   return URI.parse(uri)
+  // })
+
+  // get fsPath () {
+  //   return path.relative(
+  //     path.join(__dirname, '../'),
+  //     super.fsPath,
+  //   )
+  // }
+
+  static file = vi.fn(super.file)
+  static parse = vi.fn(super.parse)
+
+  static joinPath = vi.fn((uri: Uri, ...paths: string[]) => {
+    return Uri.file(path.join(uri.fsPath, ...paths))
+  })
 }
 
 export const workspace = {

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -19,27 +19,6 @@ export const notebooks = {
 
 
 export class Uri extends URI {
-  // private constructor (private filePath: string) { }
-
-  // static file = vi.fn((filePath: string): Uri => {
-  //   return new Uri(filePath)
-  // })
-
-  // static joinPath = vi.fn((uri: Uri, ...segments: string[]): Uri => {
-  //   return new Uri(path.join(uri.fsPath, ...segments))
-  // })
-
-  // static parse = vi.fn((uri: string) => {
-  //   return URI.parse(uri)
-  // })
-
-  // get fsPath () {
-  //   return path.relative(
-  //     path.join(__dirname, '../'),
-  //     super.fsPath,
-  //   )
-  // }
-
   static file = vi.fn(super.file)
   static parse = vi.fn(super.parse)
 

--- a/package.json
+++ b/package.json
@@ -273,7 +273,6 @@
           "runme.server.binaryPath": {
             "type": "string",
             "scope": "machine",
-            "default": "bin",
             "markdownDescription": "Runme server path to binary. (It requires the GRPC interface enabled)"
           },
           "runme.server.enableLogger": {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -31,7 +31,7 @@ export class RunmeExtension {
     const kernel = new Kernel(context)
     const grpcSerializer = kernel.hasExperimentEnabled('grpcSerializer')
     const grpcServer = kernel.hasExperimentEnabled('grpcServer')
-    const server = new RunmeServer(context.extensionUri.fsPath, {
+    const server = new RunmeServer(context.extensionUri, {
       retryOnFailure: true,
       maxNumberOfIntents: 2,
     })

--- a/src/extension/server/runmeServer.ts
+++ b/src/extension/server/runmeServer.ts
@@ -2,10 +2,10 @@ import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
 import fs from 'node:fs/promises'
 import EventEmitter from 'node:events'
 
-import { Disposable } from 'vscode'
+import { Disposable, Uri } from 'vscode'
 
 import { SERVER_ADDRESS } from '../../constants'
-import { enableServerLogs, getBinaryLocation, getPath, getPortNumber } from '../../utils/configuration'
+import { enableServerLogs, getBinaryPath, getPortNumber } from '../../utils/configuration'
 import { initParserClient } from '../grpc/client'
 import { DeserializeRequest } from '../grpc/serializerTypes'
 
@@ -25,7 +25,7 @@ class RunmeServer implements Disposable {
 
     #runningPort: number
     #process: ChildProcessWithoutNullStreams | undefined
-    #binaryPath: string
+    #binaryPath: Uri
     #retryOnFailure: boolean
     #maxNumberOfIntents: number
     #loggingEnabled: boolean
@@ -35,10 +35,10 @@ class RunmeServer implements Disposable {
     #acceptsInterval: number
     events: EventEmitter
 
-    constructor(extBasePath: string, options: IServerConfig) {
+    constructor(extBasePath: Uri, options: IServerConfig) {
         this.#runningPort = getPortNumber()
         this.#loggingEnabled = enableServerLogs()
-        this.#binaryPath = getPath(extBasePath)
+        this.#binaryPath = getBinaryPath(extBasePath, process.platform)
         this.#retryOnFailure = options.retryOnFailure || false
         this.#maxNumberOfIntents = options.maxNumberOfIntents
         this.#intent = 0
@@ -76,7 +76,7 @@ class RunmeServer implements Disposable {
           return this.#address
         }
 
-        const binaryLocation = getBinaryLocation(this.#binaryPath, process.platform)
+        const binaryLocation = this.#binaryPath.fsPath
 
         const binaryExists = await fs.access(binaryLocation)
             .then(() => true, () => false)

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -15,9 +15,7 @@ const configurationSchema = {
             .default(7863),
         binaryPath: z
             .string()
-            .transform((schema) => {
-                return schema || 'bin'
-            }),
+            .optional(),
         enableLogger: z
             .boolean()
             .default(false)
@@ -63,5 +61,6 @@ const enableServerLogs = (): boolean => {
 export {
     getPortNumber,
     getBinaryPath,
-    enableServerLogs
+    enableServerLogs,
+    getServerConfigurationValue
 }

--- a/tests/extension/__snapshots__/utils.test.ts.snap
+++ b/tests/extension/__snapshots__/utils.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Vitest Snapshot v1
 
 exports[`getCmdShellSeq > complex wrapped 1`] = `"set -e -o pipefail; curl \\"https://api-us-west-2.graphcms.com/v2/cksds5im94b3w01xq4hfka1r4/master?query=$(deno run -A query.ts)\\" --compressed 2>/dev/null | jq -r '.[].posts[] | \\"(.title) - by (.authors[0].name), id: (.id)\\"'"`;
 

--- a/tests/extension/__snapshots__/utils.test.ts.snap
+++ b/tests/extension/__snapshots__/utils.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`getCmdShellSeq > complex wrapped 1`] = `"set -e -o pipefail; curl \\"https://api-us-west-2.graphcms.com/v2/cksds5im94b3w01xq4hfka1r4/master?query=$(deno run -A query.ts)\\" --compressed 2>/dev/null | jq -r '.[].posts[] | \\"(.title) - by (.authors[0].name), id: (.id)\\"'"`;
 

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -3,7 +3,12 @@ import path from 'node:path'
 import { suite, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Uri, workspace } from 'vscode'
 
-import { getPortNumber, enableServerLogs, getBinaryPath } from '../../src/utils/configuration'
+import {
+  getPortNumber,
+  enableServerLogs,
+  getBinaryPath,
+  getServerConfigurationValue
+} from '../../src/utils/configuration'
 
 const FAKE_UNIX_EXT_PATH = '/Users/user/.vscode/extension/stateful.runme'
 const FAKE_WIN_EXT_PATH = 'C:\\Users\\.vscode\\extensions\\stateful.runme'
@@ -89,6 +94,22 @@ suite('Configuration', () => {
         SETTINGS_MOCK.enableLogger = 'true'
         const path = enableServerLogs()
         expect(path).toBeFalsy()
+    })
+
+    test('getServerConfigurationValue Should default to undefined binaryPath', () => {
+      SETTINGS_MOCK.binaryPath = undefined
+
+      expect(
+        getServerConfigurationValue<string | undefined>('binaryPath', undefined)
+      ).toStrictEqual(undefined)
+    })
+
+    test('getServerConfigurationValue Should give proper binaryPath if defined', () => {
+      SETTINGS_MOCK.binaryPath = '/binary/path'
+
+      expect(
+        getServerConfigurationValue<string | undefined>('binaryPath', undefined)
+      ).toStrictEqual('/binary/path')
     })
 
     suite('posix', () => {

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -32,12 +32,6 @@ beforeEach(() => {
         }),
       },
       Uri: mocked.Uri,
-      // Uri: {
-      //     joinPath: vi.fn().mockImplementation((uri: any, fragment: string) => {
-      //         return URI.parse(`${uri.fsPath}/${fragment}`)
-      //     }),
-      //     parse: vi.fn((uri: string) => URI.parse(uri)),
-      // }
     })
   })
 

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, vi } from 'vitest'
-import { notebooks, workspace, commands, window } from 'vscode'
+import { notebooks, workspace, commands, window, Uri } from 'vscode'
 
 import { RunmeExtension } from '../../src/extension/extension'
 
@@ -20,6 +20,7 @@ test('initializes all providers', async () => {
   vi.mocked(workspace.getConfiguration).mockReturnValue({
     get: vi.fn((config: string) => configValues[config])
   } as any)
+  vi.mocked(Uri.joinPath).mockReturnValue('/foo/bar' as any)
   const context: any = { subscriptions: [], extensionUri: { fsPath: '/foo/bar' } }
   const ext = new RunmeExtension()
   await ext.initialize(context)

--- a/tests/extension/provider/launcher.test.ts
+++ b/tests/extension/provider/launcher.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
-import { commands } from 'vscode'
+import { commands, Uri } from 'vscode'
 
 import { RunmeFile, RunmeLauncherProvider } from '../../../src/extension/provider/launcher'
 import { getDefaultWorkspace } from '../../../src/extension/utils'
@@ -64,9 +64,11 @@ describe('Runme Notebooks', () => {
     })
 
     it('should open a file using runme renderer', () => {
+      vi.mocked(Uri.file).mockImplementation((p) => p as any)
+
       RunmeLauncherProvider.openFile({ file: 'README.md', folderPath: 'runme/workspace/src' })
       expect(commands.executeCommand).toBeCalledTimes(1)
-      expect(commands.executeCommand).toBeCalledWith('vscode.openWith', expect.any(String), 'runme')
+      expect(commands.executeCommand).toBeCalledWith('vscode.openWith', 'runme/workspace/src/README.md', 'runme')
     })
   })
 

--- a/tests/extension/server/runmeServer.test.ts
+++ b/tests/extension/server/runmeServer.test.ts
@@ -1,5 +1,5 @@
 import { suite, test, expect, vi, beforeEach } from 'vitest'
-import { workspace } from 'vscode'
+import { Uri, workspace } from 'vscode'
 
 vi.mock('vscode')
 vi.mock('../../../src/extension/grpc/client', () => ({ initParserClient: vi.fn() }))
@@ -28,7 +28,7 @@ suite('Runme server spawn process', () => {
 
     test('Should try 2 times before failing', async () => {
         const server = new Server(
-          '/Users/user/.vscode/extension/stateful.runme',
+          Uri.file('/Users/user/.vscode/extension/stateful.runme'),
           {
             retryOnFailure: true,
             maxNumberOfIntents: 2,
@@ -44,7 +44,7 @@ suite('Runme server accept connections', () => {
     let server: Server
     beforeEach(() => {
         server = new Server(
-          '/Users/user/.vscode/extension/stateful.runme',
+          Uri.file('/Users/user/.vscode/extension/stateful.runme'),
           {
             retryOnFailure: false,
             maxNumberOfIntents: 2,


### PR DESCRIPTION
Implements the feedback I gave in #245 .

In summary:

 - Binary path configuration now points to the binary itself, rather than the enclosing folder
 - There is one singular function for finding the binary path, `getBinaryPath`
 - The extension root Uri is passed down as a Uri, rather than as a string (avoids unnecessary (re)-parsing)
 - Relative binary paths now act relative to the current workspace folder, rather than relative to extension folder