### PR TITLE
Allow font customization in Notebook Terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,6 +322,16 @@
             "scope": "machine",
             "default": false,
             "markdownDescription": "Enable Runme notebook terminal in interactive scripts (experimental)"
+          },
+          "runme.terminal.fontSize": {
+            "type": [ "number", "null" ],
+            "default": null,
+            "markdownDescription": "Font size of Runme notebook terminal"
+          },
+          "runme.terminal.fontFamily": {
+            "type": [ "string", "null" ],
+            "default": null,
+            "markdownDescription": "Font family of Runme notebook terminal"
           }
         }
       }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -21,6 +21,10 @@ import { TelemetryReporter } from 'vscode-telemetry'
 import type { CellOutputPayload, ClientMessage, Serializer } from '../types'
 import { ClientMessages, OutputType } from '../constants'
 import { API } from '../utils/deno/api'
+import {
+  getNotebookTerminalFontFamily,
+  getNotebookTerminalFontSize
+} from '../utils/configuration'
 
 import executor, { type IEnvironmentManager, ENV_STORE_MANAGER } from './executors'
 import { DENO_ACCESS_TOKEN_KEY } from './constants'
@@ -116,12 +120,15 @@ export class Kernel implements Disposable {
 
     const editorSettings = workspace.getConfiguration('editor')
 
+    const terminalFontFamily = getNotebookTerminalFontFamily() ?? editorSettings.get<string>('fontFamily', 'Arial')
+    const terminalFontSize = getNotebookTerminalFontSize() ?? editorSettings.get<number>('fontSize', 10)
+
     const json: CellOutputPayload<OutputType.terminal> = {
       type: OutputType.terminal,
       output: {
         'runme.dev/uuid': cellId,
-        terminalFontFamily: editorSettings.get<string>('fontFamily', 'Arial'),
-        terminalFontSize: editorSettings.get<number>('fontSize', 10),
+        terminalFontFamily,
+        terminalFontSize,
         content: terminalState.serialize(),
       }
     }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -39,7 +39,7 @@ const configurationSchema = {
         backgroundTask: z.boolean().default(true),
         nonInteractive: z.boolean().default(false),
         interactive: z.boolean().default(false),
-        fontSize: z.number().int().optional(),
+        fontSize: z.number().optional(),
         fontFamily: z.string().optional()
     }
 }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -38,7 +38,9 @@ const configurationSchema = {
     notebookTerminal: {
         backgroundTask: z.boolean().default(true),
         nonInteractive: z.boolean().default(false),
-        interactive: z.boolean().default(false)
+        interactive: z.boolean().default(false),
+        fontSize: z.number().int().optional(),
+        fontFamily: z.string().optional()
     }
 }
 
@@ -105,6 +107,14 @@ const isNotebookTerminalFeatureEnabled = (featureName: keyof typeof configuratio
     return getRunmeTerminalConfigurationValue(featureName, false)
 }
 
+const getNotebookTerminalFontSize = (): number|undefined => {
+  return getRunmeTerminalConfigurationValue<number|undefined>('fontSize', undefined)
+}
+
+const getNotebookTerminalFontFamily = (): string|undefined => {
+  return getRunmeTerminalConfigurationValue<string|undefined>('fontFamily', undefined)
+}
+
 const isNotebookTerminalEnabledForCell = (cell: NotebookCell): boolean => {
   const { interactive, background } = getAnnotations(cell)
 
@@ -124,4 +134,6 @@ export {
     isNotebookTerminalEnabledForCell,
     getTLSEnabled,
     getTLSDir,
+    getNotebookTerminalFontFamily,
+    getNotebookTerminalFontSize,
 }

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -9,7 +9,9 @@ import {
   getBinaryPath,
   getServerConfigurationValue,
   getTLSDir,
-  DEFAULT_TLS_DIR
+  DEFAULT_TLS_DIR,
+  getNotebookTerminalFontFamily,
+  getNotebookTerminalFontSize
 } from '../../src/utils/configuration'
 
 const FAKE_UNIX_EXT_PATH = '/Users/user/.vscode/extension/stateful.runme'
@@ -78,6 +80,16 @@ afterEach(() => {
 })
 
 suite('Configuration', () => {
+    test('should get nullish from font family', () => {
+      const fontFamily = getNotebookTerminalFontFamily()
+      expect(fontFamily).toBeUndefined()
+    })
+
+    test('should get nullish from font size', () => {
+      const fontSize = getNotebookTerminalFontSize()
+      expect(fontSize).toBeUndefined()
+    })
+
     test('Should default to a valid port number', () => {
         const portNumber = getPortNumber()
         expect(portNumber).toStrictEqual(7863)


### PR DESCRIPTION
Adds two configurations, `runme.terminal.fontSize` and `runme.terminal.fontFamily`.