### PR TITLE
fix `getLastStableRelease` for Windows

### DIFF
--- a/.github/scripts/getLastStableRelease.js
+++ b/.github/scripts/getLastStableRelease.js
@@ -12,7 +12,7 @@ const getLastStableRelease = async () => {
     })
     const { tag_name } = await response.json()
     const arch = os.arch()
-    const binary = `${os.platform()}_${arch === 'x64' ? 'x86_64' : arch}.tar.gz`
+    const binary = `${os.platform().replace('win32', 'windows')}_${arch === 'x64' ? 'x86_64' : arch}.tar.gz`
     const downloadUrl = `https://download.stateful.com/runme/${tag_name.replace('v', '')}/runme_${binary}`
     // This console log is important since it's being exported to a ENV VAR
     console.log(downloadUrl)

--- a/.github/scripts/getLastStableRelease.js
+++ b/.github/scripts/getLastStableRelease.js
@@ -12,7 +12,8 @@ const getLastStableRelease = async () => {
     })
     const { tag_name } = await response.json()
     const arch = os.arch()
-    const binary = `${os.platform().replace('win32', 'windows')}_${arch === 'x64' ? 'x86_64' : arch}.tar.gz`
+    const ext = os.platform() === 'win32' ? 'zip' : 'tar.gz'
+    const binary = `${os.platform().replace('win32', 'windows')}_${arch === 'x64' ? 'x86_64' : arch}.${ext}`
     const downloadUrl = `https://download.stateful.com/runme/${tag_name.replace('v', '')}/runme_${binary}`
     // This console log is important since it's being exported to a ENV VAR
     console.log(downloadUrl)


### PR DESCRIPTION
`os.platform()` returns in Windows `win32` while our download directory lists Windows artifacts as e.g. `0.6.5/runme_windows_x86_64.zip`.