### PR TITLE
Use gRPC health check for runme server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1730,6 +1730,91 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@buf/cncf_xds.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20230106150209-c313df85559e.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cncf_xds.community_timostamm-protobuf-ts/2.8.2-20230106150209-c313df85559e.1/tarball",
+      "dependencies": {
+        "@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts": "2.8.2-20221025150516-6607b10f00ed.1",
+        "@buf/googleapis_googleapis.community_timostamm-protobuf-ts": "2.8.2-20221214150216-75b4300737fb.1"
+      },
+      "peerDependencies": {
+        "@protobuf-ts/runtime": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
+      }
+    },
+    "node_modules/@buf/envoyproxy_envoy.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20230310150312-30eb1ed13cd9.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/envoyproxy_envoy.community_timostamm-protobuf-ts/2.8.2-20230310150312-30eb1ed13cd9.1/tarball",
+      "dependencies": {
+        "@buf/cncf_xds.community_timostamm-protobuf-ts": "2.8.2-20230106150209-c313df85559e.1",
+        "@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts": "2.8.2-20221025150516-6607b10f00ed.1",
+        "@buf/googleapis_googleapis.community_timostamm-protobuf-ts": "2.8.2-20221214150216-75b4300737fb.1",
+        "@buf/opencensus_opencensus.community_timostamm-protobuf-ts": "2.8.2-20220922204435-bc2645b08553.1",
+        "@buf/opentelemetry_opentelemetry.community_timostamm-protobuf-ts": "2.8.2-20230127150227-43554dfbbfbd.1",
+        "@buf/prometheus_client-model.community_timostamm-protobuf-ts": "2.8.2-20220112145104-1d56a02d481a.1"
+      },
+      "peerDependencies": {
+        "@protobuf-ts/runtime": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
+      }
+    },
+    "node_modules/@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20221025150516-6607b10f00ed.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts/2.8.2-20221025150516-6607b10f00ed.1/tarball",
+      "peerDependencies": {
+        "@protobuf-ts/runtime": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
+      }
+    },
+    "node_modules/@buf/googleapis_googleapis.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20221214150216-75b4300737fb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.community_timostamm-protobuf-ts/2.8.2-20221214150216-75b4300737fb.1/tarball",
+      "peerDependencies": {
+        "@protobuf-ts/runtime": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
+      }
+    },
+    "node_modules/@buf/grpc_grpc.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20230310150327-f6c75491ea13.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/grpc_grpc.community_timostamm-protobuf-ts/2.8.2-20230310150327-f6c75491ea13.1/tarball",
+      "dependencies": {
+        "@buf/cncf_xds.community_timostamm-protobuf-ts": "2.8.2-20230106150209-c313df85559e.1",
+        "@buf/envoyproxy_envoy.community_timostamm-protobuf-ts": "2.8.2-20230310150312-30eb1ed13cd9.1",
+        "@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts": "2.8.2-20221025150516-6607b10f00ed.1",
+        "@buf/googleapis_googleapis.community_timostamm-protobuf-ts": "2.8.2-20221214150216-75b4300737fb.1",
+        "@buf/opencensus_opencensus.community_timostamm-protobuf-ts": "2.8.2-20220922204435-bc2645b08553.1",
+        "@buf/opentelemetry_opentelemetry.community_timostamm-protobuf-ts": "2.8.2-20230127150227-43554dfbbfbd.1",
+        "@buf/prometheus_client-model.community_timostamm-protobuf-ts": "2.8.2-20220112145104-1d56a02d481a.1"
+      },
+      "peerDependencies": {
+        "@protobuf-ts/runtime": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
+      }
+    },
+    "node_modules/@buf/opencensus_opencensus.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20220922204435-bc2645b08553.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/opencensus_opencensus.community_timostamm-protobuf-ts/2.8.2-20220922204435-bc2645b08553.1/tarball",
+      "peerDependencies": {
+        "@protobuf-ts/runtime": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
+      }
+    },
+    "node_modules/@buf/opentelemetry_opentelemetry.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20230127150227-43554dfbbfbd.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/opentelemetry_opentelemetry.community_timostamm-protobuf-ts/2.8.2-20230127150227-43554dfbbfbd.1/tarball",
+      "peerDependencies": {
+        "@protobuf-ts/runtime": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
+      }
+    },
+    "node_modules/@buf/prometheus_client-model.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20220112145104-1d56a02d481a.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/prometheus_client-model.community_timostamm-protobuf-ts/2.8.2-20220112145104-1d56a02d481a.1/tarball",
+      "peerDependencies": {
+        "@protobuf-ts/runtime": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
+      }
+    },
     "node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts": {
       "version": "2.8.2-20230307185721-114a366533aa.1",
       "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/2.8.2-20230307185721-114a366533aa.1/tarball",
@@ -25452,6 +25537,64 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@buf/cncf_xds.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20230106150209-c313df85559e.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cncf_xds.community_timostamm-protobuf-ts/2.8.2-20230106150209-c313df85559e.1/tarball",
+      "requires": {
+        "@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts": "2.8.2-20221025150516-6607b10f00ed.1",
+        "@buf/googleapis_googleapis.community_timostamm-protobuf-ts": "2.8.2-20221214150216-75b4300737fb.1"
+      }
+    },
+    "@buf/envoyproxy_envoy.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20230310150312-30eb1ed13cd9.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/envoyproxy_envoy.community_timostamm-protobuf-ts/2.8.2-20230310150312-30eb1ed13cd9.1/tarball",
+      "requires": {
+        "@buf/cncf_xds.community_timostamm-protobuf-ts": "2.8.2-20230106150209-c313df85559e.1",
+        "@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts": "2.8.2-20221025150516-6607b10f00ed.1",
+        "@buf/googleapis_googleapis.community_timostamm-protobuf-ts": "2.8.2-20221214150216-75b4300737fb.1",
+        "@buf/opencensus_opencensus.community_timostamm-protobuf-ts": "2.8.2-20220922204435-bc2645b08553.1",
+        "@buf/opentelemetry_opentelemetry.community_timostamm-protobuf-ts": "2.8.2-20230127150227-43554dfbbfbd.1",
+        "@buf/prometheus_client-model.community_timostamm-protobuf-ts": "2.8.2-20220112145104-1d56a02d481a.1"
+      }
+    },
+    "@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20221025150516-6607b10f00ed.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts/2.8.2-20221025150516-6607b10f00ed.1/tarball",
+      "requires": {}
+    },
+    "@buf/googleapis_googleapis.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20221214150216-75b4300737fb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.community_timostamm-protobuf-ts/2.8.2-20221214150216-75b4300737fb.1/tarball",
+      "requires": {}
+    },
+    "@buf/grpc_grpc.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20230310150327-f6c75491ea13.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/grpc_grpc.community_timostamm-protobuf-ts/2.8.2-20230310150327-f6c75491ea13.1/tarball",
+      "requires": {
+        "@buf/cncf_xds.community_timostamm-protobuf-ts": "2.8.2-20230106150209-c313df85559e.1",
+        "@buf/envoyproxy_envoy.community_timostamm-protobuf-ts": "2.8.2-20230310150312-30eb1ed13cd9.1",
+        "@buf/envoyproxy_protoc-gen-validate.community_timostamm-protobuf-ts": "2.8.2-20221025150516-6607b10f00ed.1",
+        "@buf/googleapis_googleapis.community_timostamm-protobuf-ts": "2.8.2-20221214150216-75b4300737fb.1",
+        "@buf/opencensus_opencensus.community_timostamm-protobuf-ts": "2.8.2-20220922204435-bc2645b08553.1",
+        "@buf/opentelemetry_opentelemetry.community_timostamm-protobuf-ts": "2.8.2-20230127150227-43554dfbbfbd.1",
+        "@buf/prometheus_client-model.community_timostamm-protobuf-ts": "2.8.2-20220112145104-1d56a02d481a.1"
+      }
+    },
+    "@buf/opencensus_opencensus.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20220922204435-bc2645b08553.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/opencensus_opencensus.community_timostamm-protobuf-ts/2.8.2-20220922204435-bc2645b08553.1/tarball",
+      "requires": {}
+    },
+    "@buf/opentelemetry_opentelemetry.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20230127150227-43554dfbbfbd.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/opentelemetry_opentelemetry.community_timostamm-protobuf-ts/2.8.2-20230127150227-43554dfbbfbd.1/tarball",
+      "requires": {}
+    },
+    "@buf/prometheus_client-model.community_timostamm-protobuf-ts": {
+      "version": "2.8.2-20220112145104-1d56a02d481a.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/prometheus_client-model.community_timostamm-protobuf-ts/2.8.2-20220112145104-1d56a02d481a.1/tarball",
+      "requires": {}
     },
     "@buf/stateful_runme.community_timostamm-protobuf-ts": {
       "version": "2.8.2-20230307185721-114a366533aa.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2471,6 +2471,7 @@
       "version": "1.8.13",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.13.tgz",
       "integrity": "sha512-iY3jsdfbc0ARoCLFvbvUB8optgyb0r1XLPb142u+QtgBcKJYkCIFt3Fd/881KqjLYWjsBJF57N3b8Eop9NDfUA==",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -5972,6 +5973,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.6.2.tgz",
       "integrity": "sha512-vmvau1rGqyWkmVLOeWtdw7Q1rE12BJDaGp//G9ZOVMEmpTLqjuof+wB9eCXjVvpxyOcl4GWiz7xpTnXUPwoydQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "@wdio/logger": "8.1.0",
         "@wdio/types": "8.4.0",
@@ -5991,6 +5993,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.6.1.tgz",
       "integrity": "sha512-F/ITsHOG6Q1RxZaQuGcuti/noqxWmgkYQmRM8XdqZe0gSy4VdflGfc6TKCnfcn2oV3VPAX2HiORdTZnEGvzH2g==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "@wdio/logger": "8.1.0",
         "@wdio/types": "8.4.0",
@@ -6006,6 +6009,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.0.tgz",
       "integrity": "sha512-EAZejC7JvnQINayvB/7BJbpZpNOJ8Lrw2OZNEvQxe0vaLn1SuwMcfV7/MNaX8L/T0wmptBFI4YMtDvSBxYDc7w==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "minimatch": "^7.4.1",
@@ -6024,6 +6028,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
       "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6039,6 +6044,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
       "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6048,6 +6054,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.6.3.tgz",
       "integrity": "sha512-JnoBsPx4puebxgrkdwYEYYDdYzRXjckDVS/FEhEnU6MbEX2me328VwdEIP0Q74igZaaFoRGdihfXmGgP+pUHkw==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": "^16.13 || >=18"
       },
