### PR TITLE
Fix notebook terminal cursor color

### DIFF
--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -360,9 +360,11 @@ export class TerminalView extends LitElement {
   }
 
   #updateTerminalTheme(): void {
+    const foregroundColor = this.#getThemeHexColor(terminalCSS('foreground'))
+
     const terminalTheme: ITheme = {
-      foreground: this.#getThemeHexColor(terminalCSS('foreground')),
-      cursor: this.#getThemeHexColor(vscodeCSS('terminalCursor', 'foreground')),
+      foreground: foregroundColor,
+      cursor: this.#getThemeHexColor(vscodeCSS('terminalCursor', 'foreground')) || foregroundColor,
       cursorAccent: this.#getThemeHexColor(vscodeCSS('terminalCursor', 'background')),
       selectionForeground: this.#getThemeHexColor(terminalCSS('selectionForeground')),
       selectionBackground: this.#getThemeHexColor(terminalCSS('selectionBackground')),


### PR DESCRIPTION
If there is no `--vscode-terminalCursor-foreground` variable, this will revert to the foreground color instead.

This fixes the terminal cursor not appearing in the `Github Light (Colorblind)` theme.