### PR TITLE
Use PID for background task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.8.2-20230310150327-f6c75491ea13.1",
-        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.8.2-20230307185721-114a366533aa.1",
+        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.8.3-20230411173542-ee7abafe0a79.1",
         "@protobuf-ts/grpc-transport": "^2.8.2",
         "@protobuf-ts/runtime": "^2.8.2",
         "@protobuf-ts/runtime-rpc": "^2.8.2",
@@ -1804,11 +1804,11 @@
       }
     },
     "node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.8.2-20230307185721-114a366533aa.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/2.8.2-20230307185721-114a366533aa.1/tarball",
+      "version": "2.8.3-20230411173542-ee7abafe0a79.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.8.3-20230411173542-ee7abafe0a79.1.tgz",
       "peerDependencies": {
-        "@protobuf-ts/runtime": "^2.8.2",
-        "@protobuf-ts/runtime-rpc": "^2.8.2"
+        "@protobuf-ts/runtime": "^2.8.3",
+        "@protobuf-ts/runtime-rpc": "^2.8.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -24768,8 +24768,8 @@
       "requires": {}
     },
     "@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.8.2-20230307185721-114a366533aa.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/2.8.2-20230307185721-114a366533aa.1/tarball",
+      "version": "2.8.3-20230411173542-ee7abafe0a79.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.8.3-20230411173542-ee7abafe0a79.1.tgz",
       "requires": {}
     },
     "@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
         "title": "Open Terminal for Background Task"
       },
       {
+        "command": "runme.openIntegratedTerminal",
+        "title": "Open Integrated Terminal for Background Task"
+      },
+      {
         "command": "runme.copyCellToClipboard",
         "title": "Copy Cell Content into Clipboard"
       },