@@ -6465,13 +6472,15 @@
       "version": "8.5.7",
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.5.7.tgz",
       "integrity": "sha512-ymdXSRqHugEptLdjLnvX7m7TY6cvae1B1yiFJVpaKwj88s4PaCUs7aISexC0ES9s6z8ZWRjZo3mrKPlwZ/IKCw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/@wdio/repl": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.1.0.tgz",
       "integrity": "sha512-96G4TzbYnRf95+GURo15FYt6iTYq85nbWU6YQedLRAV15RfSp4foKTbAnq++bKKMALNL6gdzTc+HGhQr3Q0sQg==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "^18.0.0"
       },
@@ -6773,6 +6782,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.4.0.tgz",
       "integrity": "sha512-1eA0D0jS8Ttg67zB2gsZJFUcHcRz4VRjLTjxdLKh70+ZfB1+YZr9tScLgQjc+qsjsK1wKSzOz03uZiidwNnN9g==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "^18.0.0"
       },
@@ -9730,6 +9740,7 @@
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.3.0.tgz",
       "integrity": "sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12.4.0"
       }
@@ -23060,6 +23071,7 @@
       "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.6.2.tgz",
       "integrity": "sha512-jgnu/hB7O8hrjCZm6zW77QhBEdwteQF+liWvjZcflQXUmS/YLdS/UAfCBQzt1CIUHfbGrlxHshwFm+ywjT9XJw==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "^18.0.0",
         "@types/ws": "^8.5.3",
