### PR TITLE
Force focus notebook terminal on window focus

### DIFF
--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -319,8 +319,13 @@ export class TerminalView extends LitElement {
 
   protected firstUpdated(props: PropertyValues): void {
     super.firstUpdated(props)
-    const terminalContainer = this.#getTerminalElement()
-    this.terminal!.open(terminalContainer as HTMLElement)
+    const terminalContainer = this.#getTerminalElement() as HTMLElement
+
+    window.addEventListener('focus', () => {
+      this.terminal?.focus()
+    })
+
+    this.terminal!.open(terminalContainer)
     this.terminal!.focus()
     this.fitAddon?.fit()
     this.#updateTerminalTheme()


### PR DESCRIPTION
This forces a terminal focus when the window focues.

Before this, short clicks can sometimes fail to focus the terminal.

Unfortunately, this creates a "flicker effect" where you try to focus the terminal, it unfocuses, and then refocuses as a result of this PR. I figure this behavior is better than staying unfocused after clicking.

I am still not sure what is causing the issue in the first place, so this is effectively a work-around.