### PR TITLE
Integrate CLI button with gRPC runner

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -85,7 +85,10 @@ export class RunmeExtension {
 
       commands.registerCommand('runme.resetEnv', resetEnv),
       RunmeExtension.registerCommand('runme.openTerminal', openTerminal),
-      RunmeExtension.registerCommand('runme.runCliCommand', runCLICommand),
+      RunmeExtension.registerCommand(
+        'runme.runCliCommand',
+        runCLICommand(context.extensionUri, !!grpcRunner, server, kernel)
+      ),
       RunmeExtension.registerCommand('runme.copyCellToClipboard', copyCellToClipboard),
       RunmeExtension.registerCommand('runme.stopBackgroundTask', stopBackgroundTask),
       RunmeExtension.registerCommand('runme.openSplitViewAsMarkdownText', openSplitViewAsMarkdownText),

--- a/src/extension/server/runmeServer.ts
+++ b/src/extension/server/runmeServer.ts
@@ -90,7 +90,7 @@ class RunmeServer implements Disposable {
       }
     }
 
-    protected address() {
+    address() {
       return `${SERVER_ADDRESS}:${this.#port}`
     }
 


### PR DESCRIPTION
This fixes the CLI button for use with the gRPC runner. Needs version of binary including stateful/runme#202 (built from main)

Not sure whether to pass everything as command line parameters, or environment variables. I used environment variables because it looks cleaner (and allows users to easily run other commands in the same session), but a lot is then "hidden" from the user. Thoughts @sourishkrout ?