@@ -23082,6 +23094,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.6.1.tgz",
       "integrity": "sha512-F/ITsHOG6Q1RxZaQuGcuti/noqxWmgkYQmRM8XdqZe0gSy4VdflGfc6TKCnfcn2oV3VPAX2HiORdTZnEGvzH2g==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "@wdio/logger": "8.1.0",
         "@wdio/types": "8.4.0",
@@ -23097,6 +23110,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -26024,6 +26038,7 @@
       "version": "1.8.13",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.13.tgz",
       "integrity": "sha512-iY3jsdfbc0ARoCLFvbvUB8optgyb0r1XLPb142u+QtgBcKJYkCIFt3Fd/881KqjLYWjsBJF57N3b8Eop9NDfUA==",
+      "peer": true,
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -28675,6 +28690,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.6.2.tgz",
       "integrity": "sha512-vmvau1rGqyWkmVLOeWtdw7Q1rE12BJDaGp//G9ZOVMEmpTLqjuof+wB9eCXjVvpxyOcl4GWiz7xpTnXUPwoydQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@wdio/logger": "8.1.0",
         "@wdio/types": "8.4.0",
@@ -28691,6 +28707,7 @@
           "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.6.1.tgz",
           "integrity": "sha512-F/ITsHOG6Q1RxZaQuGcuti/noqxWmgkYQmRM8XdqZe0gSy4VdflGfc6TKCnfcn2oV3VPAX2HiORdTZnEGvzH2g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@wdio/logger": "8.1.0",
             "@wdio/types": "8.4.0",
