### PR TITLE
Update cell names on save

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -222,6 +222,12 @@ export class EventEmitter<T> {
     this.listeners.forEach(l => l(data))
   }
 
+  async fireAsync(data: T) {
+    await Promise.all(
+      this.listeners.map(l => l(data))
+    )
+  }
+
   dispose() { }
 }
 

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -28,7 +28,6 @@ import { IRunner, IRunnerEnvironment } from './runner'
 import { executeRunner } from './executors/runner'
 import { ITerminalState, NotebookTerminalType } from './terminal/terminalState'
 import { NotebookCellManager, NotebookCellOutputManager, RunmeNotebookCellExecution } from './cell'
-import { SerializerBase } from './serializer'
 
 enum ConfirmationItems {
   Yes = 'Yes',
@@ -55,8 +54,6 @@ export class Kernel implements Disposable {
   protected runnerReadyListener?: Disposable
 
   protected cellManager = new NotebookCellManager(this.#controller)
-
-  protected serializer?: SerializerBase
 
   constructor(
     protected context: ExtensionContext
@@ -93,10 +90,6 @@ export class Kernel implements Disposable {
     this.#controller.dispose()
     this.#disposables.forEach((d) => d.dispose())
     this.runnerReadyListener?.dispose()
-  }
-
-  registerSerializer(serializer: SerializerBase) {
-    this.serializer = serializer
   }
 
   async getTerminalState(cell: NotebookCell): Promise<ITerminalState|undefined> {

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -93,18 +93,17 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
 
     const notebookEdits = deserialized.cells.flatMap((updatedCell, i) => {
       const updatedName = (updatedCell.metadata as Serializer.Metadata|undefined)?.['runme.dev/name']
-      if (updatedName) {
-        const oldCell = cellAt(i)
-
-        return [
-            NotebookEdit.updateCellMetadata(i, {
-            ...oldCell.metadata || {},
-            'runme.dev/name': updatedName,
-          } as Serializer.Metadata)
-        ]
+      if (!updatedName) {
+        return []
       }
 
-      return []
+      const oldCell = cellAt(i)
+      return [
+        NotebookEdit.updateCellMetadata(i, {
+          ...oldCell.metadata || {},
+          'runme.dev/name': updatedName,
+        } as Serializer.Metadata)
+      ]
     })
 
     const edit = new WorkspaceEdit()

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -92,7 +92,7 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
     const deserialized = await this.deserializeNotebook(bytes, new CancellationTokenSource().token)
 
     const notebookEdits = deserialized.cells.flatMap((updatedCell, i) => {
-      const updatedName: string|undefined = (updatedCell.metadata as Serializer.Metadata|undefined)?.['runme.dev/name']
+      const updatedName = (updatedCell.metadata as Serializer.Metadata|undefined)?.['runme.dev/name']
       if (updatedName) {
         const oldCell = cellAt(i)
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -52,7 +52,6 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
         this.handleNotebookSaved.bind(this)
       )
     )
-    kernel.registerSerializer(this)
   }
 
   public dispose() {

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -32,9 +32,7 @@ vi.mock('../../src/extension/utils', () => ({
 }))
 
 function newKernel(): Kernel {
-  return {
-    registerSerializer: vi.fn(),
-  } as unknown as Kernel
+  return { } as unknown as Kernel
 }
 
 describe('WasmSerializer', () => {


### PR DESCRIPTION
Fixes #461 

In the future we should probably return a more detailed response from the serialize request, and then use that to update the metadata.