### PR TITLE
Use runme for setting up test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: coactions/setup-xvfb@v1
+      - name: 🧪 Setup and Test with Runme
+        uses: coactions/setup-xvfb@v1
         with:
           run: |
             npm i -g runme
@@ -19,7 +20,8 @@ jobs:
             npx runme run --filename=CONTRIBUTING.md test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - name: 🔼 Upload Artifacts
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,10 @@ jobs:
         with:
           run: |
             npm i -g runme
-            npx runme2 configureNPM setup build test
+            npx runme run --filename=CONTRIBUTING.md configureNPM
+            npx runme run --filename=CONTRIBUTING.md setup
+            npx runme run --filename=CONTRIBUTING.md build
+            npx runme run --filename=CONTRIBUTING.md test
           working-directory: ${{ env.GITHUB_WORKSPACE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - run: |
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+          echo -n 'nvm "$@" && echo $NVM_BIN >> $GITHUB_PATH' >>  ~/.nvm/nvm.sh
+          sudo cp ~/.nvm/nvm.sh /usr/local/bin/nvm
+          sudo chmod +x /usr/local/bin/nvm
+      - uses: coactions/setup-xvfb@v1
         with:
-          node-version: 18
-      - name: 📦 Install Dependencies
-        run: npm install
+          run: |
+            npm i -g runme
+            npx runme2 configureNPM setup build test
+          working-directory: ${{ env.GITHUB_WORKSPACE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 🏗 Build Project
-        run: npm run build:dev
-      - name: 🧪 Run Tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: npm test
-          options: "-screen 0 1600x1200x24"
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
             npx runme run --filename=CONTRIBUTING.md setup
             npx runme run --filename=CONTRIBUTING.md build
             npx runme run --filename=CONTRIBUTING.md test
-          working-directory: ${{ env.GITHUB_WORKSPACE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - run: |
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-          echo -n 'nvm "$@" && echo $NVM_BIN >> $GITHUB_PATH' >>  ~/.nvm/nvm.sh
-          sudo cp ~/.nvm/nvm.sh /usr/local/bin/nvm
-          sudo chmod +x /usr/local/bin/nvm
       - uses: coactions/setup-xvfb@v1
         with:
           run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ To get the code base, have [git](https://git-scm.com/downloads) installed and ru
 
 ```sh
 git clone git@github.com:stateful/vscode-runme.git
+cd vscode-runme
+nvm install
 ```
 
 optionally install the GitHub CLI to streamline downloading the WASM binary:
@@ -69,15 +71,13 @@ brew install gh
 
 make sure to configure your local npm to pull from Buf's registry (for GRPC dependencies)
 
-```sh
+```sh { name=configureNPM }
 npm config set @buf:registry https://buf.build/gen/npm/v1
 ```
 
-then ensure to install all project dependencies:
+then ensure to install all project dependencies.
 
-```sh
-cd vscode-runme
-nvm install
+```sh { name=setup }
 GITHUB_REF_NAME=$(git branch --show-current) GITHUB_TOKEN=$(gh auth token) npm install --include=dev
 ```
 
@@ -93,7 +93,7 @@ DOWNLOAD_URL=$(node .github/scripts/getLastStableRelease) TYPE=tar npm run prepa
 
 To compile all extension files, run:
 
-```sh
+```sh { name=build }
 npm run build
 ```
 
@@ -101,7 +101,7 @@ npm run build
 
 To test the project, run:
 
-```sh
+```sh { name=test }
 npm run test
 ```
 


### PR DESCRIPTION
Instead of re-defining our set-up process in CI again, let's use Runme to re-purpose our documentation.

### Note

I currently use the original CLI:

```sh
npx runme run --filename=CONTRIBUTING.md configureNPM
npx runme run --filename=CONTRIBUTING.md setup
npx runme run --filename=CONTRIBUTING.md build
npx runme run --filename=CONTRIBUTING.md test
```

instead of the experimental one:

```sh
npx runme2 configureNPM setup build test
```

Let me know if you prefer the experimental one instead.