### PR TITLE
Hard disable grpc runner on windows

### DIFF
--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -1,5 +1,6 @@
 import cp from 'node:child_process'
 import path from 'node:path'
+import os from 'node:os'
 
 import { NotebookCellOutput, NotebookCellExecution, NotebookCellOutputItem, window } from 'vscode'
 
@@ -243,4 +244,8 @@ export async function parseCommandSeq(
 
   return parsedCommandBlocks
     .flatMap(({ type, content }) => type === 'block' ? getCmdSeq(content) : [content])
+}
+
+export function isWindows(): boolean {
+  return os.platform().startsWith('win')
 }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -24,6 +24,7 @@ import { resetEnv, getKey, getAnnotations, hashDocumentUri } from './utils'
 import './wasm/wasm_exec.js'
 import { IRunner, IRunnerEnvironment } from './runner'
 import { executeRunner } from './executors/runner'
+import { isWindows } from './executors/utils'
 
 enum ConfirmationItems {
   Yes = 'Yes',
@@ -284,7 +285,10 @@ export class Kernel implements Disposable {
 
     if(
       this.runner &&
-      !(hasPsuedoTerminalExperimentEnabled && terminal)
+      !(hasPsuedoTerminalExperimentEnabled && terminal) &&
+      // hard disable gRPC runner on windows
+      // TODO(mxs): support windows shells
+      !isWindows()
     ) {
       const runScript = async (execKey: 'sh'|'bash' = 'bash') => await executeRunner(
         this.context,


### PR DESCRIPTION
Windows does not have a `$SHELL` environment variable, so it becomes our responsibility to detect the location of the shell. 

Basically, until #312 is solved, it's probably best to hard disable the gRPC runner on windows, since we don't know where the shell is.