### PR TITLE
Parse dotenv files

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -19,7 +19,6 @@ export const notebooks = {
   }),
 }
 
-
 export class Uri extends URI {
   static file = vi.fn(super.file)
   static parse = vi.fn(super.parse)
@@ -51,13 +50,7 @@ export const workspace = {
     onDidCreate: vi.fn(),
     onDidDelete: vi.fn()
   }),
-  workspaceFolders: [
-    {
-      uri: {
-        fsPath: '/runme/workspace',
-      },
-    },
-  ],
+  workspaceFolders: [ { uri: { fsPath: '/runme/workspace' } } ],
   findFiles: vi.fn().mockReturnValue([
     {
       path: 'runme/workspace/README.md',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@vscode/webview-ui-toolkit": "^1.2.1",
         "clipboardy": "^3.0.0",
         "detect-port": "^1.5.1",
+        "dotenv": "^16.0.3",
         "filenamify": "^6.0.0",
         "get-port": "^6.1.2",
         "got": "^12.5.3",

--- a/package.json
+++ b/package.json
@@ -366,6 +366,16 @@
             "type": "boolean",
             "default": true,
             "markdownDescription": "Enable CodeLens support in markdown documents"
+          },
+          "runme.env.workspaceFileOrder": {
+            "type": "array",
+            "default": [ ".env.local", ".env" ],
+            "markdownDescription": "List of workspace environment files to parse in order; variables defined in later files take priority"
+          },
+          "runme.env.loadWorkspaceFiles": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Load environment files from workspace into all scripts"
           }
         }
       }
@@ -545,6 +555,7 @@
     "@vscode/webview-ui-toolkit": "^1.2.1",
     "clipboardy": "^3.0.0",
     "detect-port": "^1.5.1",
+    "dotenv": "^16.0.3",
     "filenamify": "^6.0.0",
     "get-port": "^6.1.2",
     "got": "^12.5.3",

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -20,7 +20,14 @@ import { ClientMessages } from '../../constants'
 import { ClientMessage } from '../../types'
 import { PLATFORM_OS } from '../constants'
 import { IRunner, IRunnerEnvironment, RunProgramExecution } from '../runner'
-import { getAnnotations, getCellRunmeId, getCmdShellSeq, getTerminalByCell, prepareCmdSeq } from '../utils'
+import {
+  getAnnotations,
+  getCellRunmeId,
+  getCmdShellSeq,
+  getTerminalByCell,
+  getWorkspaceEnvs,
+  prepareCmdSeq
+} from '../utils'
 import { postClientMessage } from '../../utils/messaging'
 import { isNotebookTerminalEnabledForCell } from '../../utils/configuration'
 import { Kernel } from '../kernel'
