### PR TITLE
Fix non-text outputs

### DIFF
--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -113,7 +113,7 @@ export async function executeRunner(
     cwd,
     background,
     tty: interactive,
-    mimeType: mimeType,
+    convertEol: (!mimeType || mimeType === 'text/plain'),
   })
 
   context.subscriptions.push(program)

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -113,7 +113,7 @@ export async function executeRunner(
     cwd,
     background,
     tty: interactive,
-    mimeType: mimeType ?? 'text/plain',
+    mimeType: mimeType,
   })
 
   context.subscriptions.push(program)

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -113,6 +113,7 @@ export async function executeRunner(
     cwd,
     background,
     tty: interactive,
+    mimeType: mimeType ?? 'text/plain',
   })
 
   context.subscriptions.push(program)

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -118,7 +118,7 @@ export class RunmeTaskProvider implements TaskProvider {
       cwd,
       environment,
       tty: interactive,
-      mimeType: mimeType ?? 'text/plain',
+      mimeType: mimeType,
     }
 
     if (!environment) {

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -101,7 +101,7 @@ export class RunmeTaskProvider implements TaskProvider {
       path.relative(workspace.workspaceFolders[0].uri.fsPath, filePath) :
       path.basename(filePath)
 
-    const { interactive, background, mimeType } = getAnnotations(cell.metadata)
+    const { interactive, background } = getAnnotations(cell.metadata)
 
     const cwd = options.cwd || path.dirname(filePath)
     const isBackground = options.isBackground || background
@@ -118,7 +118,7 @@ export class RunmeTaskProvider implements TaskProvider {
       cwd,
       environment,
       tty: interactive,
-      mimeType: mimeType,
+      convertEol: true,
     }
 
     if (!environment) {

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -101,7 +101,7 @@ export class RunmeTaskProvider implements TaskProvider {
       path.relative(workspace.workspaceFolders[0].uri.fsPath, filePath) :
       path.basename(filePath)
 
-    const { interactive, background } = getAnnotations(cell.metadata)
+    const { interactive, background, mimeType } = getAnnotations(cell.metadata)
 
     const cwd = options.cwd || path.dirname(filePath)
     const isBackground = options.isBackground || background
@@ -118,6 +118,7 @@ export class RunmeTaskProvider implements TaskProvider {
       cwd,
       environment,
       tty: interactive,
+      mimeType: mimeType ?? 'text/plain',
     }
 
     if (!environment) {

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -47,7 +47,6 @@ export interface RunProgramOptions {
   terminalDimensions?: TerminalDimensions
   background?: boolean
   convertEol?: boolean
-  mimeType?: string
 }
 
 export interface IRunner extends Disposable {
@@ -442,8 +441,7 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
   protected write(channel: 'stdout'|'stderr', bytes: Uint8Array): void {
     if (
       this.convertEol &&
-      !this.isPseudoterminal() &&
-      (!this.opts.mimeType || this.opts.mimeType === 'text/plain')
+      !this.isPseudoterminal()
     ) {
       const newBytes = new Array(bytes.byteLength)
 

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -443,7 +443,7 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
     if (
       this.convertEol &&
       !this.isPseudoterminal() &&
-      this.opts.mimeType === 'text/plain'
+      (!this.opts.mimeType || this.opts.mimeType === 'text/plain')
     ) {
       const newBytes = new Array(bytes.byteLength)
 

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -47,6 +47,7 @@ export interface RunProgramOptions {
   terminalDimensions?: TerminalDimensions
   background?: boolean
   convertEol?: boolean
+  mimeType?: string
 }
 
 export interface IRunner extends Disposable {
@@ -439,7 +440,11 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
   } as const
 
   protected write(channel: 'stdout'|'stderr', bytes: Uint8Array): void {
-    if (this.convertEol && !this.isPseudoterminal()) {
+    if (
+      this.convertEol &&
+      !this.isPseudoterminal() &&
+      this.opts.mimeType === 'text/plain'
+    ) {
       const newBytes = new Array(bytes.byteLength)
 
       let i = 0, j = 0


### PR DESCRIPTION
Non-text outputs are broken due to #445, since we're mangling all non-interactive outputs.

This PR now only does the convert eol functionality on non-interactive cells with type `text/plain`