@@ -137,6 +141,10 @@
       "commandPalette": [
         {
           "command": "runme.openTerminal",
+          "when": "false"
+        },
+        {
+          "command": "runme.openIntegratedTerminal",
           "when": "false"
         },
         {
@@ -510,7 +518,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.8.2-20230307185721-114a366533aa.1",
+    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.8.3-20230411173542-ee7abafe0a79.1",
     "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.8.2-20230310150327-f6c75491ea13.1",
     "@protobuf-ts/grpc-transport": "^2.8.2",
     "@protobuf-ts/runtime": "^2.8.2",

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -17,14 +17,14 @@ function showWarningMessage () {
   return window.showWarningMessage('Couldn\'t find terminal! Was it already closed?')
 }
 
-export function openTerminal (kernel: Kernel, grpcRunner: boolean, existingExecution?: NotebookCellExecution) {
+export function openTerminal (kernel: Kernel, notebookTerminal: boolean, existingExecution?: NotebookCellExecution) {
   return async function (cell: NotebookCell) {
     const terminal = getTerminalByCell(cell)
     if (!terminal) {
       return showWarningMessage()
     }
 
-    if (isNotebookTerminalEnabledForCell(cell) && grpcRunner) {
+    if (isNotebookTerminalEnabledForCell(cell) && notebookTerminal) {
       const terminalOutput = kernel.getCellTerminalOutputPayload(cell)
 
       if (terminalOutput) {

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -16,7 +16,7 @@ import {
 } from 'vscode'
 
 import { ClientMessages, OutputType } from '../../constants'
-import { CellOutputPayload, ClientMessage, RunmeTerminal } from '../../types'
+import { CellOutputPayload, ClientMessage } from '../../types'
 import { PLATFORM_OS } from '../constants'
 import { IRunner, IRunnerEnvironment, RunProgramExecution } from '../runner'
 import { getAnnotations, getCmdShellSeq, getTerminalByCell, prepareCmdSeq, replaceOutput } from '../utils'

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -93,6 +93,7 @@ export class RunmeExtension {
 
       commands.registerCommand('runme.resetEnv', resetEnv),
       RunmeExtension.registerCommand('runme.openTerminal', openTerminal(kernel, !!grpcRunner)),
+      RunmeExtension.registerCommand('runme.openIntegratedTerminal', openTerminal(kernel, false)),
       RunmeExtension.registerCommand(
         'runme.runCliCommand',
         runCLICommand(context.extensionUri, !!grpcRunner, server, kernel)

--- a/src/extension/provider/background.ts
+++ b/src/extension/provider/background.ts
@@ -24,9 +24,8 @@ export class ShowTerminalProvider implements vscode.NotebookCellStatusBarItemPro
     }
 
     const terminal = getTerminalByCell(cell)
-    const pid = await terminal?.processId
 
-    if (!Boolean(terminal) || !pid) {
+    if (!Boolean(terminal)) {
       return
     }
 
@@ -34,10 +33,6 @@ export class ShowTerminalProvider implements vscode.NotebookCellStatusBarItemPro
       '$(terminal)',
       'Open Terminal',
     ]
-
-    if (pid > -1) {
-      terminalButtonParts.push(`(PID: ${pid})`)
-    }
 
     const item = new NotebookCellStatusBarItem(
       terminalButtonParts.join(' '),
@@ -58,8 +53,17 @@ export class ShowTerminalProvider implements vscode.NotebookCellStatusBarItemPro
 }
 
 export class BackgroundTaskProvider implements vscode.NotebookCellStatusBarItemProvider {
-  provideCellStatusBarItems(cell: vscode.NotebookCell): vscode.NotebookCellStatusBarItem | undefined {
+  async provideCellStatusBarItems(cell: vscode.NotebookCell): Promise<vscode.NotebookCellStatusBarItem | undefined> {
     const annotations = getAnnotations(cell)
+
+    const terminal = getTerminalByCell(cell)
+    const pid = await terminal?.processId
+
+    let text = 'Background Task'
+
+    if (pid !== undefined && pid > -1) {
+      text = `PID: ${pid}`
+    }
 
     /**
      * don't show if not a background task
@@ -69,9 +73,14 @@ export class BackgroundTaskProvider implements vscode.NotebookCellStatusBarItemP
     }
 
     const item = new NotebookCellStatusBarItem(
-      'Background Task',
+      text,
       NotebookCellStatusBarAlignment.Right
     )
+
+    if (terminal) {
+      item.command = 'runme.openIntegratedTerminal'
+    }
+
     return item
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { NotebookCellKind, TaskDefinition, Terminal, TerminalDimensions } from 'vscode'
+import { NotebookCellKind, TaskDefinition, type Terminal, TerminalDimensions } from 'vscode'
 import { z } from 'zod'
 
 import { OutputType, ClientMessages } from './constants'
@@ -159,5 +159,4 @@ export interface DisposableAsync {
 
 export interface RunmeTerminal extends Terminal {
   runnerSession?: IRunnerProgramSession
-  runmeProcessId?: Promise<number | undefined>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,4 +159,5 @@ export interface DisposableAsync {
 
 export interface RunmeTerminal extends Terminal {
   runnerSession?: IRunnerProgramSession
+  runmeProcessId?: Promise<number | undefined>
 }

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -54,7 +54,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(17)
+  expect(commands.registerCommand).toBeCalledTimes(18)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
 

--- a/tests/extension/provider/background.test.ts
+++ b/tests/extension/provider/background.test.ts
@@ -47,7 +47,7 @@ describe('ShowTerminalProvider', () => {
     const p = new ShowTerminalProvider()
     const item = await p.provideCellStatusBarItems('cell' as any)
     expect(item).toEqual({
-      label: '$(terminal) Open Terminal (PID: 123)',
+      label: '$(terminal) Open Terminal',
       command: 'runme.openTerminal',
       alignment: 2
     })

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -10,6 +10,7 @@ import {
   GrpcRunnerProgramSession,
   RunProgramOptions
 } from '../../src/extension/runner'
+import type { ExecuteResponse } from '../../src/extension/grpc/runnerTypes'
 
 
 vi.mock('../../src/extension/utils', () => ({

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 
 import { vi, suite, test, expect, beforeEach } from 'vitest'
-import type { ExecuteResponse } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/runner/v1/runner_pb'
 import { type GrpcTransport } from '@protobuf-ts/grpc-transport'
 import { EventEmitter } from 'vscode'
 
@@ -209,6 +208,32 @@ suite('grpc Runner', () => {
 
       expect(stderrListener).toBeCalledTimes(1)
       expect(stderrListener).toBeCalledWith(Buffer.from('test'))
+    })
+
+    test('duplex onMessage exposes PID in background mode', async () => {
+      const { duplex, session } = await createNewSession({ background: true })
+
+      duplex._onMessage.fire({
+        stdoutData: Buffer.from(''),
+        stderrData: Buffer.from(''),
+        pid: {
+          pid: '1234'
+        }
+      })
+
+      const pid = await session.pid
+
+      expect(pid).toStrictEqual(1234)
+    })
+
+    test('PID is undefined in non-background mode', async () => {
+      const { session } = await createNewSession()
+
+      await session.run()
+
+      const pid = await session.pid
+
+      expect(pid).toBeUndefined()
     })
 
     test('duplex onMessage calls onDidWrite', async () => {


### PR DESCRIPTION
 - When running, "Background Task" becomes "PID: ####" (for background tasks)
   - When clicked on, this opens the task's integrated terminal
 - Removed PID from "Open Terminal" button

Note that this feature requires the latest stateful/runme executable (on main branch, not release)