@@ -28703,6 +28720,7 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.0.tgz",
           "integrity": "sha512-EAZejC7JvnQINayvB/7BJbpZpNOJ8Lrw2OZNEvQxe0vaLn1SuwMcfV7/MNaX8L/T0wmptBFI4YMtDvSBxYDc7w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "minimatch": "^7.4.1",
@@ -28715,6 +28733,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
           "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -28723,7 +28742,8 @@
           "version": "4.2.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
           "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -28732,6 +28752,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.6.3.tgz",
       "integrity": "sha512-JnoBsPx4puebxgrkdwYEYYDdYzRXjckDVS/FEhEnU6MbEX2me328VwdEIP0Q74igZaaFoRGdihfXmGgP+pUHkw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "expect-webdriverio": "^4.0.1",
         "webdriverio": "8.6.3"
@@ -29041,13 +29062,15 @@
       "version": "8.5.7",
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.5.7.tgz",
       "integrity": "sha512-ymdXSRqHugEptLdjLnvX7m7TY6cvae1B1yiFJVpaKwj88s4PaCUs7aISexC0ES9s6z8ZWRjZo3mrKPlwZ/IKCw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@wdio/repl": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.1.0.tgz",
       "integrity": "sha512-96G4TzbYnRf95+GURo15FYt6iTYq85nbWU6YQedLRAV15RfSp4foKTbAnq++bKKMALNL6gdzTc+HGhQr3Q0sQg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/node": "^18.0.0"
       }
@@ -29269,6 +29292,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.4.0.tgz",
       "integrity": "sha512-1eA0D0jS8Ttg67zB2gsZJFUcHcRz4VRjLTjxdLKh70+ZfB1+YZr9tScLgQjc+qsjsK1wKSzOz03uZiidwNnN9g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/node": "^18.0.0"
       }
@@ -31530,7 +31554,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.3.0.tgz",
       "integrity": "sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "defaults": {
       "version": "1.0.4",
@@ -41193,6 +41218,7 @@
       "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.6.2.tgz",
       "integrity": "sha512-jgnu/hB7O8hrjCZm6zW77QhBEdwteQF+liWvjZcflQXUmS/YLdS/UAfCBQzt1CIUHfbGrlxHshwFm+ywjT9XJw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/node": "^18.0.0",
         "@types/ws": "^8.5.3",
@@ -41212,6 +41238,7 @@
           "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.6.1.tgz",
           "integrity": "sha512-F/ITsHOG6Q1RxZaQuGcuti/noqxWmgkYQmRM8XdqZe0gSy4VdflGfc6TKCnfcn2oV3VPAX2HiORdTZnEGvzH2g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@wdio/logger": "8.1.0",
             "@wdio/types": "8.4.0",
@@ -41224,6 +41251,7 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
           "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
           "dev": true,
+          "optional": true,
           "requires": {}
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.8.2-20230310150327-f6c75491ea13.1",
         "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.8.2-20230307185721-114a366533aa.1",
-        "@grpc/grpc-js": "^1.8.4",
         "@protobuf-ts/grpc-transport": "^2.8.2",
         "@protobuf-ts/runtime": "^2.8.2",
         "@protobuf-ts/runtime-rpc": "^2.8.2",
