### PR TITLE
Add Runme Welcome Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -353,21 +353,6 @@
             }
           }
         ]
-      },
-      {
-        "id": "runme.welcomePage",
-        "title": "Get Started with creating Runme Notebooks",
-        "description": "Runme allows to create interactive runbooks for VS Code.",
-        "steps": [
-          {
-            "id": "runme.welcome.why",
-            "title": "Why Runme?",
-            "description": "Runme provides developers with the ability to navigate workflows center around code repositories by making Readme markdown files interactive and smart",
-            "media": {
-              "markdown": "walkthroughs/0-intro.md"
-            }
-          }
-        ]
       }
     ],
     "taskDefinitions": [

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "activationEvents": [
     "onNotebook:runme",
     "onRenderer:runme-renderer",
+    "onCommand:runme.welcome",
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
@@ -113,6 +114,12 @@
         "category": "Runme",
         "title": "Expand all items",
         "icon": "$(search-expand-results)"
+      },
+      {
+        "command": "runme.welcome",
+        "title": "Welcome",
+        "category": "Runme",
+        "description": "Open the welcome page for the Runme extension."
       }
     ],
     "menus": {
@@ -343,6 +350,21 @@
             "title": "Learn more",
             "media": {
               "markdown": "walkthroughs/4-learn-more.md"
+            }
+          }
+        ]
+      },
+      {
+        "id": "runme.welcomePage",
+        "title": "Get Started with creating Runme Notebooks",
+        "description": "Runme allows to create interactive runbooks for VS Code.",
+        "steps": [
+          {
+            "id": "runme.welcome.why",
+            "title": "Why Runme?",
+            "description": "Runme provides developers with the ability to navigate workflows center around code repositories by making Readme markdown files interactive and smart",
+            "media": {
+              "markdown": "walkthroughs/0-intro.md"
             }
           }
         ]

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -1,6 +1,5 @@
 import path from 'node:path'
 import os from 'node:os'
-import fs from 'node:fs/promises'
 
 import {
   NotebookCell, Uri, window, env, NotebookDocument, TextDocument, ViewColumn,
@@ -145,7 +144,10 @@ export async function welcome (context: ExtensionContext) {
    * create temporary markdown file
    */
   try {
-    const fileContent = (await fs.readFile(path.resolve(__dirname, '..', 'walkthroughs', 'welcome.md')))
+    const fileContent = await workspace.fs.readFile(
+      Uri.file(path.join(__dirname, '..', 'walkthroughs', 'welcome.md'))
+    )
+
     const projectUri = Uri.joinPath(context.globalStorageUri, uuidv4())
     await workspace.fs.createDirectory(projectUri)
     const enc = new TextEncoder()

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -137,3 +137,11 @@ export async function createNewRunmeNotebook () {
   )
   await commands.executeCommand('vscode.openWith', newNotebook.uri, Kernel.type)
 }
+
+export function welcome () {
+  commands.executeCommand(
+    'workbench.action.openWalkthrough',
+    'stateful.runme#runme.welcomePage',
+    false
+  )
+}

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -95,7 +95,7 @@ export class RunmeExtension {
       RunmeExtension.registerCommand('runme.openSplitViewAsMarkdownText', openSplitViewAsMarkdownText),
       RunmeExtension.registerCommand('runme.openAsRunmeNotebook', openAsRunmeNotebook),
       RunmeExtension.registerCommand('runme.new', createNewRunmeNotebook),
-      RunmeExtension.registerCommand('runme.welcome', welcome),
+      RunmeExtension.registerCommand('runme.welcome', () => welcome(context)),
       RunmeExtension.registerCommand('runme.openRunmeFile', RunmeLauncherProvider.openFile),
       RunmeExtension.registerCommand('runme.keybinding.m', () => { }),
       RunmeExtension.registerCommand('runme.keybinding.y', () => { }),

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -17,7 +17,8 @@ import {
   openAsRunmeNotebook,
   openSplitViewAsMarkdownText,
   stopBackgroundTask,
-  createNewRunmeNotebook
+  createNewRunmeNotebook,
+  welcome
 } from './commands'
 import { WasmSerializer, GrpcSerializer } from './serializer'
 import { RunmeLauncherProvider } from './provider/launcher'
@@ -94,6 +95,7 @@ export class RunmeExtension {
       RunmeExtension.registerCommand('runme.openSplitViewAsMarkdownText', openSplitViewAsMarkdownText),
       RunmeExtension.registerCommand('runme.openAsRunmeNotebook', openAsRunmeNotebook),
       RunmeExtension.registerCommand('runme.new', createNewRunmeNotebook),
+      RunmeExtension.registerCommand('runme.welcome', welcome),
       RunmeExtension.registerCommand('runme.openRunmeFile', RunmeLauncherProvider.openFile),
       RunmeExtension.registerCommand('runme.keybinding.m', () => { }),
       RunmeExtension.registerCommand('runme.keybinding.y', () => { }),

--- a/tests/extension/commands/index.test.ts
+++ b/tests/extension/commands/index.test.ts
@@ -22,7 +22,8 @@ import {
   openAsRunmeNotebook,
   openSplitViewAsMarkdownText,
   stopBackgroundTask,
-  createNewRunmeNotebook
+  createNewRunmeNotebook,
+  welcome
 } from '../../../src/extension/commands'
 import { getTerminalByCell, getAnnotations, replaceOutput } from '../../../src/extension/utils'
 import { getBinaryPath, isNotebookTerminalEnabledForCell } from '../../../src/utils/configuration'
@@ -147,4 +148,25 @@ test('createNewRunmeNotebook', async () => {
   expect(workspace.openNotebookDocument).toBeCalledWith('runme', expect.any(Object))
   expect(NotebookCellData).toBeCalledTimes(3)
   expect(commands.executeCommand).toBeCalledWith('vscode.openWith', expect.any(String), 'runme')
+})
+
+test('welcome in success case', async () => {
+  await welcome({ globalStorageUri: { fsPath: '/foo/bar' } } as any)
+  expect(
+    vi.mocked(workspace.fs.createDirectory).mock.calls[0][0].path.startsWith('/foo/bar')
+  ).toBe(true)
+  expect(
+    vi.mocked(workspace.fs.writeFile).mock.calls[0][0].path.endsWith('Welcome to Runme.md')
+  ).toBe(true)
+  expect(commands.executeCommand).toBeCalledWith('vscode.openWith', expect.any(Object), 'runme')
+})
+
+test('welcome in failure case', async () => {
+  vi.mocked(workspace.fs.createDirectory).mockRejectedValue(new Error('ups'))
+  await welcome({ globalStorageUri: { fsPath: '/foo/bar' } } as any)
+  expect(commands.executeCommand).toBeCalledWith(
+    'workbench.action.openWalkthrough',
+    'stateful.runme#runme.welcome',
+    false
+  )
 })

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -42,7 +42,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(14)
+  expect(commands.registerCommand).toBeCalledTimes(15)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
 

--- a/walkthroughs/welcome.md
+++ b/walkthroughs/welcome.md
@@ -8,7 +8,7 @@ It allows you to run Shell scripts within a Notebook interface, give it a try:
 echo "Hello Runme!"
 ```
 
-Awesome!
+Awesome! 🎉
 
 It also persist your session state, so all environment variables stay around, e.g.:
 

--- a/walkthroughs/welcome.md
+++ b/walkthroughs/welcome.md
@@ -1,0 +1,27 @@
+# ![Runme](https://runme.dev/img/logo.svg "Runme") Welcome to Runme
+
+Runme is primary a VS Code extension that provides developers with the ability to navigate workflows center around code repositories by making Readme markdown files interactive and smart.
+
+It allows you to run Shell scripts within a Notebook interface, give it a try:
+
+```sh { interactive=false }
+echo "Hello Runme!"
+```
+
+Awesome!
+
+It also persist your session state, so all environment variables stay around, e.g.:
+
+```sh
+export RUNME_MESSAGE="<input message here>"
+```
+
+now run:
+
+```sh { interactive=false }
+echo $RUNME_MESSAGE
+```
+
+Nice! 👌
+
+There is a lot more of that. Checkout the [Runme docs](https://runme.dev) and checkout all features that this extension can help you with. Also, make sure to join our [Discord](https://discord.gg/BQm8zRCBUY) in case you have any questions or like to provide feedback!


### PR DESCRIPTION
fixes #359

This PR adds a Welcome command so that users can do some onboarding aside from the VS Code walkthrough feature. I thought the best we could do is just do an onboarding markdown with some examples. I know @degrammer had some thoughts about it. This is the current state:

![welcome-demo](https://user-images.githubusercontent.com/731337/228953934-f16cd5a6-797b-494e-a2da-abb68a74572b.gif)

Feedback appreciated!