### PR TITLE
Bump `@vitest/coverage-c8` to `v0.30.1` (restore test coverage)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@types/yargs": "^17.0.20",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
         "@typescript-eslint/parser": "^5.49.0",
-        "@vitest/coverage-c8": "^0.29.1",
+        "@vitest/coverage-c8": "^0.30.1",
         "@vscode/vsce": "^2.16.0",
         "@wdio/cli": "^8.2.3",
         "@wdio/local-runner": "^8.2.3",
@@ -5604,20 +5604,20 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@vitest/coverage-c8": {
-      "version": "0.29.7",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.29.7.tgz",
-      "integrity": "sha512-TSubtP9JFBuI/wuApxwknHe40VDkX8hFbBak0OXj4/jCeXrEu5B5GPWcxzyk9YvzXgCaDvoiZV79I7AvhNI9YQ==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.30.1.tgz",
+      "integrity": "sha512-/Wa3dtSuckpdngAmiCwowaEXXgJkqPrtfvrs9HTB9QoEfNbZWPu4E4cjEn4lJZb4qcGf4fxFtUA2f9DnDNAzBA==",
       "dev": true,
       "dependencies": {
         "c8": "^7.13.0",
         "picocolors": "^1.0.0",
-        "std-env": "^3.3.1"
+        "std-env": "^3.3.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
-        "vitest": ">=0.29.0 <1"
+        "vitest": ">=0.30.0 <1"
       }
     },
     "node_modules/@vitest/expect": {
@@ -28267,14 +28267,14 @@
       }
     },
     "@vitest/coverage-c8": {
-      "version": "0.29.7",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.29.7.tgz",
-      "integrity": "sha512-TSubtP9JFBuI/wuApxwknHe40VDkX8hFbBak0OXj4/jCeXrEu5B5GPWcxzyk9YvzXgCaDvoiZV79I7AvhNI9YQ==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.30.1.tgz",
+      "integrity": "sha512-/Wa3dtSuckpdngAmiCwowaEXXgJkqPrtfvrs9HTB9QoEfNbZWPu4E4cjEn4lJZb4qcGf4fxFtUA2f9DnDNAzBA==",
       "dev": true,
       "requires": {
         "c8": "^7.13.0",
         "picocolors": "^1.0.0",
-        "std-env": "^3.3.1"
+        "std-env": "^3.3.2"
       }
     },
     "@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -488,7 +488,7 @@
     "@types/yargs": "^17.0.20",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
-    "@vitest/coverage-c8": "^0.29.1",
+    "@vitest/coverage-c8": "^0.30.1",
     "@vscode/vsce": "^2.16.0",
     "@wdio/cli": "^8.2.3",
     "@wdio/local-runner": "^8.2.3",


### PR DESCRIPTION
This PR restores test coverage

We can also close #401 