### PR TITLE
Allow custom rows/vertical resizing in Notebook Terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,6 +332,11 @@
             "type": [ "string", "null" ],
             "default": null,
             "markdownDescription": "Font family of Runme notebook terminal"
+          },
+          "runme.terminal.rows": {
+            "type": "integer",
+            "default": 10,
+            "markdownDescription": "Default number of rows in notebook terminal"
           }
         }
       }

--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -408,21 +408,21 @@ export class TerminalView extends LitElement {
       initialRows: number
     } | undefined
 
-    dragHandle.addEventListener('mousedown', (e) => {
+    const onMouseDown = (e: MouseEvent) => {
       dragState = {
         initialClientY: e.clientY,
         initialRows: this.rows
       }
       e.preventDefault()
       this.terminal?.focus()
-    })
+    }
 
-    window.addEventListener('mouseup', () => {
+    const onMouseUp = () => {
       if (dragState === undefined) { return }
       dragState = undefined
-    })
+    }
 
-    window.addEventListener('mousemove', (e) => {
+    const onMouseMove = (e: MouseEvent) => {
       if (dragState === undefined || !this.fitAddon) { return }
 
       const delta = e.clientY - dragState.initialClientY
@@ -434,7 +434,17 @@ export class TerminalView extends LitElement {
         this.#resizeTerminal(newRows)
         this.terminal?.focus()
       }
-    })
+    }
+
+    dragHandle.addEventListener('mousedown', onMouseDown)
+    window.addEventListener('mouseup', onMouseUp)
+    window.addEventListener('mousemove', onMouseMove)
+
+    this.disposables.push({dispose: () => {
+      dragHandle.removeEventListener('mousedown', onMouseDown)
+      window.removeEventListener('mouseup', onMouseUp)
+      window.removeEventListener('mousemove', onMouseMove)
+    }})
 
     return dragHandle
   }

