### PR TITLE
Remove runner incompatible default

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod'
 
-const CELL_RANDOM_NAME = `Cell #${Math.random().toString().slice(2)}`
-
 const cleanAnnotation = (value: string, character: string): string => {
     return value.trim().replaceAll(/[ ]{2,}/g, '').replaceAll(character, '')
 }
@@ -49,7 +47,7 @@ export const AnnotationSchema = {
             typeof value === 'string' ?
                 cleanAnnotation(value, ',') :
                 value,
-        z.string().default(CELL_RANDOM_NAME)),
+        z.string().default('')),
     mimeType: z
         .string()
         .refine((subject) => {

--- a/tests/extension/schema.test.ts
+++ b/tests/extension/schema.test.ts
@@ -2,8 +2,6 @@ import { expect, test, suite } from 'vitest'
 
 import { AnnotationSchema, SafeCellAnnotationsSchema, CellAnnotationsSchema } from '../../src/schema'
 
-const CELL_REGEX = new RegExp('(Cell #)[0-9]+')
-
 suite('AnnotationSchema', () => {
     suite('mimeType', () => {
         test('should fail for an invalid mime-type', () => {
@@ -30,7 +28,9 @@ suite('AnnotationSchema', () => {
         test('it should add a default name when empty', () => {
             const parseResult = AnnotationSchema.name.safeParse(undefined)
             expect(parseResult.success).toBeTruthy()
-            expect(parseResult.success && CELL_REGEX.test(parseResult.data)).toBeTruthy()
+            if (parseResult.success) {
+              expect(parseResult.data).toBe('')
+            }
         })
 
         test('it should fail for null value', () => {
@@ -121,7 +121,7 @@ suite('AnnotationSchema', () => {
                 expect(closeTerminalOnSuccess).toBeTruthy()
                 expect(interactive).toBeFalsy()
                 expect(mimeType).toStrictEqual('text/plain')
-                expect(CELL_REGEX.test(name)).toBeTruthy()
+                expect(name).toBe('')
             }
         })
     })
@@ -153,7 +153,7 @@ suite('AnnotationSchema', () => {
                 expect(closeTerminalOnSuccess).toBeTruthy()
                 expect(interactive).toBeFalsy()
                 expect(mimeType).toStrictEqual('text/plain')
-                expect(CELL_REGEX.test(name)).toBeTruthy()
+                expect(name).toBe('')
             }
         })
     })


### PR DESCRIPTION
We will have fewer edge cases "without default" than introducing them starting their lifecycle in the extension.

There is more work to be done here but it's important to get this fix in for now.