### PR TITLE
Fix unnecessary error tracking Notebook Terminal input

### DIFF
--- a/src/extension/terminal/terminalState.ts
+++ b/src/extension/terminal/terminalState.ts
@@ -32,7 +32,11 @@ export class XTermState implements ITerminalState {
   }
 
   input(data: string, wasUserInput: boolean): void {
-    // @ts-expect-error unexposed method
-    this.xterm['coreService']['triggerDataEvent'](data, wasUserInput)
+    try {
+      // @ts-expect-error unexposed method
+      this.xterm['_core']['coreService']['triggerDataEvent'](data, wasUserInput)
+    } catch (e) {
+      console.error(e)
+    }
   }
 }


### PR DESCRIPTION
I made a mistake when adding this line. 

This PR prevents console from being overwhelmed with error messages on interactive scripts.