@@ -2483,6 +2483,7 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.5.tgz",
       "integrity": "sha512-mfcTuMbFowq1wh/Rn5KQl6qb95M21Prej3bewD9dUQMurYGVckGO/Pbe2Ocwto6sD05b/mxZLspvqwx60xO2Rg==",
+      "peer": true,
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -2501,6 +2502,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2515,6 +2517,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -2525,6 +2528,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2535,17 +2539,20 @@
     "node_modules/@grpc/proto-loader/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "peer": true
     },
     "node_modules/@grpc/proto-loader/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "peer": true
     },
     "node_modules/@grpc/proto-loader/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2554,6 +2561,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2567,6 +2575,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2583,6 +2592,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -3241,27 +3251,32 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "peer": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "peer": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "peer": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -3270,27 +3285,32 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "peer": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "peer": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "peer": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "peer": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "peer": true
     },
     "node_modules/@remix-run/dev": {
       "name": "@vercel/remix-run-dev",
@@ -4160,7 +4180,8 @@
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "peer": true
     },
     "node_modules/@types/lru-cache": {
       "version": "4.1.1",
@@ -15849,7 +15870,8 @@
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "peer": true
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -18853,6 +18875,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
       "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -18874,7 +18897,8 @@
     "node_modules/protobufjs/node_modules/long": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
+      "peer": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -26009,6 +26033,7 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.5.tgz",
       "integrity": "sha512-mfcTuMbFowq1wh/Rn5KQl6qb95M21Prej3bewD9dUQMurYGVckGO/Pbe2Ocwto6sD05b/mxZLspvqwx60xO2Rg==",
+      "peer": true,
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -26021,6 +26046,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -26029,6 +26055,7 @@
           "version": "7.0.4",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
           "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "peer": true,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
@@ -26039,6 +26066,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "peer": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -26046,22 +26074,26 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "peer": true
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "peer": true
         },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "peer": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -26072,6 +26104,7 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
           "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "peer": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
@@ -26082,6 +26115,7 @@
           "version": "16.2.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
           "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "peer": true,
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",
@@ -26616,27 +26650,32 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "peer": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "peer": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "peer": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "peer": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "peer": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -26645,27 +26684,32 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "peer": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "peer": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "peer": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "peer": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "peer": true
     },
     "@remix-run/dev": {
       "version": "npm:@vercel/remix-run-dev@1.14.2",
@@ -27336,7 +27380,8 @@
     "@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "peer": true
     },
     "@types/lru-cache": {
       "version": "4.1.1",
@@ -36070,7 +36115,8 @@
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "peer": true
     },
     "longest-streak": {
       "version": "3.1.0",
@@ -38181,6 +38227,7 @@
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
       "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
+      "peer": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -38199,7 +38246,8 @@
         "long": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -472,7 +472,7 @@
   },
   "dependencies": {
     "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.8.2-20230307185721-114a366533aa.1",
-    "@grpc/grpc-js": "^1.8.4",
+    "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.8.2-20230310150327-f6c75491ea13.1",
     "@protobuf-ts/grpc-transport": "^2.8.2",
     "@protobuf-ts/runtime": "^2.8.2",
     "@protobuf-ts/runtime-rpc": "^2.8.2",

--- a/src/extension/grpc/client.ts
+++ b/src/extension/grpc/client.ts
@@ -2,10 +2,11 @@
 import { ParserServiceClient } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/parser/v1/parser_pb.client'
 // eslint-disable-next-line max-len
 import { RunnerServiceClient } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/runner/v1/runner_pb.client'
+import { HealthClient } from '@buf/grpc_grpc.community_timostamm-protobuf-ts/grpc/health/v1/health_pb.client'
 import { GrpcTransport } from '@protobuf-ts/grpc-transport'
 
 function initParserClient(transport: GrpcTransport): ParserServiceClient {
   return new ParserServiceClient(transport)
 }
 
-export { ParserServiceClient, RunnerServiceClient, initParserClient }
+export { ParserServiceClient, RunnerServiceClient, initParserClient, HealthClient }

--- a/src/extension/grpc/healthTypes.ts
+++ b/src/extension/grpc/healthTypes.ts
@@ -1,0 +1,1 @@
+export * from '@buf/grpc_grpc.community_timostamm-protobuf-ts/grpc/health/v1/health_pb'

--- a/src/extension/server/runmeServer.ts
+++ b/src/extension/server/runmeServer.ts
@@ -5,11 +5,11 @@ import path from 'node:path'
 import { ChannelCredentials } from '@grpc/grpc-js'
 import { GrpcTransport } from '@protobuf-ts/grpc-transport'
 import { Disposable, Uri, EventEmitter } from 'vscode'
+
 import {
   HealthCheckRequest,
   HealthCheckResponse_ServingStatus
-} from '@buf/grpc_grpc.community_timostamm-protobuf-ts/grpc/health/v1/health_pb'
-
+} from '../grpc/healthTypes'
 import { SERVER_ADDRESS } from '../../constants'
 import { enableServerLogs, getBinaryPath, getPortNumber, getTLSDir, getTLSEnabled } from '../../utils/configuration'
 import { isPortAvailable } from '../utils'

