### PR TITLE
Convert textRange bytes to characters

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -285,3 +285,17 @@ export class WorkspaceEdit {
 export class NotebookEdit {
   static updateCellMetadata = vi.fn()
 }
+
+/**
+ * Represents an end of line character sequence in a {@link TextDocument document}.
+ */
+export enum EndOfLine {
+  /**
+   * The line feed `\n` character.
+   */
+  LF = 1,
+  /**
+   * The carriage return line feed `\r\n` sequence.
+   */
+  CRLF = 2
+}

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { vi, suite, test, expect, beforeEach } from 'vitest'
 import { type GrpcTransport } from '@protobuf-ts/grpc-transport'
-import { EventEmitter, NotebookCellKind, Position, tasks, commands } from 'vscode'
+import { EventEmitter, NotebookCellKind, Position, tasks, commands, EndOfLine } from 'vscode'
 
 import {
   GrpcRunner,
@@ -560,16 +560,43 @@ suite('RunmeCodeLensProvider', () => {
   })
 
   test('returns serializer result normally', async () => {
+    const textParts = [
+      '```sh\n',
+      'echo "Hello World!"\n```',
+      '\n\n',
+      '🔥'.repeat(20),
+      '🔥'.repeat(20),
+      '🔥'.repeat(20),
+      '🔥'.repeat(20),
+      '\n\n',
+      '```sh\n',
+      'echo "Hello World!"',
+      '\n```',
+    ]
+
+    const block1Start = textParts.slice(0, 1).join('')
+    const block1End = textParts.slice(0, 2).join('')
+
+    const block2Start = textParts.slice(0, 9).join('')
+    const block2End = textParts.slice(0, 10).join('')
+
     const serializer = {
       reviveNotebook: vi.fn(async () => ({
         cells: [
           {
             kind: NotebookCellKind.Code,
             textRange: {
-              start: 2,
-              end: 3,
+              start: Buffer.from(block1Start, 'utf-8').length,
+              end: Buffer.from(block1End, 'utf-8').length,
             }
-          }
+          },
+          {
+            kind: NotebookCellKind.Code,
+            textRange: {
+              start: Buffer.from(block2Start, 'utf-8').length,
+              end: Buffer.from(block2End, 'utf-8').length,
+            }
+          },
         ]
       }))
     } as any
@@ -578,7 +605,8 @@ suite('RunmeCodeLensProvider', () => {
 
     const lenses = await provider.provideCodeLenses(
       {
-        getText: vi.fn().mockReturnValue(''),
+        eol: EndOfLine.LF,
+        getText: vi.fn().mockReturnValue(textParts.join('')),
         positionAt: vi.fn((c) => new Position(1, c)),
       } as any,
       {} as any
@@ -586,15 +614,37 @@ suite('RunmeCodeLensProvider', () => {
 
     expect(serializer.reviveNotebook).toBeCalledTimes(1)
 
-    expect(lenses).toHaveLength(2)
+    expect(lenses).toHaveLength(4)
 
-    for (const lens of lenses) {
+    lenses.forEach((lens, i) => {
+      switch (i) {
+        case 0: {
+          const line = block1Start.split('\n').length - 2
+
+          expect(lens.range.start.line).toStrictEqual(line)
+          expect(lens.range.start.character).toStrictEqual(0)
+
+          expect(lens.range.end.line).toStrictEqual(line)
+          expect(lens.range.end.character).toStrictEqual(0)
+        } break
+
+        case 2: {
+          const line = block2Start.split('\n').length - 2
+
+          expect(lens.range.start.line).toStrictEqual(line)
+          expect(lens.range.start.character).toStrictEqual(0)
+
+          expect(lens.range.end.line).toStrictEqual(line)
+          expect(lens.range.end.character).toStrictEqual(0)
+        } break
+      }
+
       expect(lens.command).toBeTruthy()
 
       expect(lens.command!.command).toStrictEqual(ActionCommand)
 
       expect(lens.command!.tooltip).toBeUndefined()
-    }
+    })
   })
 
   test('action callback for run command', async () => {

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -589,9 +589,6 @@ suite('RunmeCodeLensProvider', () => {
     expect(lenses).toHaveLength(2)
 
     for (const lens of lenses) {
-      expect(lens.range.start.character).toStrictEqual(2)
-      expect(lens.range.end.character).toStrictEqual(3)
-
       expect(lens.command).toBeTruthy()
 
       expect(lens.command!.command).toStrictEqual(ActionCommand)


### PR DESCRIPTION
Fixes stateful/runme#269

The `TextRange` information reported from grpc gives offset in bytes, but VSCode expects offset in characters.

My solution was to count the lines manually with rudimentary string operations. This has comically awful performance, but doing it the "right" way is tough, since we'd need to iterate through characters.

For now it should be fine on small-ish files. But if we run into problems with performance for CodeLens, this is the first thing to optimize. [I found a library too](https://www.npmjs.com/package/codepoint-iterator) that could be of help.

Another thing: anything that's not `utf-8` and has wide characters will almost certainly break. VSCode does not appear to let you determine the encoding of a `TextDocument` - see microsoft/vscode#824 - so we can't really figure out the right encoding. Hopefully `UTF-16` and others are uncommon enough that this doesn't become an issue.
