### PR TITLE
Prefer `vscode.openWith` over `vscode.open`

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -144,7 +144,7 @@ export class RunmeExtension {
         const bootFile = new TextDecoder().decode(await workspace.fs.readFile(startupFileUri))
         const bootFileUri = Uri.joinPath(workspace.workspaceFolders[0].uri, bootFile)
         await workspace.fs.delete(startupFileUri)
-        await commands.executeCommand('vscode.open', bootFileUri)
+        await commands.executeCommand('vscode.openWith', bootFileUri, Kernel.type)
       }
     }
   }

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -58,7 +58,7 @@ test('initializes all providers', async () => {
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
 
-  expect(commands.executeCommand).toBeCalledWith('vscode.open', '/foo/bar')
+  expect(commands.executeCommand).toBeCalledWith('vscode.openWith', '/foo/bar', 'runme')
   expect(workspace.fs.stat).toBeCalledWith('/foo/bar')
   expect(workspace.fs.delete).toBeCalledWith('/foo/bar')
 })


### PR DESCRIPTION
Fixes #432 