### PR TITLE
Support terminal dimensions in gRPC runner

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -137,3 +137,10 @@ def hello():
 ```sh { interactive=false, mimeType=image/png }
 curl https://lever-client-logos.s3.us-west-2.amazonaws.com/a8ff9b1f-f313-4632-b90f-1f7ae7ee807f-1638388150933.png 2>/dev/null
 ```
+
+## Terminal Dimensions
+
+```sh { closeTerminalOnSuccess=false }
+echo Rows: $(tput lines)
+echo Columns: $(tput cols)
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@buf/stateful_runme.community_timostamm-protobuf-ts": "2.8.2-20230217155517-b1ae5526a72e.1",
+        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.8.2-20230307185721-114a366533aa.1",
         "@grpc/grpc-js": "^1.8.4",
         "@protobuf-ts/grpc-transport": "^2.8.2",
         "@protobuf-ts/runtime": "^2.8.2",
@@ -1728,8 +1728,8 @@
       "dev": true
     },
     "node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.8.2-20230217155517-b1ae5526a72e.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/2.8.2-20230217155517-b1ae5526a72e.1/tarball",
+      "version": "2.8.2-20230307185721-114a366533aa.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/2.8.2-20230307185721-114a366533aa.1/tarball",
       "peerDependencies": {
         "@protobuf-ts/runtime": "^2.8.2",
         "@protobuf-ts/runtime-rpc": "^2.8.2"
@@ -24628,8 +24628,8 @@
       "dev": true
     },
     "@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.8.2-20230217155517-b1ae5526a72e.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/2.8.2-20230217155517-b1ae5526a72e.1/tarball",
+      "version": "2.8.2-20230307185721-114a366533aa.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/2.8.2-20230307185721-114a366533aa.1/tarball",
       "requires": {}
     },
     "@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -454,7 +454,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@buf/stateful_runme.community_timostamm-protobuf-ts": "2.8.2-20230217155517-b1ae5526a72e.1",
+    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.8.2-20230307185721-114a366533aa.1",
     "@grpc/grpc-js": "^1.8.4",
     "@protobuf-ts/grpc-transport": "^2.8.2",
     "@protobuf-ts/runtime": "^2.8.2",

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -392,7 +392,7 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
     this.opts.envs ??= []
 
     if(this.opts.tty) {
-      this.opts.envs.push('TERM=xterm')
+      this.opts.envs.push('TERM=xterm-256color')
     } else {
       this.opts.envs.push('TERM=')
     }

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -1,10 +1,11 @@
 import { GrpcTransport } from '@protobuf-ts/grpc-transport'
 import { DuplexStreamingCall } from '@protobuf-ts/runtime-rpc/build/types/duplex-streaming-call'
 import {
-  Pseudoterminal,
-  Event,
+  type Pseudoterminal,
+  type Event,
+  type Disposable,
+  type TerminalDimensions,
   EventEmitter,
-  Disposable,
 } from 'vscode'
 import { RpcError } from '@protobuf-ts/runtime-rpc'
 
@@ -41,6 +42,7 @@ export interface RunProgramOptions {
     RunProgramExecution
   tty?: boolean
   environment?: IRunnerEnvironment
+  terminalDimensions?: TerminalDimensions
 }
 
 export interface IRunner extends Disposable {
@@ -450,13 +452,15 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
     }))
   }
 
-  open(): void {
+  open(initialDimensions?: TerminalDimensions): void {
     // Workaround to force terminal to close if opened after early exit
     // TODO(mxs): find a better solution here
     if(this.hasExited()) {
       this._onDidClose.fire(1)
       return
     }
+
+    this.opts.terminalDimensions = initialDimensions
 
     // in pty, we wait for open to run
     this.run()
@@ -557,3 +561,7 @@ export class GrpcRunnerEnvironment implements IRunnerEnvironment {
     return await this.client.deleteSession({ id: this.getSessionId() })
   }
 }
+
+// function terminalDimensionsToWinsize(terminalDimension: TerminalDimensions) {
+
+// }


### PR DESCRIPTION
Solves #252 

Added a section to `examples/README.md` to test against.