### PR TITLE
Disable grpc runner command normalization

### DIFF
--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -57,8 +57,8 @@ export async function executeRunner(
     RUNME_ID
   }
 
-  const commands = await parseCommandSeq(cellText)
-  if (!commands) { return false }
+  const commands = await parseCommandSeq(cellText, (s) => s.split('\n'))
+  if(!commands) { return false }
 
   if (commands.length === 0) {
     commands.push('')

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -7,7 +7,7 @@ import { NotebookCellOutput, NotebookCellExecution, NotebookCellOutputItem, wind
 import { ENV_STORE } from '../constants'
 import { OutputType } from '../../constants'
 import type { CellOutputPayload } from '../../types'
-import { replaceOutput, getCmdSeq } from '../utils'
+import { replaceOutput } from '../utils'
 
 const ENV_VAR_REGEXP = /(\$\w+)/g
 /**
@@ -191,7 +191,8 @@ export function getShellPath(execKey?: string): string|undefined {
  * Returns `undefined` when a user cancels on prompt
  */
 export async function parseCommandSeq(
-  cellText: string
+  cellText: string,
+  parseBlock?: (block: string) => string[]
 ): Promise<string[]|undefined> {
   const exportMatches = getCommandExportExtractMatches(cellText)
 
@@ -243,7 +244,7 @@ export async function parseCommandSeq(
   parsedCommandBlocks.push({ type: 'block', content: cellText.slice(offset) })
 
   return parsedCommandBlocks
-    .flatMap(({ type, content }) => type === 'block' ? getCmdSeq(content) : [content])
+    .flatMap(({ type, content }) => type === 'block' && parseBlock?.(content) || [content])
 }
 
 export function isWindows(): boolean {

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -209,24 +209,24 @@ suite('parseCommandSeq', () => {
   })
 
   test('multiline export', async () => {
-    const exportLine = [
+    const exportLines = [
       'export TEST="I',
       'am',
       'doing',
       'well!"'
-    ].join('\n')
+    ]
 
-    const res = await parseCommandSeq(exportLine)
+    const res = await parseCommandSeq(exportLines.join('\n'))
 
     expect(res).toBeTruthy
-    expect(res).toHaveLength(1)
-    expect(res?.[0]).toBe(exportLine)
+    expect(res).toHaveLength(4)
+    expect(res).toStrictEqual(exportLines)
   })
 
   test('exports between normal command sequences', async () => {
     vi.mocked(window.showInputBox).mockImplementationOnce(async () => 'test value')
 
-    const cmd = [
+    const cmdLines = [
       'echo "Hello!"',
       'echo "Hi!"',
       'export TEST="<placeholder>"',
@@ -237,23 +237,24 @@ suite('parseCommandSeq', () => {
       'multiline',
       'env!"',
       'echo $TEST_MULTILINE'
-    ].join('\n')
+    ]
 
-    const res = await parseCommandSeq(cmd)
+    const res = await parseCommandSeq(cmdLines.join('\n'))
 
     expect(res).toBeTruthy()
     expect(res).toStrictEqual([
       'echo "Hello!"',
       'echo "Hi!"',
       'export TEST="test value"',
+      '',
       'echo $TEST',
-      [
+      ...[
         'export TEST_MULTILINE="This',
         'is',
         'a',
         'multiline',
         'env!"',
-      ].join('\n'),
+      ],
       'echo $TEST_MULTILINE'
     ])
   })

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -5,6 +5,7 @@ import { expect, vi, test, suite, beforeEach } from 'vitest'
 
 import { ENV_STORE } from '../../../src/extension/constants'
 import { retrieveShellCommand, parseCommandSeq } from '../../../src/extension/executors/utils'
+import { getCmdSeq } from '../../../src/extension/utils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
@@ -208,6 +209,16 @@ suite('parseCommandSeq', () => {
     expect(res?.[0]).toBe('export TEST="test value"')
   })
 
+  test('single line export with cancelled prompt', async () => {
+    vi.mocked(window.showInputBox).mockImplementationOnce(async () => undefined)
+
+    const res = await parseCommandSeq([
+      'export TEST="<placeholder>"'
+    ].join('\n'))
+
+    expect(res).toBe(undefined)
+  })
+
   test('multiline export', async () => {
     const exportLines = [
       'export TEST="I',
@@ -247,6 +258,41 @@ suite('parseCommandSeq', () => {
       'echo "Hi!"',
       'export TEST="test value"',
       '',
+      'echo $TEST',
+      ...[
+        'export TEST_MULTILINE="This',
+        'is',
+        'a',
+        'multiline',
+        'env!"',
+      ],
+      'echo $TEST_MULTILINE'
+    ])
+  })
+
+  test('exports between normal command sequences with getCmdSeq', async () => {
+    vi.mocked(window.showInputBox).mockImplementationOnce(async () => 'test value')
+
+    const cmdLines = [
+      'echo "Hello!"',
+      'echo "Hi!"',
+      'export TEST="<placeholder>"',
+      'echo $TEST',
+      'export TEST_MULTILINE="This',
+      'is',
+      'a',
+      'multiline',
+      'env!"',
+      'echo $TEST_MULTILINE'
+    ]
+
+    const res = await parseCommandSeq(cmdLines.join('\n'), getCmdSeq)
+
+    expect(res).toBeTruthy()
+    expect(res).toStrictEqual([
+      'echo "Hello!"',
+      'echo "Hi!"',
+      'export TEST="test value"',
       'echo $TEST',
       ...[
         'export TEST_MULTILINE="This',


### PR DESCRIPTION
Along with stateful/runme#189, this improves the command normalization situation for the gRPC runner.