### PR TITLE
Better handle kernel selection error

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -93,7 +93,8 @@ export const tasks = {
 
 export const commands = {
   registerCommand: vi.fn(),
-  executeCommand: vi.fn()
+  executeCommand: vi.fn(),
+  getCommands: vi.fn().mockResolvedValue(['_notebook.selectKernel'])
 }
 
 export enum ViewColumn {

--- a/src/extension/provider/annotations.ts
+++ b/src/extension/provider/annotations.ts
@@ -1,4 +1,5 @@
 import {
+  commands,
   window,
   NotebookCell,
   NotebookCellOutput,
@@ -52,6 +53,10 @@ export class AnnotationsProvider implements NotebookCellStatusBarItemProvider {
         ]),
       ])
     } catch (e: any) {
+      if (e.message.toString().includes('controller is NOT associated')) {
+        commands.executeCommand('_notebook.selectKernel')
+        return
+      }
       window.showErrorMessage(e.message)
     } finally {
       exec?.end(true)


### PR DESCRIPTION
Prompt users to select a notebook kernel instead of the raw error message.

![image](https://user-images.githubusercontent.com/250527/222924320-0beaae40-0a53-4d78-806b-fdc1f64f7416.png)