--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -427,8 +427,6 @@ export class TerminalView extends LitElement {
 
       const delta = e.clientY - dragState.initialClientY
 
-      console.log({ delta, cellHeight: this.fitAddon.getCellSize().height })
-
       const deltaRows = delta / this.fitAddon.getCellSize().height
       const newRows = Math.round(dragState.initialRows + deltaRows)
 

--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -413,6 +413,8 @@ export class TerminalView extends LitElement {
         initialClientY: e.clientY,
         initialRows: this.rows
       }
+      e.preventDefault()
+      this.terminal?.focus()
     })
 
     window.addEventListener('mouseup', () => {
@@ -432,6 +434,7 @@ export class TerminalView extends LitElement {
 
       if (newRows !== this.rows) {
         this.#resizeTerminal(newRows)
+        this.terminal?.focus()
       }
     })
 

--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -249,6 +249,18 @@ export class TerminalView extends LitElement {
       flex-direction: column;
       gap: 5px;
     }
+
+    .xterm-drag-handle {
+      width: 100%;
+      position: absolute;
+      bottom: -5px;
+      height: 10px;
+      cursor: row-resize;
+    }
+
+    #terminal {
+      position: relative;
+    }
   `
 
   protected disposables: Disposable[] = []
@@ -256,6 +268,8 @@ export class TerminalView extends LitElement {
   protected fitAddon?: FitAddon
   protected serializer?: SerializeAddon
   protected windowSize: IWindowSize
+
+  protected rows: number = 10
 
   @property({ type: String })
   uuid?: string
@@ -268,6 +282,9 @@ export class TerminalView extends LitElement {
 
   @property({ type: String })
   initialContent?: string
+
+  @property({ type: Number })
+  initialRows?: number
 
   @property({ type: Number })
   lastLine?: number // TODO: Get the last line of the terminal and store it.
@@ -287,8 +304,10 @@ export class TerminalView extends LitElement {
       throw new Error('No uuid provided to terminal!')
     }
 
+    this.rows = this.initialRows ?? this.rows
+
     this.terminal = new XTermJS({
-      rows: 10,
+      rows: this.rows,
       cursorBlink: true,
       fontSize: this.terminalFontSize,
       cursorStyle: 'bar',
@@ -357,8 +376,10 @@ export class TerminalView extends LitElement {
 
     this.terminal!.open(terminalContainer)
     this.terminal!.focus()
-    this.fitAddon?.fit()
+    this.#resizeTerminal()
     this.#updateTerminalTheme()
+
+    terminalContainer.appendChild(this.#createResizeHandle())
 
     const ctx = getContext()
     ctx.postMessage && postClientMessage(ctx, ClientMessages.terminalOpen, {
@@ -371,6 +392,50 @@ export class TerminalView extends LitElement {
     if (this.lastLine) {
       this.terminal!.scrollToLine(this.lastLine)
     }
+  }
+
+  #resizeTerminal(rows?: number) {
+    if (rows !== undefined) { this.rows = rows }
+    return this.fitAddon?.fit(this.rows)
+  }
+
+  #createResizeHandle(): HTMLElement {
+    const dragHandle = document.createElement('div')
+    dragHandle.setAttribute('class', 'xterm-drag-handle')
+
+    let dragState: {
+      initialClientY: number
+      initialRows: number
+    } | undefined
+
+    dragHandle.addEventListener('mousedown', (e) => {
+      dragState = {
+        initialClientY: e.clientY,
+        initialRows: this.rows
+      }
+    })
+
+    window.addEventListener('mouseup', () => {
+      if (dragState === undefined) { return }
+      dragState = undefined
+    })
+
+    window.addEventListener('mousemove', (e) => {
+      if (dragState === undefined || !this.fitAddon) { return }
+
+      const delta = e.clientY - dragState.initialClientY
+
+      console.log({ delta, cellHeight: this.fitAddon.getCellSize().height })
+
+      const deltaRows = delta / this.fitAddon.getCellSize().height
+      const newRows = Math.round(dragState.initialRows + deltaRows)
+
+      if (newRows !== this.rows) {
+        this.#resizeTerminal(newRows)
+      }
+    })
+
+    return dragHandle
   }
 
   #getTerminalElement(): Element {
@@ -410,9 +475,9 @@ export class TerminalView extends LitElement {
     }
 
     this.windowSize.width = innerWidth
-    this.fitAddon.fit()
 
-    const proposedDimensions = this.fitAddon.proposeDimensions()
+    const proposedDimensions = this.#resizeTerminal()
+
     if (proposedDimensions) {
       const ctx = getContext()
       if (!ctx.postMessage) { return }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -59,6 +59,11 @@ export const activate: ActivationFunction = (context: RendererContext<void>) => 
           terminalElement.setAttribute('uuid', payload.output['runme.dev/uuid'])
           terminalElement.setAttribute('terminalFontFamily', payload.output.terminalFontFamily)
           terminalElement.setAttribute('terminalFontSize', payload.output.terminalFontSize.toString())
+
+          if (payload.output.initialRows !== undefined) {
+            terminalElement.setAttribute('initialRows', payload.output.initialRows.toString())
+          }
+
           if (payload.output.content !== undefined) {
             terminalElement.setAttribute('initialContent', payload.output.content)
           }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -23,7 +23,8 @@ import { ClientMessages, OutputType } from '../constants'
 import { API } from '../utils/deno/api'
 import {
   getNotebookTerminalFontFamily,
-  getNotebookTerminalFontSize
+  getNotebookTerminalFontSize,
+  getNotebookTerminalRows
 } from '../utils/configuration'
 
 import executor, { type IEnvironmentManager, ENV_STORE_MANAGER } from './executors'
@@ -130,6 +131,7 @@ export class Kernel implements Disposable {
         terminalFontFamily,
         terminalFontSize,
         content: terminalState.serialize(),
+        initialRows: getNotebookTerminalRows(),
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ interface Payload {
     terminalFontFamily: string
     terminalFontSize: number
     content?: string
+    initialRows?: number
   }
 }
 

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -40,7 +40,8 @@ const configurationSchema = {
         nonInteractive: z.boolean().default(false),
         interactive: z.boolean().default(false),
         fontSize: z.number().optional(),
-        fontFamily: z.string().optional()
+        fontFamily: z.string().optional(),
+        rows: z.number().int()
     }
 }
 
@@ -125,6 +126,10 @@ const isNotebookTerminalEnabledForCell = (cell: NotebookCell): boolean => {
     isNotebookTerminalFeatureEnabled('nonInteractive')
 }
 
+const getNotebookTerminalRows = (): number => {
+  return getRunmeTerminalConfigurationValue<number>('rows', 10)
+}
+
 export {
     getPortNumber,
     getBinaryPath,
@@ -136,4 +141,5 @@ export {
     getTLSDir,
     getNotebookTerminalFontFamily,
     getNotebookTerminalFontSize,
+    getNotebookTerminalRows,
 }


### PR DESCRIPTION
![2023-04-07 15-53-32](https://user-images.githubusercontent.com/16108792/230689723-5ecf6110-c499-438e-99d0-0ae2b508dfb8.gif)

Allows user to define config `runme.terminal.rows` for the initial row setting for a terminal.

Also adds vertical drag handle, to adjust number of rows.

**Known Issues**:

 - The number of rows resets when re-running a cell. We would need to code a persistence layer to change this
 - Terminal is not "focused" when dragging.