### PR TITLE
Parse out trailing dollar signs in cmd sequences

### DIFF
--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -57,8 +57,8 @@ export async function executeRunner(
     RUNME_ID
   }
 
-  const commands = await parseCommandSeq(cellText)
-  if (!commands) { return false }
+  const commands = await parseCommandSeq(cellText, (s) => s.split('\n'))
+  if(!commands) { return false }
 
   if (commands.length === 0) {
     commands.push('')

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -19,7 +19,7 @@ import { ClientMessages, OutputType } from '../../constants'
 import { CellOutputPayload, ClientMessage } from '../../types'
 import { PLATFORM_OS } from '../constants'
 import { IRunner, IRunnerEnvironment, RunProgramExecution } from '../runner'
-import { getAnnotations, getCmdShellSeq, replaceOutput } from '../utils'
+import { getAnnotations, getCmdShellSeq, prepareCmdSeq, replaceOutput } from '../utils'
 import { postClientMessage } from '../../utils/messaging'
 import { isNotebookTerminalEnabledForCell } from '../../utils/configuration'
 import { Kernel } from '../kernel'
@@ -57,7 +57,7 @@ export async function executeRunner(
     RUNME_ID
   }
 
-  const commands = await parseCommandSeq(cellText, (s) => s.split('\n'))
+  const commands = await parseCommandSeq(cellText, prepareCmdSeq)
   if(!commands) { return false }
 
   if (commands.length === 0) {

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -6,7 +6,7 @@ import { NotebookCellOutput, NotebookCellExecution, NotebookCellOutputItem, wind
 import { ENV_STORE } from '../constants'
 import { OutputType } from '../../constants'
 import type { CellOutputPayload } from '../../types'
-import { replaceOutput, getCmdSeq } from '../utils'
+import { replaceOutput } from '../utils'
 
 const ENV_VAR_REGEXP = /(\$\w+)/g
 /**
@@ -59,7 +59,8 @@ export async function promptUserForVariable(
 }
 
 export function getCommandExportExtractMatches(
-  rawText: string
+  rawText: string,
+  supportsDirect = true
 ): CommandExportExtractMatch[] {
   const test = new RegExp(EXPORT_EXTRACT_REGEX)
 
@@ -84,8 +85,10 @@ export function getCommandExportExtractMatches(
       value = placeHolder.slice(2, -1)
     } else if (!placeHolder.includes('\n')) {
       matchType = 'prompt'
-    } else {
+    } else if (supportsDirect) {
       matchType = 'direct'
+    } else {
+      continue
     }
 
     result.push({
@@ -190,9 +193,12 @@ export function getShellPath(execKey?: string): string|undefined {
  * Returns `undefined` when a user cancels on prompt
  */
 export async function parseCommandSeq(
-  cellText: string
+  cellText: string,
+  parseBlock?: (block: string) => string[]
 ): Promise<string[]|undefined> {
-  const exportMatches = getCommandExportExtractMatches(cellText)
+  parseBlock ??= (s) => s ? s.split('\n') : []
+
+  const exportMatches = getCommandExportExtractMatches(cellText, false)
 
   type CommandBlock =
     |{
@@ -242,5 +248,5 @@ export async function parseCommandSeq(
   parsedCommandBlocks.push({ type: 'block', content: cellText.slice(offset) })
 
   return parsedCommandBlocks
-    .flatMap(({ type, content }) => type === 'block' ? getCmdSeq(content) : [content])
+    .flatMap(({ type, content }) => (type === 'block' && parseBlock?.(content)) || (content ? [content] : []))
 }

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -151,6 +151,25 @@ export function getCmdSeq(cellText: string): string[] {
 }
 
 /**
+ * Does the following to a command list:
+ *
+ * - Splits by new lines
+ * - Removes trailing `$` characters
+ */
+export function prepareCmdSeq(cellText: string): string[] {
+  return cellText.split('\n')
+    .map(l => {
+      const stripped = l.trimStart()
+
+      if (stripped.startsWith('$')) {
+        return stripped.slice(1).trimStart()
+      }
+
+      return l
+    })
+}
+
+/**
  * treat cells like like a series of individual commands
  * which need to be executed in sequence
  *

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -295,5 +295,6 @@ suite('prepareCmdSeq', () => {
   test('should eliminate trailing dollar signs', () => {
     expect(prepareCmdSeq('$ echo hi')).toStrictEqual([ 'echo hi' ])
     expect(prepareCmdSeq('  $  echo hi')).toStrictEqual([ 'echo hi' ])
+    expect(prepareCmdSeq('echo 1\necho 2\n $ echo 4')).toStrictEqual(['echo 1', 'echo 2', 'echo 4'])
   })
 })

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -12,6 +12,7 @@ import {
   mapGitIgnoreToGlobFolders,
   hashDocumentUri,
   getGrpcHost,
+  prepareCmdSeq,
 } from '../../src/extension/utils'
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
 import { CellAnnotations } from '../../src/types'
@@ -287,5 +288,12 @@ suite('#getGrpcHost', () => {
   test('should return host addr including config port', () => {
     vi.mocked(workspace.getConfiguration).mockReturnValue({ get: vi.fn().mockReturnValue(7863) } as any)
     expect(getGrpcHost()).toStrictEqual('localhost:7863')
+  })
+})
+
+suite('prepareCmdSeq', () => {
+  test('should eliminate trailing dollar signs', () => {
+    expect(prepareCmdSeq('$ echo hi')).toStrictEqual([ 'echo hi' ])
+    expect(prepareCmdSeq('  $  echo hi')).toStrictEqual([ 'echo hi' ])
   })
 })


### PR DESCRIPTION
Executes sequences like `$ echo Hello` as `echo Hello`

Note that this will affect sequences such as:

```
export VAR="
$
"
```

Though usually `$` are escaped in bash so I imagine this kind of a thing to be rather uncommon.