### PR TITLE
Native scrollbar in Notebook Terminal

### DIFF
--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -121,6 +121,27 @@ export class TerminalView extends LitElement {
         top: 0;
     }
 
+    .xterm-viewport::-webkit-scrollbar {
+      width: 10px;
+    }
+
+    .xterm-viewport::-webkit-scrollbar-thumb {
+      background-color: rgba(0, 0, 0, 0);
+      min-height: 20px;
+    }
+
+    .xterm:hover .xterm-viewport::-webkit-scrollbar-thumb {
+      background-color: var(${unsafeCSS(vscodeCSS('scrollbarSlider', 'background'))});
+    }
+
+    .xterm:hover .xterm-viewport::-webkit-scrollbar-thumb:hover {
+      background-color: var(${unsafeCSS(vscodeCSS('scrollbarSlider', 'hoverBackground'))});
+    }
+
+    .xterm:hover .xterm-viewport::-webkit-scrollbar-thumb:active {
+      background-color: var(${unsafeCSS(vscodeCSS('scrollbarSlider', 'activeBackground'))});
+    }
+
     .xterm .xterm-scroll-area {
         visibility: hidden;
     }


### PR DESCRIPTION
<p align="center">
<img width="493" alt="image" src="https://user-images.githubusercontent.com/16108792/228981974-aeb40c11-e3e0-487d-9d6f-e995cbdab5d6.png">
</p>

Mimics style of VSCode

Was not able to get the scrollbar to transition (fade in/out), apparently `::-webkit-scrollbar-thumb` doesn't allow transitions - @christian-bromann do you have any ideas here as to if VSCode could've accomplished this with pure css? 

