### PR TITLE
Fix image paths for walkthrough images

### DIFF
--- a/walkthroughs/0-intro.md
+++ b/walkthroughs/0-intro.md
@@ -36,7 +36,7 @@ Gaps in developer experience such as:
 - Docs that have fallen behind undetected
 - The vault lines of commonplace tools were designed for machines, not humans.
 
-![Readme as Notebook and Markdown side-by-side](https://www.runme.dev/assets/images/README_side_by_side-e67bbc4db8e183d9193f1fcccd9b302b.png)
+![Readme as Notebook and Markdown side-by-side](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/sidebyside.png)
 
 Runme’s purpose is to enable developers to achieve a functional local development environment quickly, starting with copy&paste, click to run commands, and many more features. While README.md is the most well-known, there are several other markdown files often found in a repo that you may encounter, including; BUILD.md, CONTRIBUTING.md, and many more. Runme supports most .md and .mdx files!
 

--- a/walkthroughs/1-annotations.md
+++ b/walkthroughs/1-annotations.md
@@ -8,11 +8,11 @@ See the complete list of cell configuration options [in the docs](https://runme.
 
 You want to enable the `background` setting if notebook execution will continue indefinitely on a single command.
 
-![Readme background task status bar](https://runme.dev/assets/images/long-running-process-28a244ba20337b531c85fd31e7a669ad.png)
+![Readme background task status bar](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/long-running-process.png)
 
 It is very common to use file-watcher enabled compilers/bundlers (`npm start dev`, `watchexec`... etc) in the background during development. For any cell containing an instance of these commands be sure to tick the `"background"` cell setting. It prevents execution from permanently blocking the notebook UX. Once ticked notice the "Background Task" label shows up in the cell status bar.
 
-![Readme background task status bar](https://runme.dev/assets/images/background-task-process-fb519197e23bcf3411d4ce405ae93082.png)
+![Readme background task status bar](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/background-task-process.png)
 
 **Default:** `false`
 **Example:**
@@ -25,7 +25,7 @@ It is very common to use file-watcher enabled compilers/bundlers (`npm start dev
 
 If a cell's commands do not require any input from a reader it might be a good fit to include the cell's output inside the notebook. This is useful if the resulting output could be useful as input in a downstream cell. This is what `interactive=false` is for which defaults to true.
 
-![Readme interactive task status bar](https://runme.dev/assets/images/interactive-execution-46d0d65215954b7ac770448a5394051d.png)
+![Readme interactive task status bar](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/interactive-execution.png)
 
 **Default:** `true`
 **Example:**
@@ -52,7 +52,7 @@ Check the docs on [runme.dev](https://runme.dev/docs/annotations) for more
 
 JSON, text, images, etc. Not all cells’ output is plain text. Using the `mimeType` specifier it is possible to specify the expected output's type. Notebooks have a variety of renderers that will display them human friendly. The MIME type defaults to text/plain.
 
-![Readme mimeType task status bar](https://runme.dev/assets/images/human-centric-output-b9290d4818822a18e4e45700efa7592a.png)
+![Readme mimeType task status bar](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/human-centric-output.png)
 
 
 ## Supported MIME types

--- a/walkthroughs/3-features.md
+++ b/walkthroughs/3-features.md
@@ -4,11 +4,11 @@
 
 To run a command, simply click the run button (may require your mouse over the command in some themes). You will notice that this turns into a stop button for hung or long-running commands, which can be used to kill the terminal process.
 
-![Readme run a command](https://runme.dev/assets/images/run-a-command-f37f5462befc66c5721c19dfe4336352.png)
+![Readme run a command](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/run-a-command.png)
 
 A succeeding exit code will be indicated with the small green checkbox seen below:
 
-![Readme run a command result](https://runme.dev/assets/images/check-mark-success-d2f5bcb93690d780969dda1a3b710034.png)
+![Readme run a command result](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/check-mark-success.png)
 
 You can also open the terminal that did the execution by clicking the “Open Terminal” button as shown above with its PID.
 
@@ -17,18 +17,18 @@ You can also open the terminal that did the execution by clicking the “Open Te
 
 Outside of literally running commands, Runme offers the ability to quickly copy commands (with the click of a button) out of a markdown file to paste into your terminal.
 
-![Readme run a command result](https://runme.dev/assets/images/feature-copy-d4563fd523f32ecc468254750d3aafe4.png)
+![Readme run a command result](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/feature-copy.png)
 
 
 ## Run all commands
 
 To run all the commands in the notebook in the order they are found, you can click the “Run All” button.
 
-![Readme run all commands](https://runme.dev/assets/images/run-all-877ed54c3b7bd63b837c8e5a7cfd1235.png)
+![Readme run all commands](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/run-all.png)
 
 To be extra safe, you will be prompted before each step to confirm your intentions unless you select “Skip Prompt and run all”.
 
-![Readme run all commands confirm step](https://runme.dev/assets/images/confirm-run-all-def58028aa9410f8abdcf9c0e79d37c9.png)
+![Readme run all commands confirm step](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/confirm-run-all.png)
 
 ## Split view of markdown and notebook
 
@@ -36,11 +36,11 @@ It’s easy to get from notebook to markdown and vice versa.
 
 ### Open the notebook version
 
-![Readme run all commands confirm step](https://runme.dev/assets/images/split-view-ba9635ba52ccc77021f35e23da587bdb.png)
+![Readme run all commands confirm step](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/split-view.png)
 
 ### Open the markdown version
 
-![Readme open md version](https://runme.dev/assets/images/markdown-version-4a58ba676a1a96571a7188c643bcab6d.png)
+![Readme open md version](https://github.com/stateful/runme.dev/raw/63f857ba8f4f8cfd824099c80c14ffc405802ea4/static/img/markdown-version.png)
 
 ## Summary
 


### PR DESCRIPTION
Using `runme.dev/img/....` image path don't work as file paths can change after every deploy. This patch replaces them using github links.