### PR TITLE
Improve gRPC runner error handling

### DIFF
--- a/src/extension/executors/task.ts
+++ b/src/extension/executors/task.ts
@@ -17,10 +17,14 @@ import { sh as inlineSh } from './shell'
 const BACKGROUND_TASK_HIDE_TIMEOUT = 2000
 const LABEL_LIMIT = 15
 
-export function closeTerminalByEnvID (id: string) {
+export function closeTerminalByEnvID (id: string, kill?: boolean) {
   const terminal = window.terminals.find(t => getTerminalRunmeId(t) === id)
   if (terminal) {
-    terminal.hide()
+    if(kill) {
+      terminal.dispose()
+    } else {
+      terminal.hide()
+    }
   }
 }
 

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -267,7 +267,7 @@ export class Kernel implements Disposable {
       this.runner &&
       !(hasPsuedoTerminalExperimentEnabled && terminal)
     ) {
-      const runScript = (execKey: 'sh'|'bash' = 'bash') => executeRunner(
+      const runScript = async (execKey: 'sh'|'bash' = 'bash') => await executeRunner(
         this.context,
         this.runner!,
         exec,
@@ -277,7 +277,8 @@ export class Kernel implements Disposable {
         environmentManager
       )
         .catch((e) => {
-          console.error(e)
+          window.showErrorMessage(`Internal failure executing runner: ${e.message}`)
+          console.error('Internal failure executing runner', e.message)
           return false
         })
 
@@ -323,17 +324,22 @@ export class Kernel implements Disposable {
     if(this.#experiments.get('grpcRunner') && runner) {
       this.runner = runner
 
-      this.runnerReadyListener = runner.onReady(() => {
+      this.runnerReadyListener = runner.onReady(async () => {
         this.environment = undefined
 
-        runner.createEnvironment(
-          // copy env from process naively for now
-          // later we might want a more sophisticated approach/to bring this serverside
-          Object.entries(process.env).map(([k, v]) => `${k}=${v || ''}`)
-        ).then(env => {
+        try {
+          const env = await runner.createEnvironment(
+            // copy env from process naively for now
+            // later we might want a more sophisticated approach/to bring this serverside
+            Object.entries(process.env).map(([k, v]) => `${k}=${v || ''}`)
+          )
+
           if(this.runner !== runner) { return }
           this.environment = env
-        })
+        } catch(e: any) {
+          window.showErrorMessage(`[Runme] Failed to create environment for gRPC Runner: ${e.message}`)
+          console.error('Failed to create gRPC Runner environment', e)
+        }
       })
     }
   }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -337,8 +337,8 @@ export class Kernel implements Disposable {
           if(this.runner !== runner) { return }
           this.environment = env
         } catch(e: any) {
-          window.showErrorMessage(`[Runme] Failed to create environment for gRPC Runner: ${e.message}`)
-          console.error('Failed to create gRPC Runner environment', e)
+          window.showErrorMessage(`Failed to create environment for gRPC Runner: ${e.message}`)
+          console.error('[Runme] Failed to create gRPC Runner environment', e)
         }
       })
     }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -278,7 +278,7 @@ export class Kernel implements Disposable {
       )
         .catch((e) => {
           window.showErrorMessage(`Internal failure executing runner: ${e.message}`)
-          console.error('Internal failure executing runner', e.message)
+          console.error('[Runme] Internal failure executing runner', e.message)
           return false
         })
 


### PR DESCRIPTION
Significantly improves the error handling situation for gRPC runner. Included is:

 - Handle case where server is disconnected prematurely and close terminal (previously terminal task would hang)
 - If grpc runner fails, show error message to user
 - If grpc environment creation fails, show error message to user