### PR TITLE
Close cell output

### DIFF
--- a/src/client/components/annotations.ts
+++ b/src/client/components/annotations.ts
@@ -4,7 +4,7 @@ import { when } from 'lit/directives/when.js'
 
 import { ClientMessages, OutputType } from '../../constants'
 import type { ClientMessage, CellAnnotations, CellAnnotationsErrorResult } from '../../types'
-import { getContext } from '../utils'
+import { closeOutput, getContext } from '../utils'
 import { CellAnnotationsSchema, AnnotationSchema } from '../../schema'
 
 import './closeCellButton'
@@ -102,9 +102,6 @@ export class Annotations extends LitElement {
   @property({ type: Object, reflect: true })
   validationErrors?: CellAnnotationsErrorResult
 
-  @property({ type: Number })
-  cellIndex?: number
-
   #desc(id: string): string {
     return this.#descriptions.get(id) || id
   }
@@ -192,7 +189,7 @@ export class Annotations extends LitElement {
       type="text"
       value="${text}"
       @change="${this.#onChange}"
-      @keyup="${ this.#onChange}"
+      @keyup="${this.#onChange}"
       placeholder=${placeHolder}
       size="50"
       class="annotation-item"
@@ -256,7 +253,12 @@ export class Annotations extends LitElement {
     <section class="annotation-container ${errorCount ? 'has-errors' : ''}">
       <h4>Configure cell's execution behavior:</h4>
       ${markup}
-      <close-cell-button cellIndex="${this.cellIndex}" outputType="${OutputType.annotations}" />
+      <close-cell-button @closed="${() => {
+        return closeOutput({
+          uuid: (this.annotations && this.annotations['runme.dev/uuid']) || '',
+          outputType: OutputType.annotations
+        })
+      } }" />
       ${when(
       errorCount,
       () => html`<p class="error-item">This configuration block contains errors, using the default values instead</p>`,

--- a/src/client/components/annotations.ts
+++ b/src/client/components/annotations.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
-import { ClientMessages } from '../../constants'
+import { ClientMessages, OutputType } from '../../constants'
 import type { ClientMessage, CellAnnotations, CellAnnotationsErrorResult } from '../../types'
 import { getContext } from '../utils'
 import { CellAnnotationsSchema, AnnotationSchema } from '../../schema'
@@ -37,7 +37,7 @@ export class Annotations extends LitElement {
       flex-direction: column;
       align-items: flex-start;
       gap: 1rem;
-      width: 94%;
+      width: inherited;
       position: relative;
     }
 
@@ -256,7 +256,7 @@ export class Annotations extends LitElement {
     <section class="annotation-container ${errorCount ? 'has-errors' : ''}">
       <h4>Configure cell's execution behavior:</h4>
       ${markup}
-      <close-cell-button cellIndex="${this.cellIndex}" />
+      <close-cell-button cellIndex="${this.cellIndex}" outputType="${OutputType.annotations}" />
       ${when(
       errorCount,
       () => html`<p class="error-item">This configuration block contains errors, using the default values instead</p>`,

--- a/src/client/components/annotations.ts
+++ b/src/client/components/annotations.ts
@@ -6,7 +6,8 @@ import { ClientMessages } from '../../constants'
 import type { ClientMessage, CellAnnotations, CellAnnotationsErrorResult } from '../../types'
 import { getContext } from '../utils'
 import { CellAnnotationsSchema, AnnotationSchema } from '../../schema'
-import '@vscode/webview-ui-toolkit/dist/data-grid/index'
+
+import './closeCellButton'
 
 type AnnotationsMutation = Partial<CellAnnotations>
 type AnnotationsKey = keyof typeof AnnotationSchema
@@ -37,6 +38,7 @@ export class Annotations extends LitElement {
       align-items: flex-start;
       gap: 1rem;
       width: 94%;
+      position: relative;
     }
 
     .annotation-container h4 {
@@ -99,6 +101,9 @@ export class Annotations extends LitElement {
 
   @property({ type: Object, reflect: true })
   validationErrors?: CellAnnotationsErrorResult
+
+  @property({ type: Number })
+  cellIndex?: number
 
   #desc(id: string): string {
     return this.#descriptions.get(id) || id
@@ -247,9 +252,11 @@ export class Annotations extends LitElement {
       </div>`
     })
 
-    return html`<section class="annotation-container ${errorCount ? 'has-errors' : ''}">
+    return html`
+    <section class="annotation-container ${errorCount ? 'has-errors' : ''}">
       <h4>Configure cell's execution behavior:</h4>
       ${markup}
+      <close-cell-button cellIndex="${this.cellIndex}" />
       ${when(
       errorCount,
       () => html`<p class="error-item">This configuration block contains errors, using the default values instead</p>`,

--- a/src/client/components/closeCellButton.ts
+++ b/src/client/components/closeCellButton.ts
@@ -1,0 +1,91 @@
+import { LitElement, css, html } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+
+import { getContext } from '../utils'
+import { postClientMessage } from '../../utils/messaging'
+import { ClientMessages } from '../../constants'
+
+@customElement('close-cell-button')
+export class CloseCellButton extends LitElement {
+
+    /* eslint-disable */
+    static styles = css`
+        :host {
+            --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
+            --tooltip-background: #343434;
+        }
+
+        .close-button {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            border-radius: 5px;
+            border: solid 1px var(--vscode-focusBorder);
+        }
+
+        @media (prefers-color-scheme: light) {
+            .icon-close {
+                background-image: url("data:image/svg+xml,%0A%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.00028 8.70711L11.6467 12.3536L12.3538 11.6465L8.70739 8.00001L12.3538 4.35356L11.6467 3.64645L8.00028 7.2929L4.35384 3.64645L3.64673 4.35356L7.29317 8.00001L3.64673 11.6465L4.35384 12.3536L8.00028 8.70711Z' fill='%23424242'/%3E%3C/svg%3E%0A");
+            }
+        }
+        
+        @media (prefers-color-scheme: dark) {
+            .icon-close {
+                background-image: url("data:image/svg+xml,%0A%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.00004 8.70711L11.6465 12.3536L12.3536 11.6465L8.70714 8.00001L12.3536 4.35356L11.6465 3.64645L8.00004 7.2929L4.35359 3.64645L3.64648 4.35356L7.29293 8.00001L3.64648 11.6465L4.35359 12.3536L8.00004 8.70711Z' fill='%23C5C5C5'/%3E%3C/svg%3E%0A");
+            }
+        }
+        
+        .tooltip .tooltiptext {
+            visibility: hidden;
+            width: 50px;
+            background-color: var(--tooltip-background);
+            color: #fff;
+            text-align: center;
+            padding: 5px 0;
+            position: absolute;
+            z-index: 1;
+            bottom: 150%;
+            right: -60%;
+            margin-left: -60px;
+            top: 126%;
+            height:15px;
+            box-shadow:2px 2px 4px -2px var(--vscode-input-border);
+        }
+        
+        .tooltip .tooltiptext::after {
+            content: " ";
+            position: absolute;
+            bottom: 100%;  /* At the top of the tooltip */
+            left: 50%;
+            margin-left: -5px;
+            border-width: 5px;
+            border-style: solid;
+            border-color: transparent transparent var(--tooltip-background) transparent;
+        }
+        
+        .tooltip:hover .tooltiptext {
+            visibility: visible;
+        }
+    `
+
+    @property({ type: Number })
+    cellIndex?: number
+
+    private close() {
+        const ctx = getContext()
+        ctx.postMessage && postClientMessage(ctx, ClientMessages.closeCellOutput, {
+            cellIndex: this.cellIndex!
+        })
+    }
+
+    render() {
+        return html`
+        <div class='close-button tooltip'>
+            <span class="tooltiptext">Close</span>
+            <vscode-button appearance='icon' aria-label='Close' @click='${this.close}'>
+                <span class='icon icon-close'></span>
+            </vscode-button>
+        </div>
+        `
+    }
+}

--- a/src/client/components/closeCellButton.ts
+++ b/src/client/components/closeCellButton.ts
@@ -3,7 +3,7 @@ import { customElement, property } from 'lit/decorators.js'
 
 import { getContext } from '../utils'
 import { postClientMessage } from '../../utils/messaging'
-import { ClientMessages } from '../../constants'
+import { ClientMessages, OutputType } from '../../constants'
 
 @customElement('close-cell-button')
 export class CloseCellButton extends LitElement {
@@ -62,7 +62,7 @@ export class CloseCellButton extends LitElement {
             border-style: solid;
             border-color: transparent transparent var(--tooltip-background) transparent;
         }
-        
+
         .tooltip:hover .tooltiptext {
             visibility: visible;
         }
@@ -71,10 +71,14 @@ export class CloseCellButton extends LitElement {
     @property({ type: Number })
     cellIndex?: number
 
+    @property()
+    outputType?: OutputType
+
     private close() {
         const ctx = getContext()
         ctx.postMessage && postClientMessage(ctx, ClientMessages.closeCellOutput, {
-            cellIndex: this.cellIndex!
+            cellIndex: this.cellIndex!,
+            outputType: this.outputType!
         })
     }
 

--- a/src/client/components/closeCellButton.ts
+++ b/src/client/components/closeCellButton.ts
@@ -1,10 +1,5 @@
 import { LitElement, css, html } from 'lit'
-import { customElement, property } from 'lit/decorators.js'
-
-import { getContext } from '../utils'
-import { postClientMessage } from '../../utils/messaging'
-import { ClientMessages, OutputType } from '../../constants'
-
+import { customElement } from 'lit/decorators.js'
 @customElement('close-cell-button')
 export class CloseCellButton extends LitElement {
 
@@ -15,12 +10,18 @@ export class CloseCellButton extends LitElement {
             --tooltip-background: #343434;
         }
 
+        .close-button  .control { 
+            outline: none;
+        }
+
         .close-button {
             position: absolute;
             top: 5px;
             right: 5px;
-            border-radius: 5px;
-            border: solid 1px var(--vscode-focusBorder);
+        }
+
+        .close-button, .close-button:hover {
+            border: none;
         }
 
         @media (prefers-color-scheme: light) {
@@ -63,30 +64,32 @@ export class CloseCellButton extends LitElement {
             border-color: transparent transparent var(--tooltip-background) transparent;
         }
 
+        .tooltip .tooltiptext {
+            transition-delay: 1s;
+        }
+
         .tooltip:hover .tooltiptext {
             visibility: visible;
         }
+
+        .tooltip:not(:hover) .tooltiptext {
+            transition-delay: 0s;
+        }
     `
 
-    @property({ type: Number })
-    cellIndex?: number
-
-    @property()
-    outputType?: OutputType
-
-    private close() {
-        const ctx = getContext()
-        ctx.postMessage && postClientMessage(ctx, ClientMessages.closeCellOutput, {
-            cellIndex: this.cellIndex!,
-            outputType: this.outputType!
-        })
+    private onClose(e: Event) {
+        if (e.defaultPrevented) {
+            e.preventDefault()
+        }
+        const event = new CustomEvent('closed')
+        this.dispatchEvent(event)
     }
 
     render() {
         return html`
         <div class='close-button tooltip'>
             <span class="tooltiptext">Close</span>
-            <vscode-button appearance='icon' aria-label='Close' @click='${this.close}'>
+            <vscode-button class="control" appearance='icon' aria-label='Close' @click='${this.onClose}'>
                 <span class='icon icon-close'></span>
             </vscode-button>
         </div>

--- a/src/client/components/outputItems.ts
+++ b/src/client/components/outputItems.ts
@@ -5,7 +5,9 @@ import '@vscode/webview-ui-toolkit/dist/button/index'
 
 import { getContext } from '../utils'
 import { ClientMessage } from '../../types'
-import { ClientMessages } from '../../constants'
+import { ClientMessages, OutputType } from '../../constants'
+
+import './closeCellButton'
 
 @customElement('shell-output-items')
 export class ShellOutputItems extends LitElement {
@@ -37,9 +39,13 @@ export class ShellOutputItems extends LitElement {
   @property({ type: String })
   content = ''
 
+  @property({ type: Number })
+  cellIndex?: number
+
   // Render the UI as a function of component state
   render() {
     return html`<section class="output-items">
+      <close-cell-button cellIndex="${this.cellIndex}" outputType="${OutputType.outputItems}" />
       <vscode-button appearance="secondary" @click="${this.#copy}">
         <svg
           class="icon" width="16" height="16" viewBox="0 0 16 16"

--- a/src/client/components/outputItems.ts
+++ b/src/client/components/outputItems.ts
@@ -3,7 +3,7 @@ import { customElement, property } from 'lit/decorators.js'
 
 import '@vscode/webview-ui-toolkit/dist/button/index'
 
-import { getContext } from '../utils'
+import { closeOutput, getContext } from '../utils'
 import { ClientMessage } from '../../types'
 import { ClientMessages, OutputType } from '../../constants'
 
@@ -39,13 +39,18 @@ export class ShellOutputItems extends LitElement {
   @property({ type: String })
   content = ''
 
-  @property({ type: Number })
-  cellIndex?: number
+  @property({ type: String })
+  uuid?: string
 
   // Render the UI as a function of component state
   render() {
     return html`<section class="output-items">
-      <close-cell-button cellIndex="${this.cellIndex}" outputType="${OutputType.outputItems}" />
+    <close-cell-button @closed="${() => {
+        return closeOutput({
+          uuid: this.uuid!,
+          outputType: OutputType.outputItems
+        })
+      }}" />
       <vscode-button appearance="secondary" @click="${this.#copy}">
         <svg
           class="icon" width="16" height="16" viewBox="0 0 16 16"
@@ -61,7 +66,7 @@ export class ShellOutputItems extends LitElement {
     </span>`
   }
 
-  #copy () {
+  #copy() {
     const ctx = getContext()
 
     if (!ctx.postMessage) {

--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -8,7 +8,7 @@ import { WebLinksAddon } from 'xterm-addon-web-links'
 
 import { FitAddon, type ITerminalDimensions } from '../fitAddon'
 import { ClientMessages, OutputType } from '../../constants'
-import { getContext } from '../utils'
+import { closeOutput, getContext } from '../utils'
 import { onClientMessage, postClientMessage } from '../../utils/messaging'
 import { stripANSI } from '../../utils/ansi'
 
@@ -293,9 +293,6 @@ export class TerminalView extends LitElement {
   @property({ type: Number })
   lastLine?: number // TODO: Get the last line of the terminal and store it.
 
-  @property({ type: Number })
-  cellIndex?: number
-
   constructor() {
     super()
     this.windowSize = {
@@ -447,11 +444,13 @@ export class TerminalView extends LitElement {
     window.addEventListener('mouseup', onMouseUp)
     window.addEventListener('mousemove', onMouseMove)
 
-    this.disposables.push({dispose: () => {
-      dragHandle.removeEventListener('mousedown', onMouseDown)
-      window.removeEventListener('mouseup', onMouseUp)
-      window.removeEventListener('mousemove', onMouseMove)
-    }})
+    this.disposables.push({
+      dispose: () => {
+        dragHandle.removeEventListener('mousedown', onMouseDown)
+        window.removeEventListener('mouseup', onMouseUp)
+        window.removeEventListener('mousemove', onMouseMove)
+      }
+    })
 
     return dragHandle
   }
@@ -528,7 +527,12 @@ export class TerminalView extends LitElement {
   render() {
     return html`<section>
       <div id="terminal"></div>
-      <close-cell-button cellIndex="${this.cellIndex}" outputType="${OutputType.terminal}" />
+      <close-cell-button @closed="${() => {
+        return closeOutput({
+          uuid: this.uuid!,
+          outputType: OutputType.terminal
+        })
+      }}" />
       <div class="button-group">
         <vscode-button appearance="secondary" @click="${this.#copy.bind(this)}">
           <svg
@@ -564,8 +568,8 @@ export class TerminalView extends LitElement {
 
 function convertXTermDimensions(dimensions: ITerminalDimensions): TerminalDimensions
 function convertXTermDimensions(dimensions: undefined): undefined
-function convertXTermDimensions(dimensions: ITerminalDimensions|undefined): TerminalDimensions|undefined
-function convertXTermDimensions(dimensions?: ITerminalDimensions): TerminalDimensions|undefined {
+function convertXTermDimensions(dimensions: ITerminalDimensions | undefined): TerminalDimensions | undefined
+function convertXTermDimensions(dimensions?: ITerminalDimensions): TerminalDimensions | undefined {
   if (!dimensions) { return undefined }
 
   const { rows, cols } = dimensions

--- a/src/client/components/terminal.ts
+++ b/src/client/components/terminal.ts
@@ -7,10 +7,12 @@ import { Unicode11Addon } from 'xterm-addon-unicode11'
 import { WebLinksAddon } from 'xterm-addon-web-links'
 
 import { FitAddon, type ITerminalDimensions } from '../fitAddon'
-import { ClientMessages } from '../../constants'
+import { ClientMessages, OutputType } from '../../constants'
 import { getContext } from '../utils'
 import { onClientMessage, postClientMessage } from '../../utils/messaging'
 import { stripANSI } from '../../utils/ansi'
+
+import './closeCellButton'
 
 interface IWindowSize {
   width: number
@@ -52,6 +54,7 @@ export class TerminalView extends LitElement {
       user-select: none;
       -ms-user-select: none;
       -webkit-user-select: none;
+      border-radius: 5px;
     }
 
     .xterm.focus,
@@ -248,6 +251,7 @@ export class TerminalView extends LitElement {
       display: flex;
       flex-direction: column;
       gap: 5px;
+      position:relative;
     }
 
     .xterm-drag-handle {
@@ -288,6 +292,9 @@ export class TerminalView extends LitElement {
 
   @property({ type: Number })
   lastLine?: number // TODO: Get the last line of the terminal and store it.
+
+  @property({ type: Number })
+  cellIndex?: number
 
   constructor() {
     super()
@@ -521,6 +528,7 @@ export class TerminalView extends LitElement {
   render() {
     return html`<section>
       <div id="terminal"></div>
+      <close-cell-button cellIndex="${this.cellIndex}" outputType="${OutputType.terminal}" />
       <div class="button-group">
         <vscode-button appearance="secondary" @click="${this.#copy.bind(this)}">
           <svg

--- a/src/client/components/vercel.ts
+++ b/src/client/components/vercel.ts
@@ -4,7 +4,7 @@ import { when } from 'lit/directives/when.js'
 
 import { ClientMessages, OutputType } from '../../constants'
 import type { ClientMessage } from '../../types'
-import { getContext } from '../utils'
+import { closeOutput, getContext } from '../utils'
 
 import './closeCellButton'
 
@@ -106,7 +106,12 @@ export class VercelOutput extends LitElement {
           👌 Promoted
         `)}
       </div>
-      <close-cell-button cellIndex="${this.content.payload.index}" outputType="${OutputType.vercel}" />
+      <close-cell-button @closed="${() => {
+        return closeOutput({
+          uuid: this.content.payload.uuid,
+          outputType: OutputType.vercel
+        })
+      }}" />
     </section>`
   }
 

--- a/src/client/components/vercel.ts
+++ b/src/client/components/vercel.ts
@@ -2,9 +2,11 @@ import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
-import { ClientMessages } from '../../constants'
+import { ClientMessages, OutputType } from '../../constants'
 import type { ClientMessage } from '../../types'
 import { getContext } from '../utils'
+
+import './closeCellButton'
 
 @customElement('vercel-output')
 export class VercelOutput extends LitElement {
@@ -26,6 +28,7 @@ export class VercelOutput extends LitElement {
       flex-direction: row;
       gap: 50px;
       align-items: flex-start;
+      position:relative;
     }
 
     img {
@@ -103,6 +106,7 @@ export class VercelOutput extends LitElement {
           👌 Promoted
         `)}
       </div>
+      <close-cell-button cellIndex="${this.content.payload.index}" outputType="${OutputType.vercel}" />
     </section>`
   }
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -55,20 +55,18 @@ export const activate: ActivationFunction = (context: RendererContext<void>) => 
            * output items, e.g. copy to clipboard
            */
           const outputItemElem = document.createElement('shell-output-items')
-          outputItemElem.setAttribute('cellIndex', (payload.output.cellIndex || '').toString())
+          outputItemElem.setAttribute('uuid', payload.output.uuid)
           outputItemElem.setAttribute('content', content)
           element.appendChild(outputItemElem)
           break
         case OutputType.annotations:
           const annoElem = document.createElement('edit-annotations')
-          annoElem.setAttribute('cellIndex', (payload.output.cellIndex || '').toString())
           annoElem.setAttribute('annotations', JSON.stringify(payload.output.annotations ?? []))
           annoElem.setAttribute('validationErrors', JSON.stringify(payload.output.validationErrors ?? []))
           element.appendChild(annoElem)
           break
         case OutputType.terminal:
           const terminalElement = document.createElement('terminal-view')
-          terminalElement.setAttribute('cellIndex', (payload.output.cellIndex || '').toString())
           terminalElement.setAttribute('uuid', payload.output['runme.dev/uuid'])
           terminalElement.setAttribute('terminalFontFamily', payload.output.terminalFontFamily)
           terminalElement.setAttribute('terminalFontSize', payload.output.terminalFontSize.toString())

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -60,6 +60,7 @@ export const activate: ActivationFunction = (context: RendererContext<void>) => 
           break
         case OutputType.annotations:
           const annoElem = document.createElement('edit-annotations')
+          annoElem.setAttribute('cellIndex', (payload.output.cellIndex || '').toString())
           annoElem.setAttribute('annotations', JSON.stringify(payload.output.annotations ?? []))
           annoElem.setAttribute('validationErrors', JSON.stringify(payload.output.validationErrors ?? []))
           element.appendChild(annoElem)

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -55,6 +55,7 @@ export const activate: ActivationFunction = (context: RendererContext<void>) => 
            * output items, e.g. copy to clipboard
            */
           const outputItemElem = document.createElement('shell-output-items')
+          outputItemElem.setAttribute('cellIndex', (payload.output.cellIndex || '').toString())
           outputItemElem.setAttribute('content', content)
           element.appendChild(outputItemElem)
           break
@@ -67,6 +68,7 @@ export const activate: ActivationFunction = (context: RendererContext<void>) => 
           break
         case OutputType.terminal:
           const terminalElement = document.createElement('terminal-view')
+          terminalElement.setAttribute('cellIndex', (payload.output.cellIndex || '').toString())
           terminalElement.setAttribute('uuid', payload.output['runme.dev/uuid'])
           terminalElement.setAttribute('terminalFontFamily', payload.output.terminalFontFamily)
           terminalElement.setAttribute('terminalFontSize', payload.output.terminalFontSize.toString())

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,5 +1,8 @@
 import type { RendererContext } from 'vscode-notebook-renderer'
 
+import { postClientMessage } from '../utils/messaging'
+import { ClientMessages, OutputType } from '../constants'
+
 let context: RendererContext<void> | undefined
 
 export function getContext () {
@@ -11,4 +14,12 @@ export function getContext () {
 
 export function setContext (c: RendererContext<void>) {
   context = c
+}
+
+export function closeOutput({ uuid, outputType}: { uuid: string, outputType: OutputType}) {
+  const ctx = getContext()
+  ctx.postMessage && postClientMessage(ctx, ClientMessages.closeCellOutput, {
+      uuid,
+      outputType
+  })
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export enum OutputType {
 export enum ClientMessages {
   infoMessage = 'common:infoMessage',
   errorMessage = 'common:errorMessage',
+  closeCellOutput = 'common:closeCellOutput',
   denoUpdate = 'deno:deploymentUpdate',
   denoPromote = 'deno:promoteDeployment',
   vercelProd = 'vercel:promotePreview',
@@ -26,7 +27,7 @@ export enum ClientMessages {
   terminalFocus = 'terminal:focus',
   terminalOpen = 'terminal:open',
   openLink = 'terminal:openLink',
-  activeThemeChanged = 'theme:changed'
+  activeThemeChanged = 'theme:changed',
 }
 
 // [pretty print, languageId, destination]

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -154,6 +154,7 @@ export class NotebookCellOutputManager {
               terminalFontSize,
               content: terminalState.serialize(),
               initialRows: getNotebookTerminalRows(),
+              cellIndex: cell.index
             }
           }
 
@@ -166,6 +167,7 @@ export class NotebookCellOutputManager {
             output: {
               content: terminalState.serialize(),
               mime: 'text/plain',
+              cellIndex: cell.index
             }
           }
 

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -94,7 +94,8 @@ export class NotebookCellOutputManager {
           type: OutputType.annotations,
           output: {
             annotations: getAnnotations(cell),
-            validationErrors: validateAnnotations(cell)
+            validationErrors: validateAnnotations(cell),
+            cellIndex: cell.index
           },
         }
 

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -2,10 +2,12 @@ import {
   Disposable,
   NotebookCell,
   NotebookCellExecution,
+  NotebookCellKind,
   NotebookCellOutput,
   NotebookCellOutputItem,
   NotebookController,
   NotebookEdit,
+  NotebookEditor,
   workspace,
   WorkspaceEdit
 } from 'vscode'
@@ -36,7 +38,7 @@ export class NotebookCellManager {
 
   registerCell(cell: NotebookCell): NotebookCellOutputManager {
     const existing = this.#data.get(cell)
-    if(existing) { return existing }
+    if (existing) { return existing }
 
     const outputs = new NotebookCellOutputManager(cell, this.controller)
     this.#data.set(cell, outputs)
@@ -51,7 +53,7 @@ export class NotebookCellManager {
 
   async getNotebookOutputs(cell: NotebookCell): Promise<NotebookCellOutputManager> {
     const outputs = this.#data.get(cell)
-    if(!outputs) {
+    if (!outputs) {
       console.error(`cell at index ${cell.index} has not been registered!`)
     }
 
@@ -60,6 +62,10 @@ export class NotebookCellManager {
 }
 
 type NotebookOutputs = NotebookCellOutput | readonly NotebookCellOutput[]
+interface ICellOption {
+  editor: NotebookEditor
+  uuid: string
+}
 
 export class NotebookCellOutputManager {
   protected outputs: readonly NotebookCellOutput[] = []
@@ -84,18 +90,18 @@ export class NotebookCellOutputManager {
     protected controller: NotebookController
   ) { }
 
-  protected generateOutputUnsafe(type: OutputType): NotebookCellOutput|undefined {
+  protected generateOutputUnsafe(type: OutputType): NotebookCellOutput | undefined {
     const cell = this.cell
     const metadata = cell.metadata as Serializer.Metadata
 
-    switch(type) {
+    switch (type) {
       case OutputType.annotations: {
         const annotationJson: CellOutputPayload<OutputType.annotations> = {
           type: OutputType.annotations,
           output: {
             annotations: getAnnotations(cell),
             validationErrors: validateAnnotations(cell),
-            cellIndex: cell.index
+            uuid: cell.metadata['runme.dev/uuid']
           },
         }
 
@@ -153,8 +159,7 @@ export class NotebookCellOutputManager {
               terminalFontFamily,
               terminalFontSize,
               content: terminalState.serialize(),
-              initialRows: getNotebookTerminalRows(),
-              cellIndex: cell.index
+              initialRows: getNotebookTerminalRows()
             }
           }
 
@@ -167,7 +172,7 @@ export class NotebookCellOutputManager {
             output: {
               content: terminalState.serialize(),
               mime: 'text/plain',
-              cellIndex: cell.index
+              uuid: cellId
             }
           }
 
@@ -208,7 +213,7 @@ export class NotebookCellOutputManager {
     return terminalState
   }
 
-  getCellTerminalState(): ITerminalState|undefined {
+  getCellTerminalState(): ITerminalState | undefined {
     return this.terminalState
   }
 
@@ -235,7 +240,7 @@ export class NotebookCellOutputManager {
           resolve()
         })
 
-        if(wrapper.hasEnded) {
+        if (wrapper.hasEnded) {
           resolve()
         }
       }).finally(resetExecution)
@@ -259,7 +264,7 @@ export class NotebookCellOutputManager {
     await this.showOutput(type, () => !this.hasOutputTypeUnsafe(type))
   }
 
-  async showOutput(type: OutputType, shown: boolean|(() => boolean|Promise<boolean>) = true) {
+  async showOutput(type: OutputType, shown: boolean | (() => boolean | Promise<boolean>) = true) {
     await this.refreshOutputInternal(async () => {
       this.enabledOutputs.set(type, typeof shown === 'function' ? await shown() : shown)
     })
@@ -271,7 +276,7 @@ export class NotebookCellOutputManager {
     })
   }
 
-  async showTerminal(shown: boolean|(() => boolean) = true) {
+  async showTerminal(shown: boolean | (() => boolean) = true) {
     await this.refreshOutputInternal(async () => {
       this.terminalEnabled = (typeof shown === 'function' ? shown() : shown)
     })
@@ -283,9 +288,9 @@ export class NotebookCellOutputManager {
    * @param type * If present, only refresh output list if the given OutputType(s)
    * are present in the outputs, otherwise does nothing
    */
-  async refreshOutput(type?: OutputType|OutputType[]) {
+  async refreshOutput(type?: OutputType | OutputType[]) {
     await this.refreshOutputInternal(() => {
-      if(type === undefined) { return }
+      if (type === undefined) { return }
 
       const typeSet = Array.isArray(type) ? type : [type]
       return typeSet.some(t => this.hasOutputTypeUnsafe(t))
@@ -304,10 +309,10 @@ export class NotebookCellOutputManager {
    * where the user can prevent refreshing if a certain output type is not
    * present.
    */
-  protected async refreshOutputInternal(mutater?: () => Promise<boolean|void>|boolean|void) {
+  protected async refreshOutputInternal(mutater?: () => Promise<boolean | void> | boolean | void) {
     await this.withLock(async () => {
       await this.getExecutionUnsafe(async (exec) => {
-        for(const key of [...this.enabledOutputs.keys()]) {
+        for (const key of [...this.enabledOutputs.keys()]) {
           this.enabledOutputs.set(key, this.hasOutputTypeUnsafe(key))
         }
 
@@ -324,14 +329,14 @@ export class NotebookCellOutputManager {
         let terminalCellOutput = this.terminalEnabled && terminalOutput && this.generateOutputUnsafe(terminalOutput)
 
         await replaceOutput(exec, [
-          ...[ ...this.enabledOutputs.entries() ]
+          ...[...this.enabledOutputs.entries()]
             .flatMap(([type, enabled]) => {
               if (!enabled) { return [] }
 
               const output = this.generateOutputUnsafe(type)
-              if(!output) { return [] }
+              if (!output) { return [] }
 
-              return [ output ]
+              return [output]
             }),
           ...terminalCellOutput ? [terminalCellOutput] : [],
           ...this.outputs,
@@ -340,8 +345,8 @@ export class NotebookCellOutputManager {
     })
   }
 
-  protected async getExecutionUnsafe(cb: (exec: NotebookCellExecution) => Promise<void>|void) {
-    if(this.execution) {
+  protected async getExecutionUnsafe(cb: (exec: NotebookCellExecution) => Promise<void> | void) {
+    if (this.execution) {
       await cb?.(this.execution)
       return
     }
@@ -351,7 +356,7 @@ export class NotebookCellOutputManager {
 
     try {
       await cb(exec)
-    } catch(e) {
+    } catch (e) {
       throw e
     } finally {
       exec.end(true)
@@ -360,7 +365,7 @@ export class NotebookCellOutputManager {
 }
 
 function outputsAsArray(outputs: NotebookOutputs): readonly NotebookCellOutput[] {
-  return Array.isArray(outputs) ? outputs : [ outputs ]
+  return Array.isArray(outputs) ? outputs : [outputs]
 }
 
 type OnEndCallback = (info: {
@@ -412,4 +417,26 @@ export async function updateCellMetadata(cell: NotebookCell, meta: Partial<Seria
 
   edit.set(cell.notebook.uri, [notebookEdit])
   await workspace.applyEdit(edit)
+}
+
+export async function getCellByUuId(options: ICellOption): Promise<NotebookCell | undefined> {
+  const { editor, uuid } = options
+  for (const document of workspace.notebookDocuments) {
+    for (const cell of document.getCells()) {
+      if (
+        cell.kind !== NotebookCellKind.Code ||
+        cell.document.uri.fsPath !== editor.notebook.uri.fsPath) {
+        continue
+      }
+
+      if (cell.metadata?.['runme.dev/uuid'] === undefined) {
+        console.error(`[Runme] Cell with index ${cell.index} lacks uuid`)
+        continue
+      }
+
+      if (cell.metadata?.['runme.dev/uuid'] === uuid) {
+        return cell
+      }
+    }
+  }
 }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -16,7 +16,7 @@ import {
 import { TelemetryReporter } from 'vscode-telemetry'
 
 import type { ClientMessage, Serializer } from '../types'
-import { ClientMessages, OutputType } from '../constants'
+import { ClientMessages } from '../constants'
 import { API } from '../utils/deno/api'
 import { postClientMessage } from '../utils/messaging'
 
@@ -216,7 +216,7 @@ export class Kernel implements Disposable {
         message,
         cell,
         kernel: this,
-        outputType: OutputType.annotations
+        outputType: message.output.outputType
       })
     } else if (
       message.type.startsWith('terminal:')

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -27,7 +27,7 @@ import './wasm/wasm_exec.js'
 import { IRunner, IRunnerEnvironment } from './runner'
 import { executeRunner } from './executors/runner'
 import { ITerminalState, NotebookTerminalType } from './terminal/terminalState'
-import { NotebookCellManager, NotebookCellOutputManager, RunmeNotebookCellExecution } from './cell'
+import { NotebookCellManager, NotebookCellOutputManager, RunmeNotebookCellExecution, getCellByUuId } from './cell'
 import { handleCellOutputMessage } from './messages/cellOutput'
 
 enum ConfirmationItems {
@@ -211,7 +211,10 @@ export class Kernel implements Disposable {
     } else if (message.type === ClientMessages.openLink) {
       return env.openExternal(Uri.parse(message.output))
     } else if (message.type === ClientMessages.closeCellOutput) {
-      const cell = editor.notebook.cellAt(message.output.cellIndex)
+      const cell = await getCellByUuId({ editor, uuid: message.output.uuid })
+      if (!cell) {
+        return
+      }
       return handleCellOutputMessage({
         message,
         cell,

--- a/src/extension/messages/cellOutput.ts
+++ b/src/extension/messages/cellOutput.ts
@@ -16,8 +16,8 @@ export async function handleCellOutputMessage(options: ICellOutputMessage): Prom
     if (message.type === ClientMessages.closeCellOutput) {
         const outputs = await kernel.getCellOutputs(cell)
         if ([OutputType.terminal, OutputType.outputItems].includes(outputType)) {
-            return outputs.toggleTerminal()
+            return outputs.showTerminal(false)
         }
-        return outputs.toggleOutput(outputType)
+        return outputs.showOutput(outputType, false)
     }
 }

--- a/src/extension/messages/cellOutput.ts
+++ b/src/extension/messages/cellOutput.ts
@@ -1,0 +1,20 @@
+import { NotebookCell } from 'vscode'
+
+import { ClientMessages, OutputType } from '../../constants'
+import { ClientMessage } from '../../types'
+import { Kernel } from '../kernel'
+
+export interface ICellOutputMessage {
+    message: ClientMessage<ClientMessages>
+    cell: NotebookCell
+    kernel: Kernel
+    outputType: OutputType
+}
+
+export async function handleCellOutputMessage(options: ICellOutputMessage): Promise<void> {
+    const { message, cell, kernel, outputType } = options
+    if (message.type === ClientMessages.closeCellOutput) {
+        const outputs = await kernel.getCellOutputs(cell)
+        await outputs.toggleOutput(outputType)
+    }
+}

--- a/src/extension/messages/cellOutput.ts
+++ b/src/extension/messages/cellOutput.ts
@@ -15,6 +15,9 @@ export async function handleCellOutputMessage(options: ICellOutputMessage): Prom
     const { message, cell, kernel, outputType } = options
     if (message.type === ClientMessages.closeCellOutput) {
         const outputs = await kernel.getCellOutputs(cell)
-        await outputs.toggleOutput(outputType)
+        if ([OutputType.terminal, OutputType.outputItems].includes(outputType)) {
+            return outputs.toggleTerminal()
+        }
+        return outputs.toggleOutput(outputType)
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ interface Payload {
   [OutputType.annotations]: {
     annotations?: CellAnnotations
     validationErrors?: CellAnnotationsErrorResult
+    cellIndex?: number
   }
   [OutputType.terminal]: {
     ['runme.dev/uuid']: string
@@ -124,6 +125,9 @@ export interface ClientMessagePayload {
   }
   [ClientMessages.activeThemeChanged]: string
   [ClientMessages.openLink]: string
+  [ClientMessages.closeCellOutput]: {
+    cellIndex: number
+  }
 }
 
 export interface OutputItemsPayload {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ interface Payload {
   [OutputType.annotations]: {
     annotations?: CellAnnotations
     validationErrors?: CellAnnotationsErrorResult
-    cellIndex?: number
+    uuid?: string
   }
   [OutputType.terminal]: {
     ['runme.dev/uuid']: string
@@ -81,7 +81,6 @@ interface Payload {
     terminalFontSize: number
     content?: string
     initialRows?: number
-    cellIndex?: number
   }
 }
 
@@ -127,7 +126,7 @@ export interface ClientMessagePayload {
   [ClientMessages.activeThemeChanged]: string
   [ClientMessages.openLink]: string
   [ClientMessages.closeCellOutput]: {
-    cellIndex: number
+    uuid: string
     outputType: OutputType
   }
 }
@@ -135,7 +134,7 @@ export interface ClientMessagePayload {
 export interface OutputItemsPayload {
   content: string
   mime: string
-  cellIndex?: number
+  uuid: string
 }
 
 export interface RunmeTaskDefinition extends TaskDefinition {

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ interface Payload {
     terminalFontSize: number
     content?: string
     initialRows?: number
+    cellIndex?: number
   }
 }
 
@@ -127,12 +128,14 @@ export interface ClientMessagePayload {
   [ClientMessages.openLink]: string
   [ClientMessages.closeCellOutput]: {
     cellIndex: number
+    outputType: OutputType
   }
 }
 
 export interface OutputItemsPayload {
   content: string
   mime: string
+  cellIndex?: number
 }
 
 export interface RunmeTaskDefinition extends TaskDefinition {

--- a/tests/extension/messages/cellOutput.test.ts
+++ b/tests/extension/messages/cellOutput.test.ts
@@ -24,27 +24,23 @@ suite('Handle CellOutput messages', () => {
             metadata: {},
         } as unknown as NotebookCell
         const kernel = new Kernel({} as any)
-        const toggleOutput = vi.fn().mockImplementation(() => { })
-        const toggleTerminal = vi.fn().mockImplementation(() => { })
+        const showOutput = vi.fn().mockImplementation(() => { })
+        const showTerminal = vi.fn().mockImplementation(() => { })
         kernel.getCellOutputs = vi.fn().mockResolvedValue({
-            toggleOutput,
-            toggleTerminal
+            showTerminal,
+            showOutput,
         })
 
         return {
-            toggleOutput,
-            toggleTerminal,
+            showTerminal,
+            showOutput,
             kernel,
             cell
         }
     }
 
     const expectOutput = async (type: OutputType) => {
-        const { kernel, cell, toggleOutput, toggleTerminal } = mockOutput(type)
-        const outputCaller = [OutputType.terminal, OutputType.outputItems]
-            .includes(type) ?
-            toggleTerminal :
-            toggleOutput
+        const { kernel, cell, showOutput, showTerminal } = mockOutput(type)
         await handleCellOutputMessage({
             kernel,
             cell,
@@ -52,14 +48,18 @@ suite('Handle CellOutput messages', () => {
             message: {
                 type: ClientMessages.closeCellOutput,
                 output: {
-                    cellIndex: 1,
+                    uuid: 'a17249e7-4b5f-4b40-8037-10902dd446c9',
                     outputType: type
                 }
             }
         })
-        expect(outputCaller).toBeCalledTimes(1)
-        if (outputCaller instanceof toggleOutput) {
-            expect(outputCaller).toBeCalledWith(type)
+        if ([OutputType.terminal, OutputType.outputItems]
+            .includes(type)) {
+            expect(showTerminal).toBeCalledTimes(1)
+            expect(showTerminal).toBeCalledWith(false)
+        } else {
+            expect(showOutput).toBeCalledTimes(1)
+            expect(showOutput).toBeCalledWith(type, false)
         }
     }
 

--- a/tests/extension/messages/cellOutput.test.ts
+++ b/tests/extension/messages/cellOutput.test.ts
@@ -10,11 +10,12 @@ vi.mock('vscode-telemetry')
 vi.mock('../../../src/extension/runner', () => ({}))
 
 suite('Handle CellOutput messages', () => {
-    test('Annotations cell output', async () => {
+
+    const mockOutput = (type: OutputType) => {
         const cell = {
             outputs: [{
                 items: [
-                    { id: '', items: [], metadata: {}, mime: OutputType.annotations }
+                    { id: '', items: [], metadata: {}, mime: type }
                 ]
             }],
             executionSummary: {
@@ -24,21 +25,57 @@ suite('Handle CellOutput messages', () => {
         } as unknown as NotebookCell
         const kernel = new Kernel({} as any)
         const toggleOutput = vi.fn().mockImplementation(() => { })
+        const toggleTerminal = vi.fn().mockImplementation(() => { })
         kernel.getCellOutputs = vi.fn().mockResolvedValue({
-            toggleOutput
+            toggleOutput,
+            toggleTerminal
         })
+
+        return {
+            toggleOutput,
+            toggleTerminal,
+            kernel,
+            cell
+        }
+    }
+
+    const expectOutput = async (type: OutputType) => {
+        const { kernel, cell, toggleOutput, toggleTerminal } = mockOutput(type)
+        const outputCaller = [OutputType.terminal, OutputType.outputItems]
+            .includes(type) ?
+            toggleTerminal :
+            toggleOutput
         await handleCellOutputMessage({
             kernel,
             cell,
-            outputType: OutputType.annotations,
+            outputType: type,
             message: {
                 type: ClientMessages.closeCellOutput,
                 output: {
-                    cellIndex: 1
+                    cellIndex: 1,
+                    outputType: type
                 }
             }
         })
-        expect(toggleOutput).toBeCalledTimes(1)
-        expect(toggleOutput).toBeCalledWith(OutputType.annotations)
+        expect(outputCaller).toBeCalledTimes(1)
+        if (outputCaller instanceof toggleOutput) {
+            expect(outputCaller).toBeCalledWith(type)
+        }
+    }
+
+    test('Annotations cell output', async () => {
+        return expectOutput(OutputType.annotations)
+    })
+
+    test('Terminal cell output', async () => {
+        return expectOutput(OutputType.terminal)
+    })
+
+    test('OutputItems cell output', async () => {
+        return expectOutput(OutputType.outputItems)
+    })
+
+    test('Vercel cell output', async () => {
+        return expectOutput(OutputType.vercel)
     })
 })

--- a/tests/extension/messages/cellOutput.test.ts
+++ b/tests/extension/messages/cellOutput.test.ts
@@ -1,0 +1,44 @@
+import { NotebookCell } from 'vscode'
+import { suite, vi, test, expect } from 'vitest'
+
+import { handleCellOutputMessage } from '../../../src/extension/messages/cellOutput'
+import { ClientMessages, OutputType } from '../../../src/constants'
+import { Kernel } from '../../../src/extension/kernel'
+
+vi.mock('vscode')
+vi.mock('vscode-telemetry')
+vi.mock('../../../src/extension/runner', () => ({}))
+
+suite('Handle CellOutput messages', () => {
+    test('Annotations cell output', async () => {
+        const cell = {
+            outputs: [{
+                items: [
+                    { id: '', items: [], metadata: {}, mime: OutputType.annotations }
+                ]
+            }],
+            executionSummary: {
+                success: false
+            },
+            metadata: {},
+        } as unknown as NotebookCell
+        const kernel = new Kernel({} as any)
+        const toggleOutput = vi.fn().mockImplementation(() => { })
+        kernel.getCellOutputs = vi.fn().mockResolvedValue({
+            toggleOutput
+        })
+        await handleCellOutputMessage({
+            kernel,
+            cell,
+            outputType: OutputType.annotations,
+            message: {
+                type: ClientMessages.closeCellOutput,
+                output: {
+                    cellIndex: 1
+                }
+            }
+        })
+        expect(toggleOutput).toBeCalledTimes(1)
+        expect(toggleOutput).toBeCalledWith(OutputType.annotations)
+    })
+})


### PR DESCRIPTION
Introducing a close-button component, only supported by the Annotations component so far.


https://github.com/stateful/vscode-runme/assets/4001529/eadfeaaa-a070-43e3-bd08-d895cb4d4737

Fixes https://github.com/stateful/vscode-runme/issues/500