### PR TITLE
Auto-Restart server on `onClose`

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 
 import { vi } from 'vitest'
 import { URI } from 'vscode-uri'
+import type { Disposable } from 'vscode'
+
 
 export const notebooks = {
   createNotebookController: vi.fn().mockReturnValue({
@@ -116,7 +118,6 @@ export enum NotebookCellKind {
 }
 
 export const TreeItem = vi.fn()
-export class EventEmitter {}
 export const Event = vi.fn()
 
 export enum TreeItemCollapsibleState {
@@ -192,4 +193,27 @@ export class NotebookCellOutput {
 
 export const ProgressLocation = {
   Window: 1
+}
+
+type MessageCallback<T> = (message: T) => void
+type Event<T> = (listener: MessageCallback<T>) => Disposable
+
+export class EventEmitter<T> {
+  listeners: MessageCallback<T>[] = []
+
+  event: Event<T> = (listener) => {
+    this.listeners.push(listener)
+
+    return {
+      dispose: () => {
+        this.listeners = this.listeners.filter(x => x !== listener)
+      }
+    }
+  }
+
+  fire(data: T) {
+    this.listeners.forEach(l => l(data))
+  }
+
+  dispose() { }
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -31,12 +31,13 @@ export class RunmeExtension {
     const kernel = new Kernel(context)
     const grpcSerializer = kernel.hasExperimentEnabled('grpcSerializer')
     const grpcServer = kernel.hasExperimentEnabled('grpcServer')
+    const grpcRunner = kernel.hasExperimentEnabled('grpcRunner')
     const server = new RunmeServer(context.extensionUri, {
       retryOnFailure: true,
       maxNumberOfIntents: 2,
-    }, !grpcServer)
+    }, !grpcServer, grpcRunner)
+    grpcRunner && kernel.useRunner(new GrpcRunner(server))
     const serializer = grpcSerializer ? new GrpcSerializer(context, server) : new WasmSerializer(context)
-    kernel.hasExperimentEnabled('grpcRunner') && kernel.useRunner(new GrpcRunner(server))
 
     /**
      * Start the Runme server

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -34,19 +34,15 @@ export class RunmeExtension {
     const server = new RunmeServer(context.extensionUri, {
       retryOnFailure: true,
       maxNumberOfIntents: 2,
-    })
+    }, !grpcServer)
+    const serializer = grpcSerializer ? new GrpcSerializer(context, server) : new WasmSerializer(context)
+    kernel.hasExperimentEnabled('grpcRunner') && kernel.useRunner(new GrpcRunner(server))
+
     /**
      * Start the Runme server
      */
-
     try {
-      if (grpcServer) {
-        await server.launch()
-        server.events.on('closed', () => {
-          window.showErrorMessage(`Runme server is not longer running,
-          please reload the window to start the server again`)
-        })
-      }
+      await server.launch()
     } catch (e) {
       // Unrecoverable error happened
       if (e instanceof RunmeServerError) {
@@ -57,10 +53,8 @@ export class RunmeExtension {
       return window.showErrorMessage('Failed to start Runme server, please try to reload the window')
     }
 
-    const serializer = grpcSerializer ? new GrpcSerializer(context) : new WasmSerializer(context)
     const treeViewer = new RunmeLauncherProvider(getDefaultWorkspace())
     const uriHandler = new RunmeUriHandler(context)
-    kernel.hasExperimentEnabled('grpcRunner') && kernel.useRunner(new GrpcRunner())
 
     context.subscriptions.push(
       kernel,

--- a/src/extension/grpc/client.ts
+++ b/src/extension/grpc/client.ts
@@ -2,17 +2,9 @@
 import { ParserServiceClient } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/parser/v1/parser_pb.client'
 // eslint-disable-next-line max-len
 import { RunnerServiceClient } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/runner/v1/runner_pb.client'
-import { ChannelCredentials } from '@grpc/grpc-js'
 import { GrpcTransport } from '@protobuf-ts/grpc-transport'
 
-import { getGrpcHost } from '../utils'
-
-function initParserClient(): ParserServiceClient {
-  const transport = new GrpcTransport({
-    host: getGrpcHost(),
-    channelCredentials: ChannelCredentials.createInsecure(),
-  })
-
+function initParserClient(transport: GrpcTransport): ParserServiceClient {
   return new ParserServiceClient(transport)
 }
 

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -197,6 +197,8 @@ export class GrpcRunner implements IRunner {
   async getEnvironmentVariables(
     environment: IRunnerEnvironment,
   ): Promise<Record<string, string> | undefined> {
+    GrpcRunner.assertClient(this.client)
+
     if(!(environment instanceof GrpcRunnerEnvironment)) {
       throw new Error('Invalid environment!')
     }

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -156,7 +156,7 @@ export class GrpcRunner implements IRunner {
     return session
   }
 
-  createEnvironment(
+  async createEnvironment(
     envs?: string[],
     metadata?: { [index: string]: string }
   ) {

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -299,13 +299,13 @@ export class GrpcSerializer extends SerializerBase {
     super(context)
 
     this.ready = new Promise((resolve) => {
-      this.serverReadyListener = server.onTransportReady(({ transport }) => {
-        this.initParserClient(transport)
+      const disposable = server.onTransportReady(() => {
+        disposable.dispose()
         resolve()
       })
     })
 
-    // this.serverReadyListener = server.onTransportReady(({ transport }) => this.initParserClient(transport))
+    this.serverReadyListener = server.onTransportReady(({ transport }) => this.initParserClient(transport))
   }
 
   private initParserClient(transport?: GrpcTransport) {

--- a/src/extension/server/runmeServer.ts
+++ b/src/extension/server/runmeServer.ts
@@ -113,7 +113,7 @@ class RunmeServer implements Disposable {
       return this.#transport
     }
 
-    async start(): Promise<string | RunmeServerError> {
+    async start(): Promise<string> {
         const binaryLocation = this.#binaryPath.fsPath
 
         const binaryExists = await fs.access(binaryLocation)
@@ -224,7 +224,7 @@ class RunmeServer implements Disposable {
      *
      * @returns Address of server or error
      */
-    async launch(): Promise<string | RunmeServerError> {
+    async launch(): Promise<string> {
       if (this.externalServer) {
         await this.connect()
         return this.address()

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -6,10 +6,23 @@ import { RunmeExtension } from '../../src/extension/extension'
 vi.mock('vscode')
 vi.mock('vscode-telemetry')
 
-vi.mock('../../src/extension/grpc/client', () => ({
-  ParserServiceClient: vi.fn(),
-  RunnerServiceClient: vi.fn(),
-}))
+vi.mock('../../src/extension/grpc/client', () => {
+  class MockedParserServiceClient {
+    deserialize = vi.fn(() => {
+      return { status: { code: 'OK' } }
+    })
+  }
+
+  return ({
+    ParserServiceClient: MockedParserServiceClient,
+    RunnerServiceClient: vi.fn(),
+    initParserClient: vi.fn(() => ({
+      deserialize: vi.fn(() => {
+        return { status: { code: 'OK' } }
+      })
+    })),
+  })
+})
 
 vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
 

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -132,6 +132,11 @@ suite('grpc Runner', () => {
     await expect(runner.createProgramSession({ programName: 'sh' })).rejects.toThrowError('Client is not active!')
   })
 
+  test('cannot get environment variables not initialized', async () => {
+    const { runner } = createGrpcRunner(false)
+    await expect(runner.getEnvironmentVariables({} as any)).rejects.toThrowError('Client is not active!')
+  })
+
   test('cannot create environment if server closed', async () => {
     const { runner, server } = createGrpcRunner(true)
 
@@ -144,6 +149,13 @@ suite('grpc Runner', () => {
 
     server._onClose.fire({ code: null })
     await expect(runner.createProgramSession({ programName: 'sh' })).rejects.toThrowError('Client is not active!')
+  })
+
+  test('cannot get environment variables if server closed', async () => {
+    const { runner, server } = createGrpcRunner(true)
+
+    server._onClose.fire({ code: null })
+    await expect(runner.getEnvironmentVariables({} as any)).rejects.toThrowError('Client is not active!')
   })
 
   suite('grpc program session', () => {

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -18,7 +18,6 @@ vi.mock('../../src/extension/utils', () => ({
 
 vi.mock('vscode', async () => ({
   ...await import(path.join(process.cwd(), '__mocks__', 'vscode')) ,
-  // EventEmitter: getEventEmitterClass()
 }))
 
 vi.mock('@protobuf-ts/grpc-transport', () => ({
@@ -40,33 +39,6 @@ const createSession = vi.fn(() => ({
 const deleteSession = vi.fn(async () => ({
 
 }))
-
-// function getEventEmitterClass() {
-//   return class EventEmitter<T> {
-//     listeners: MessageCallback<T>[] = []
-
-//     event: Event<T> = (listener) => {
-//       this.listeners.push(listener)
-
-//       return {
-//         dispose: () => {
-//           this.listeners = this.listeners.filter(x => x !== listener)
-//         }
-//       }
-//     }
-
-//     fire(data: T) {
-//       this.listeners.forEach(l => l(data))
-//     }
-
-//     dispose() { }
-//   }
-// }
-
-// type MessageCallback<T> = (message: T) => void
-// type Event<T> = (listener: MessageCallback<T>) => Disposable
-
-// const EventEmitter = getEventEmitterClass()
 
 class MockedDuplexClientStream {
   constructor() {}
@@ -125,10 +97,6 @@ class MockedRunmeServer {
   onTransportReady = this._onTransportReady.event
   onClose = this._onClose.event
 }
-
-// vi.mock('../../src/extension/server/runmeServer', () => ({
-//   default:
-// }))
 
 suite('grpc Runner', () => {
   test('environment dispose is called on runner dispose', async () => {

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -2,6 +2,8 @@ import path from 'node:path'
 
 import { vi, suite, test, expect } from 'vitest'
 import type { ExecuteResponse } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/runner/v1/runner_pb'
+import { type GrpcTransport } from '@protobuf-ts/grpc-transport'
+import { EventEmitter } from 'vscode'
 
 import {
   GrpcRunner,
@@ -14,9 +16,9 @@ vi.mock('../../src/extension/utils', () => ({
   getGrpcHost: vi.fn().mockReturnValue('127.0.0.1:7863')
 }))
 
-vi.mock('vscode', () => ({
-  ...import(path.join(process.cwd(), '__mocks__', 'vscode')) ,
-  EventEmitter: getEventEmitterClass()
+vi.mock('vscode', async () => ({
+  ...await import(path.join(process.cwd(), '__mocks__', 'vscode')) ,
+  // EventEmitter: getEventEmitterClass()
 }))
 
 vi.mock('@protobuf-ts/grpc-transport', () => ({
@@ -39,28 +41,32 @@ const deleteSession = vi.fn(async () => ({
 
 }))
 
-function getEventEmitterClass() {
-  return class EventEmitter<T> {
-    listeners: MessageCallback<T>[] = []
+// function getEventEmitterClass() {
+//   return class EventEmitter<T> {
+//     listeners: MessageCallback<T>[] = []
 
-    event: Event<T> = (listener) => {
-      this.listeners.push(listener)
+//     event: Event<T> = (listener) => {
+//       this.listeners.push(listener)
 
-      return () => {
-        this.listeners = this.listeners.filter(x => x !== listener)
-      }
-    }
+//       return {
+//         dispose: () => {
+//           this.listeners = this.listeners.filter(x => x !== listener)
+//         }
+//       }
+//     }
 
-    fire(data: T) {
-      this.listeners.forEach(l => l(data))
-    }
-  }
-}
+//     fire(data: T) {
+//       this.listeners.forEach(l => l(data))
+//     }
 
-type MessageCallback<T> = (message: T) => void
-type Event<T> = (listener: MessageCallback<T>) => (() => void)
+//     dispose() { }
+//   }
+// }
 
-const EventEmitter = getEventEmitterClass()
+// type MessageCallback<T> = (message: T) => void
+// type Event<T> = (listener: MessageCallback<T>) => Disposable
+
+// const EventEmitter = getEventEmitterClass()
 
 class MockedDuplexClientStream {
   constructor() {}
@@ -112,12 +118,24 @@ vi.mock('@buf/stateful_runme.community_timostamm-protobuf-ts/runme/runner/v1/run
   }
 }))
 
+class MockedRunmeServer {
+  _onTransportReady = new EventEmitter<{ transport: GrpcTransport }>()
+  _onClose = new EventEmitter<{ code: number|null }>()
+
+  onTransportReady = this._onTransportReady.event
+  onClose = this._onClose.event
+}
+
+// vi.mock('../../src/extension/server/runmeServer', () => ({
+//   default:
+// }))
+
 suite('grpc Runner', () => {
   test('environment dispose is called on runner dispose', async () => {
     resetId()
     deleteSession.mockClear()
 
-    const runner = new GrpcRunner()
+    const { runner } = createGrpcRunner()
     const environment = (await runner.createEnvironment()) as GrpcRunnerEnvironment
 
     const oldEnvDispose = environment.dispose
@@ -233,8 +251,21 @@ function getMockedDuplex(session: GrpcRunnerProgramSession): MockedDuplexClientS
   return session['session'] as unknown as MockedDuplexClientStream
 }
 
-async function createNewSession(options: Partial<RunProgramOptions> = {}, runner?: GrpcRunner) {
-  runner ??= new GrpcRunner()
+function createGrpcRunner(initialize = true) {
+  const server = new MockedRunmeServer()
+  const runner = new GrpcRunner(server as any)
+
+  if (initialize) {
+    server._onTransportReady.fire({ transport: {} as any })
+  }
+
+  return { server, runner }
+}
+
+async function createNewSession(options: Partial<RunProgramOptions> = {}, runner?: GrpcRunner, initialize?: boolean) {
+  const { runner: generatedRunner, server } = createGrpcRunner(initialize)
+
+  runner ??= generatedRunner
   const session = (await runner.createProgramSession({
     programName: 'sh',
     ...options
@@ -260,5 +291,6 @@ async function createNewSession(options: Partial<RunProgramOptions> = {}, runner
     closeListener,
     writeListener,
     errListener,
+    server,
   }
 }

--- a/tests/extension/server/runmeServer.test.ts
+++ b/tests/extension/server/runmeServer.test.ts
@@ -43,7 +43,8 @@ suite('Runme server spawn process', () => {
           {
             retryOnFailure: true,
             maxNumberOfIntents: 2,
-          }
+          },
+          false
         )
         const serverLaunchSpy = vi.spyOn(server, 'launch')
         await expect(server.launch()).rejects.toBeInstanceOf(RunmeServerError)
@@ -56,7 +57,8 @@ suite('Runme server spawn process', () => {
         {
           retryOnFailure: true,
           maxNumberOfIntents: 2,
-        }
+        },
+        false
       )
 
       vi.mocked(fs.access).mockResolvedValueOnce()
@@ -84,7 +86,8 @@ suite('Runme server accept connections', () => {
               intents: 4,
               interval: 1,
             }
-          }
+          },
+          false
         )
     })
 


### PR DESCRIPTION
Makes runme server resistant against closing, as long as it is caught by the `onClose` callback.

Might want to think about polling/regular health checks in case something more dubious occurs. (Long-term)

Should be functional, just need to write/fix tests at this point.