### PR TITLE
Match explorer's UX: no leading slashes

### DIFF
--- a/src/extension/provider/launcher.ts
+++ b/src/extension/provider/launcher.ts
@@ -184,7 +184,8 @@ export class RunmeLauncherProvider implements TreeDataProvider<RunmeFile>, Dispo
     const rootFolder = basename(this.workspaceRoot || '')
     const info = basename(file.path)
     const folderPath = dirname(file.path)
-    const folderName = folderPath.replace(resolve(this.workspaceRoot || '', '..'), '') + nameTweaker || rootFolder
+    let folderName = folderPath.replace(resolve(this.workspaceRoot || '', '..'), '') + nameTweaker || rootFolder
+    folderName = folderName.startsWith('/') ? folderName.substring(1, folderName.length) : folderName
     return { info, folderPath, folderName }
   }
 

--- a/tests/extension/provider/launcher.test.ts
+++ b/tests/extension/provider/launcher.test.ts
@@ -101,7 +101,7 @@ describe('Runme Notebooks', () => {
     expect(workspace.createFileSystemWatcher).toBeCalledWith('**/*.md', false, true, false)
     handler.mock.calls[0][0]({ path: '/foo/bar' }, true)
     expect([...launchProvider['filesTree'].entries()])
-      .toEqual([['/foo ', { files: ['bar'], folderPath: '/foo' }]])
+      .toEqual([['foo ', { files: ['bar'], folderPath: '/foo' }]])
       handler.mock.calls[1][0]({ path: '/foo/bar' })
     expect(launchProvider.refresh).toBeCalledTimes(1)
   })


### PR DESCRIPTION
The original version had leading slashes on all entries. This changes will make the tree view match the explorer view.

<img width="496" alt="image" src="https://user-images.githubusercontent.com/250527/229905880-45430ec5-3a2a-4943-80c2-3300c9649709.png">
