### PR TITLE
hotfix ci

### DIFF
--- a/.github/scripts/downloadWasm.js
+++ b/.github/scripts/downloadWasm.js
@@ -43,17 +43,23 @@ async function getGitHubToken () {
 
 async function downloadWasm (token) {
   const octokit = new Octokit({ auth: token })
-  const wasmReleaseDefined = Boolean(process.env.RUNME_VERSION)
+
+  let releaseArg = process.env.RUNME_VERSION
+  if (releaseArg && !releaseArg.startsWith("v")) {
+    releaseArg = "v" + releaseArg
+  }
+
+  const wasmReleaseDefined = Boolean(releaseArg)
   const releases = await octokit.repos.listReleases({ owner, repo })
   const release = wasmReleaseDefined
-    ? releases.data.find((r) => r.tag_name === process.env.RUNME_VERSION)
+    ? releases.data.find((r) => r.tag_name === releaseArg)
     : releases.data.filter(
         (r) => r.prerelease === (process.env.GITHUB_REF_NAME !== "main")
       )[0]
 
   if (wasmReleaseDefined && !release) {
     throw new Error(
-      `No release found with tag name "${process.env.RUNME_VERSION}", ` +
+      `No release found with tag name "${releaseArg}", ` +
       `available releases: ${releases.data.map((r) => r.tag_name).join(', ')}`
     )
   }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: 🧪 Setup and Test with Runme
         uses: coactions/setup-xvfb@v1
         with:
-          run: ./runme run configureNPM setup build test
+          run: npx runme run configureNPM setup build test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNME_PROJECT: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNME_PROJECT: ${{ github.workspace }}
+          RUNME_VERSION: 1.2.2-rc.0
       - name: 🔼 Upload Artifacts
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: 🧪 Setup and Test with Runme
         uses: coactions/setup-xvfb@v1
         with:
-          run: npx runme run configureNPM setup build test
+          run: ./runme run configureNPM setup build test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNME_PROJECT: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNME_PROJECT: ${{ github.workspace }}
+          # FIXME: remove explicit version after 1.2.2 is released
           RUNME_VERSION: 1.2.2-rc.0
       - name: 🔼 Upload Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Sets ci version explicitly to latest rc, to unblock CI. Once we cut a main release, we should switch it back to implicit (latest).