### PR TITLE
Background as singleton

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -95,7 +95,9 @@ export const window = {
 }
 
 export const tasks = {
-  registerTaskProvider: vi.fn()
+  registerTaskProvider: vi.fn(),
+  onDidEndTaskProcess: vi.fn(),
+  onDidStartTaskProcess: vi.fn()
 }
 
 export const commands = {

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -24,6 +24,7 @@ import { postClientMessage } from '../../utils/messaging'
 import { isNotebookTerminalEnabledForCell } from '../../utils/configuration'
 import { Kernel } from '../kernel'
 import { ITerminalState } from '../terminal/terminalState'
+import { openTerminal } from '../commands'
 
 import { closeTerminalByEnvID } from './task'
 import { getShellPath, parseCommandSeq } from './utils'
@@ -57,7 +58,7 @@ export async function executeRunner(
 
     if (terminal && terminal.runnerSession) {
       if (!terminal.runnerSession.hasExited()) {
-        // TODO: focus terminal
+        openTerminal(kernel, true, exec)(exec.cell)
         return true
       } else {
         terminal.dispose()

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -318,10 +318,6 @@ export async function executeRunner(
     if (background && interactive) {
       setTimeout(
         () => {
-          if (closeTerminalOnSuccess) {
-            closeTerminalByEnvID(RUNME_ID)
-          }
-
           resolve(true)
         },
         BACKGROUND_TASK_HIDE_TIMEOUT

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -66,6 +66,7 @@ export class RunmeExtension {
     const treeViewer = new RunmeLauncherProvider(getDefaultWorkspace())
     const uriHandler = new RunmeUriHandler(context)
     const winSurvey = new survey.WinDefaultShell(context)
+    const stopBackgroundTaskProvider = new StopBackgroundTaskProvider()
 
     context.subscriptions.push(
       kernel,
@@ -84,9 +85,11 @@ export class RunmeExtension {
       notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new ShowTerminalProvider()),
       notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new BackgroundTaskProvider()),
       notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new CopyProvider()),
-      notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new StopBackgroundTaskProvider()),
+      notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, stopBackgroundTaskProvider),
       notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new AnnotationsProvider(kernel)),
       // notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new TerminalViewProvider(kernel)),
+
+      stopBackgroundTaskProvider,
 
       commands.registerCommand('runme.resetEnv', resetEnv),
       RunmeExtension.registerCommand('runme.openTerminal', openTerminal(kernel, !!grpcRunner)),

--- a/src/extension/provider/background.ts
+++ b/src/extension/provider/background.ts
@@ -1,4 +1,5 @@
-import vscode, { window, EventEmitter, NotebookCellStatusBarItem, NotebookCellStatusBarAlignment } from 'vscode'
+import type vscode from 'vscode'
+import { window, EventEmitter, NotebookCellStatusBarItem, NotebookCellStatusBarAlignment, tasks } from 'vscode'
 
 import { getAnnotations, getTerminalByCell } from '../utils'
 
@@ -82,7 +83,7 @@ export class StopBackgroundTaskProvider implements vscode.NotebookCellStatusBarI
 
   constructor() {
     this.disposables.push(
-      vscode.tasks.onDidEndTaskProcess(() => {
+      tasks.onDidEndTaskProcess(() => {
         this._onDidChangeCellStatusBarItems.fire()
       })
     )
@@ -100,7 +101,7 @@ export class StopBackgroundTaskProvider implements vscode.NotebookCellStatusBarI
     /**
      * don't show if not a background task & if not command currently running
      */
-    if (!annotations.background || !annotations.interactive || !cell.executionSummary?.success) {
+    if (!annotations.background || !annotations.interactive) {
       return
     }
 

--- a/src/extension/provider/background.ts
+++ b/src/extension/provider/background.ts
@@ -74,7 +74,7 @@ export class BackgroundTaskProvider implements vscode.NotebookCellStatusBarItemP
     return item
   }
 }
-export class StopBackgroundTaskProvider implements vscode.NotebookCellStatusBarItemProvider {
+export class StopBackgroundTaskProvider implements vscode.NotebookCellStatusBarItemProvider, vscode.Disposable {
   private _onDidChangeCellStatusBarItems = new EventEmitter<void>()
   onDidChangeCellStatusBarItems = this._onDidChangeCellStatusBarItems.event
 
@@ -106,8 +106,7 @@ export class StopBackgroundTaskProvider implements vscode.NotebookCellStatusBarI
 
     const terminal = getTerminalByCell(cell)
 
-    // TODO: `terminal.exitStatus` does not appear to work
-    if (!terminal || terminal.exitStatus) { return }
+    if (!terminal || (terminal.runnerSession?.hasExited() !== undefined)) { return }
 
     const item = new NotebookCellStatusBarItem(
       '$(circle-slash) Stop Task',

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -20,7 +20,7 @@ import { SafeCellAnnotationsSchema, CellAnnotationsSchema } from '../schema'
 import { SERVER_ADDRESS } from '../constants'
 import { getPortNumber } from '../utils/configuration'
 
-import executor from './executors'
+import type executor from './executors'
 import { Kernel } from './kernel'
 import { ENV_STORE, DEFAULT_ENV } from './constants'
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -15,7 +15,7 @@ import vscode, {
 import { v5 as uuidv5 } from 'uuid'
 import getPort from 'get-port'
 
-import { CellAnnotations, CellAnnotationsErrorResult, Serializer } from '../types'
+import { CellAnnotations, CellAnnotationsErrorResult, RunmeTerminal, Serializer } from '../types'
 import { SafeCellAnnotationsSchema, CellAnnotationsSchema } from '../schema'
 import { SERVER_ADDRESS } from '../constants'
 import { getPortNumber } from '../utils/configuration'
@@ -98,10 +98,10 @@ export function getTerminalRunmeId(t: vscode.Terminal): string|undefined {
     ?? undefined
 }
 
-export function getTerminalByCell(cell: vscode.NotebookCell) {
+export function getTerminalByCell(cell: vscode.NotebookCell): RunmeTerminal | undefined {
   return vscode.window.terminals.find((t) => {
     return getTerminalRunmeId(t) === `${cell.document.fileName}:${cell.index}`
-  })
+  }) as RunmeTerminal | undefined
 }
 
 export function resetEnv() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
-import { NotebookCellKind, TaskDefinition, TerminalDimensions } from 'vscode'
+import { NotebookCellKind, TaskDefinition, Terminal, TerminalDimensions } from 'vscode'
 import { z } from 'zod'
 
 import { OutputType, ClientMessages } from './constants'
 import { SafeCellAnnotationsSchema } from './schema'
+import type { IRunnerProgramSession } from './extension/runner'
 
 export namespace Serializer {
   export type Notebook = {
@@ -154,4 +155,8 @@ export type CellAnnotationsErrorResult = {
 
 export interface DisposableAsync {
   dispose(): Promise<void>
+}
+
+export interface RunmeTerminal extends Terminal {
+  runnerSession?: IRunnerProgramSession
 }

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -14,6 +14,9 @@ import {
   getNotebookTerminalFontSize
 } from '../../src/utils/configuration'
 
+vi.mock('../../src/extension/grpc/client', () => ({}))
+vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
+
 const FAKE_UNIX_EXT_PATH = '/Users/user/.vscode/extension/stateful.runme'
 const FAKE_WIN_EXT_PATH = 'C:\\Users\\.vscode\\extensions\\stateful.runme'
 

--- a/tests/extension/provider/launcher.test.ts
+++ b/tests/extension/provider/launcher.test.ts
@@ -4,6 +4,9 @@ import { commands, Uri, workspace } from 'vscode'
 import { RunmeFile, RunmeLauncherProvider } from '../../../src/extension/provider/launcher'
 import { getDefaultWorkspace } from '../../../src/extension/utils'
 
+vi.mock('../../../src/extension/grpc/client', () => ({}))
+vi.mock('../../../src/extension/grpc/runnerTypes', () => ({}))
+
 vi.mock('vscode')
 vi.mock('vscode-telemetry')
 

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -17,6 +17,9 @@ import {
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
 import { CellAnnotations } from '../../src/types'
 
+vi.mock('../../src/extension/grpc/client', () => ({}))
+vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
+
 vi.mock('vscode', () => ({
   default: {
     window: {


### PR DESCRIPTION
Implements background as singleton instance.

As a bonus, the "Stop Task" button should now disappear when the task either is closed or is otherwise no longer running. This is now possible since it is clear where the associated task is.

At a low-level, this is all accomplished by attaching the grpc runner object instance to the terminal object.