--- a/src/extension/server/runmeServer.ts
+++ b/src/extension/server/runmeServer.ts
@@ -5,12 +5,15 @@ import path from 'node:path'
 import { ChannelCredentials } from '@grpc/grpc-js'
 import { GrpcTransport } from '@protobuf-ts/grpc-transport'
 import { Disposable, Uri, EventEmitter } from 'vscode'
+import {
+  HealthCheckRequest,
+  HealthCheckResponse_ServingStatus
+} from '@buf/grpc_grpc.community_timostamm-protobuf-ts/grpc/health/v1/health_pb'
 
 import { SERVER_ADDRESS } from '../../constants'
 import { enableServerLogs, getBinaryPath, getPortNumber, getTLSDir, getTLSEnabled } from '../../utils/configuration'
-import { initParserClient } from '../grpc/client'
-import { DeserializeRequest } from '../grpc/serializerTypes'
 import { isPortAvailable } from '../utils'
+import { HealthClient } from '../grpc/client'
 
 import RunmeServerError from './runmeServerError'
 
@@ -76,18 +79,22 @@ class RunmeServer implements Disposable {
     }
 
     async isRunning(): Promise<boolean> {
-      const client = initParserClient(await this.transport())
+      const client = new HealthClient(this.transport())
+
       try {
-        const deserialRequest = DeserializeRequest.create({ source: Buffer.from('## Server running', 'utf-8') })
-        const request = client.deserialize(deserialRequest)
-        const status = await request.status
-        return status.code === 'OK'
+        const { response } = await client.check(HealthCheckRequest.create())
+
+        if (response.status === HealthCheckResponse_ServingStatus.SERVING) {
+          return true
+        }
       } catch (err: any) {
         if (err?.code === 'UNAVAILABLE') {
           return false
         }
         throw err
       }
+
+      return false
     }
 
     address() {

--- a/src/extension/server/runmeServer.ts
+++ b/src/extension/server/runmeServer.ts
@@ -79,7 +79,7 @@ class RunmeServer implements Disposable {
     }
 
     async isRunning(): Promise<boolean> {
-      const client = new HealthClient(this.transport())
+      const client = new HealthClient(await this.transport())
 
       try {
         const { response } = await client.check(HealthCheckRequest.create())

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -1,5 +1,8 @@
 import { test, expect, vi } from 'vitest'
 import { notebooks, workspace, commands, window, Uri } from 'vscode'
+import {
+  HealthCheckResponse_ServingStatus
+} from '@buf/grpc_grpc.community_timostamm-protobuf-ts/grpc/health/v1/health_pb'
 
 import { RunmeExtension } from '../../src/extension/extension'
 import RunmeServer from '../../src/extension/server/runmeServer'
@@ -23,6 +26,15 @@ vi.mock('../../src/extension/grpc/client', () => {
         return { status: { code: 'OK' } }
       })
     })),
+    HealthClient: class {
+      async check() {
+        return {
+          response: {
+            status: HealthCheckResponse_ServingStatus.SERVING
+          }
+        }
+      }
+    },
   })
 })
 


### PR DESCRIPTION
Detect whether gRPC server exists using `grpc/grpc` healthcheck rather than using the parser client directly. This is more in line with gRPC standard practice and gives us more options down the line.