@@ -73,11 +80,12 @@ export async function executeRunner(
 
   const RUNME_ID = getCellRunmeId(exec.cell)
 
-  let cellText = exec.cell.document.getText()
-
   const envs: Record<string, string> = {
-    RUNME_ID
+    RUNME_ID,
+    ...await getWorkspaceEnvs(runningCell.uri),
   }
+
+  let cellText = exec.cell.document.getText()
 
   const commands = await parseCommandSeq(cellText, promptEnv, prepareCmdSeq)
   if(!commands) { return false }

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -392,10 +392,13 @@ export async function getWorkspaceEnvs(uri?: Uri): Promise<Record<string, string
   if (!workspaceFolder || !getEnvLoadWorkspaceFiles()) { return res }
 
   const envFiles = getEnvWorkspaceFileOrder()
+  console.log(envFiles)
 
   const envs = await Promise.all(
     envFiles.map(async (fileName) => {
       const dotEnvFile = Uri.joinPath(workspaceFolder.uri, fileName)
+
+      // console.log(dotEnvFile.fsPath)
 
       return await workspace.fs.stat(dotEnvFile)
         .then(async (f) => {

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -392,13 +392,10 @@ export async function getWorkspaceEnvs(uri?: Uri): Promise<Record<string, string
   if (!workspaceFolder || !getEnvLoadWorkspaceFiles()) { return res }
 
   const envFiles = getEnvWorkspaceFileOrder()
-  console.log(envFiles)
 
   const envs = await Promise.all(
     envFiles.map(async (fileName) => {
       const dotEnvFile = Uri.joinPath(workspaceFolder.uri, fileName)
-
-      // console.log(dotEnvFile.fsPath)
 
       return await workspace.fs.stat(dotEnvFile)
         .then(async (f) => {

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -9,8 +9,10 @@ import { getAnnotations, isWindows } from '../extension/utils'
 import { SERVER_PORT } from '../constants'
 
 const SERVER_SECTION_NAME = 'runme.server'
-const TERMINAL_SECTION_NAME= 'runme.terminal'
-const CODELENS_SECTION_NAME= 'runme.codelens'
+const TERMINAL_SECTION_NAME = 'runme.terminal'
+const CODELENS_SECTION_NAME = 'runme.codelens'
+const ENV_SECTION_NAME = 'runme.env'
+
 export const DEFAULT_TLS_DIR = path.join(os.tmpdir(), 'runme', uuidv4(), 'tls')
 
 type NotebookTerminalValue = keyof typeof configurationSchema.notebookTerminal
@@ -45,6 +47,10 @@ const configurationSchema = {
     },
     codelens: {
       enable: z.boolean().default(true)
+    },
+    env: {
+      workspaceFileOrder: z.array(z.string()).default([ '.env.local', '.env' ]),
+      loadWorkspaceFiles: z.boolean().default(true),
     }
 }
 
@@ -72,6 +78,16 @@ const getCodeLensConfigurationValue = <T>(configName: keyof typeof configuration
   const configurationSection = workspace.getConfiguration(CODELENS_SECTION_NAME)
   const configurationValue = configurationSection.get<T>(configName)!
   const parseResult = configurationSchema.codelens[configName].safeParse(configurationValue)
+  if (parseResult.success) {
+      return parseResult.data as T
+  }
+  return defaultValue
+}
+
+const getEnvConfigurationValue = <T>(configName: keyof typeof configurationSchema.env, defaultValue: T) => {
+  const configurationSection = workspace.getConfiguration(ENV_SECTION_NAME)
+  const configurationValue = configurationSection.get<T>(configName)!
+  const parseResult = configurationSchema.env[configName].safeParse(configurationValue)
   if (parseResult.success) {
       return parseResult.data as T
   }
@@ -160,6 +176,14 @@ const registerExtensionEnvironmentVariables = (context: ExtensionContext): void 
   )
 }
 
+const getEnvWorkspaceFileOrder = (): string[] => {
+  return getEnvConfigurationValue('workspaceFileOrder', [])
+}
+
+const getEnvLoadWorkspaceFiles = (): boolean => {
+  return getEnvConfigurationValue('loadWorkspaceFiles', true)
+}
+
 export {
     getPortNumber,
     getBinaryPath,
@@ -175,4 +199,6 @@ export {
     getCodeLensEnabled,
     registerExtensionEnvironmentVariables,
     getCustomServerAddress,
+    getEnvWorkspaceFileOrder,
+    getEnvLoadWorkspaceFiles,
 }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -14,6 +14,7 @@ const CODELENS_SECTION_NAME = 'runme.codelens'
 const ENV_SECTION_NAME = 'runme.env'
 
 export const DEFAULT_TLS_DIR = path.join(os.tmpdir(), 'runme', uuidv4(), 'tls')
+const DEFAULT_WORKSPACE_FILE_ORDER = ['.env.local', '.env']
 
 type NotebookTerminalValue = keyof typeof configurationSchema.notebookTerminal
 
@@ -49,7 +50,7 @@ const configurationSchema = {
       enable: z.boolean().default(true)
     },
     env: {
-      workspaceFileOrder: z.array(z.string()).default([ '.env.local', '.env' ]),
+      workspaceFileOrder: z.array(z.string()).default(DEFAULT_WORKSPACE_FILE_ORDER),
       loadWorkspaceFiles: z.boolean().default(true),
     }
 }
@@ -177,7 +178,7 @@ const registerExtensionEnvironmentVariables = (context: ExtensionContext): void 
 }
 
 const getEnvWorkspaceFileOrder = (): string[] => {
-  return getEnvConfigurationValue('workspaceFileOrder', [])
+  return getEnvConfigurationValue('workspaceFileOrder', DEFAULT_WORKSPACE_FILE_ORDER)
 }
 
 const getEnvLoadWorkspaceFiles = (): boolean => {

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -349,6 +349,10 @@ suite('getWorkspaceFolder', () => {
     workspace.workspaceFolders = []
   })
 
+  test('is empty if no workspace folder', async () => {
+    expect(await getWorkspaceEnvs()).toStrictEqual({ })
+  })
+
   test('identifies correct workspace', () => {
     const workspaceFolder1 = { uri: Uri.file('/foo/bar') }
     const workspaceFolder2 = { uri: Uri.file('/bar/foo') }

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -1,4 +1,4 @@
-import vscode, { commands, workspace } from 'vscode'
+import vscode, { FileType, Uri, commands, workspace } from 'vscode'
 import { expect, vi, test, beforeEach, beforeAll, afterAll, suite } from 'vitest'
 import { v4 } from 'uuid'
 
@@ -15,6 +15,8 @@ import {
   getGrpcHost,
   prepareCmdSeq,
   openFileAsRunmeNotebook,
+  getWorkspaceFolder,
+  getWorkspaceEnvs,
 } from '../../src/extension/utils'
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
 import { CellAnnotations } from '../../src/types'
@@ -24,11 +26,13 @@ vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
 
 vi.mock('vscode', async () => {
   const { v4 } = await vi.importActual('uuid') as typeof import('uuid')
+  const mocked = await vi.importActual('../../__mocks__/vscode') as any
 
   const uuid1 = v4()
   const uuid2 = v4()
 
   return ({
+    ...mocked,
     default: {
       window: {
         terminals: [
@@ -37,7 +41,9 @@ vi.mock('vscode', async () => {
         ]
       },
       workspace: {
-        getConfiguration: vi.fn()
+        getConfiguration: vi.fn(),
+        workspaceFolders: [],
+        fs: mocked.workspace.fs,
       },
       env: {
         machineId: 'test-machine-id'
@@ -48,7 +54,9 @@ vi.mock('vscode', async () => {
       }
     },
     workspace: {
-      getConfiguration: vi.fn()
+      getConfiguration: vi.fn(),
+      fs: mocked.workspace.fs,
+      workspaceFolders: [],
     },
     commands: {
       executeCommand: vi.fn()
@@ -332,5 +340,64 @@ suite('openFileAsRunmeNotebook', () => {
 
     expect(commands.executeCommand).toBeCalledTimes(1)
     expect(commands.executeCommand).toBeCalledWith('vscode.openWith', uri, 'runme')
+  })
+})
+
+suite('getWorkspaceFolder', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    workspace.workspaceFolders = []
+  })
+
+  test('identifies correct workspace', () => {
+    const workspaceFolder1 = { uri: Uri.file('/foo/bar') }
+    const workspaceFolder2 = { uri: Uri.file('/bar/foo') }
+    const workspaceFolder3 = { uri: Uri.file('/bar/baz') }
+
+    // @ts-ignore
+    workspace.workspaceFolders = [
+      workspaceFolder1,
+      workspaceFolder2,
+      workspaceFolder3,
+    ]
+
+    expect(getWorkspaceFolder()).toBe(workspaceFolder1)
+    expect(getWorkspaceFolder(Uri.file('/bar/baz/.env'))).toBe(workspaceFolder3)
+  })
+})
+
+suite('getWorkspaceEnvs', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    workspace.workspaceFolders = []
+
+    vi.mocked(workspace.fs.stat).mockReset()
+    vi.mocked(workspace.fs.readFile).mockReset()
+  })
+
+  test('identifies env files', async () => {
+    const workspaceFolder = { uri: Uri.file('/foo/bar') }
+
+    vi.mocked(workspace.fs.stat).mockResolvedValue({ type: FileType.File } as any)
+    vi.mocked(workspace.fs.readFile).mockImplementation(async (uri) => {
+      if (uri.fsPath === '/foo/bar/.env') {
+        return Buffer.from('SECRET_1=secret1_override\nSECRET_2=secret2\n')
+      } else if (uri.fsPath === '/foo/bar/.env.local') {
+        return Buffer.from('SECRET_1=secret1\nSECRET_3=secret3')
+      }
+
+      return Buffer.from([])
+    })
+
+    // @ts-ignore
+    workspace.workspaceFolders = [
+      workspaceFolder,
+    ]
+
+    expect(await getWorkspaceEnvs(workspaceFolder.uri)).toStrictEqual({
+      SECRET_1: 'secret1_override',
+      SECRET_2: 'secret2',
+      SECRET_3: 'secret3',
+    })
   })
 })


### PR DESCRIPTION
Gives the user configuration to set dotenv file schema, and to toggle it in general.

Part of stateful/runme#234

Note that environment variables set in dotenv files "persist," so even if you delete it from a dotenv file, it will still exist in the runner session. Fixing this will require changes to the behavior and/or API of the grpc server.