### PR TITLE
Add Runme to recommended extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,12 @@
         "category": "Runme",
         "title": "Run cells with the same Category",
         "icon": "$(group-by-ref-type)"
-      }
+      },
+      {
+        "command": "runme.addToRecommendedExtensions",
+        "title": "Add Runme to recommended extensions",
+        "category": "Runme"
+      } 
     ],
     "menus": {
       "commandPalette": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -112,7 +112,7 @@ export const LANGUAGES = new Map([
  * For example, the vscode language id for all bash-like shells is
  * "shellscript," so this object maps "shellscript" -> "sh"
  */
-export const VSCODE_LANGUAGEID_MAP: Record<string, string|undefined> = {
+export const VSCODE_LANGUAGEID_MAP: Record<string, string | undefined> = {
   'shellscript': 'sh',
   'javascriptreact': 'jsx',
   'typescriptreact': 'tsx',
@@ -1042,3 +1042,8 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   'sh', 'bash', 'ksh', 'zsh', 'fish', 'bat', 'cmd', 'pwsh',
   ...Object.keys(LANGUAGE_PREFIXES),
 ]
+
+export const EXTENSION_NAME = 'stateful.runme'
+export enum TELEMETRY_EVENTS {
+  RecommendExtension = 'runme.recommendExtension'
+}

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -31,6 +31,7 @@ import RunmeServer from '../server/runmeServer'
 import { GrpcRunnerEnvironment } from '../runner'
 import { NotebookToolbarCommand } from '../../types'
 import getLogger from '../logger'
+import { RecommendExtensionMessage } from '../messaging'
 
 const log = getLogger('Commands')
 
@@ -259,4 +260,10 @@ export async function authenticateWithGitHub() {
   } catch (error) {
     window.showErrorMessage('Failed to authenticate with GitHub')
   }
+}
+
+export async function addToRecommendedExtensions(context: ExtensionContext) {
+  return new RecommendExtensionMessage(context, {
+    'runme.recommendExtension': true
+  }).display()
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -36,7 +36,6 @@ import { GrpcRunner, IRunner } from './runner'
 import { CliProvider } from './provider/cli'
 import * as survey from './survey'
 import { RunmeCodeLensProvider } from './provider/codelens'
-import { MessagingBuilder, RecommendExtensionMessage } from './messaging'
 
 export class RunmeExtension {
   async initialize(context: ExtensionContext) {
@@ -82,8 +81,6 @@ export class RunmeExtension {
     const activeUsersSurvey = new survey.SurveyActiveUserFeedback(context)
     const winCodeLensRunSurvey = new survey.SurveyWinCodeLensRun(context)
     const stopBackgroundTaskProvider = new StopBackgroundTaskProvider()
-    const messageBuilder = new MessagingBuilder([new RecommendExtensionMessage(context)])
-    messageBuilder.activate()
 
     const runCLI = runCLICommand(context.extensionUri, !!grpcRunner, server, kernel)
 
@@ -107,7 +104,6 @@ export class RunmeExtension {
       treeViewer,
       activeUsersSurvey,
       winCodeLensRunSurvey,
-      messageBuilder,
       workspace.registerNotebookSerializer(Kernel.type, serializer, {
         transientOutputs: true,
         transientCellMetadata

--- a/src/extension/messaging.ts
+++ b/src/extension/messaging.ts
@@ -1,0 +1,120 @@
+import { join } from 'node:path'
+
+import { Disposable, ExtensionContext, Uri, window, workspace } from 'vscode'
+import { TelemetryReporter } from 'vscode-telemetry'
+
+import { EXTENSION_NAME, TELEMETRY_EVENTS } from '../constants'
+
+import { fileOrDirectoryExists, getDefaultWorkspace } from './utils'
+
+export abstract class DisplayableMessage {
+    abstract dispose(): void
+    abstract display(): void
+    constructor(protected readonly context: ExtensionContext, readonly stateSettings?: Record<TELEMETRY_EVENTS, any>) {
+        this.context = context
+        this.stateSettings = stateSettings
+    }
+}
+
+export class MessagingBuilder implements Disposable {
+    /**
+     * Represents a collection of DisplayableMessages, useful to display window messages.
+     * @param messages Specify the displayable messages to show
+     */
+    constructor(private messages: DisplayableMessage[]) {
+        this.messages = messages
+    }
+
+    dispose() {
+        this.messages.forEach(d => d.dispose())
+    }
+
+    /**
+     * Display registered DisplayableMessages
+     */
+    activate() {
+        for (const message of this.messages) {
+            message.display()
+        }
+    }
+}
+
+
+export class RecommendExtensionMessage extends DisplayableMessage implements Disposable {
+    async display(): Promise<void> {
+        try {
+            const skipPrompSettings = this.stateSettings && this.stateSettings[TELEMETRY_EVENTS.RecommendExtension]
+            let promptUser = skipPrompSettings ||
+                this.context.globalState.get(TELEMETRY_EVENTS.RecommendExtension, true)
+            // Multi-root workspace not supported atm
+            const workspaceRoot = getDefaultWorkspace()
+            if (!workspaceRoot) {
+                return
+            }
+            const extensionsFile = Uri.parse(join(workspaceRoot, '.vscode/extensions.json'))
+            const extensionfileOrDirectoryExists = await fileOrDirectoryExists(extensionsFile)
+            let extensionRecommendations: string[] = []
+            if (extensionfileOrDirectoryExists) {
+                const extensionDocument = await workspace.openTextDocument(extensionsFile)
+                const extensionContents = JSON.parse(extensionDocument.getText())
+                const { recommendations }: Record<string, string[]> = extensionContents
+                extensionRecommendations = recommendations
+                if (recommendations.includes(EXTENSION_NAME)) {
+                    promptUser = false
+                }
+            }
+
+            if (!promptUser) {
+                return
+            }
+
+            // eslint-disable-next-line max-len
+            const answer = await window.showInformationMessage(
+                'Would you like to add Runme to the recommended extensions?',
+                'Yes',
+                'No',
+                'Don\'t ask again'
+            )
+            if (answer !== 'Yes') {
+                TelemetryReporter.sendTelemetryEvent(TELEMETRY_EVENTS.RecommendExtension,
+                    {
+                        added: 'false',
+                        error: 'false'
+                    }
+                )
+                if (answer === 'Don\'t ask again') {
+                    await this.context.globalState.update(TELEMETRY_EVENTS.RecommendExtension, false)
+                }
+                return
+            }
+
+            const folderUri = Uri.parse(join(workspaceRoot, '.vscode'))
+            const dirExists = await fileOrDirectoryExists(folderUri)
+            if (!dirExists) {
+                await workspace.fs.createDirectory(folderUri)
+            }
+
+            if (!extensionfileOrDirectoryExists) {
+                const recommendations = [EXTENSION_NAME]
+                await workspace.fs.writeFile(extensionsFile, Buffer.from(JSON.stringify({
+                    recommendations
+                })))
+            } else {
+                extensionRecommendations.push(EXTENSION_NAME)
+                await workspace.fs.writeFile(extensionsFile, Buffer.from(JSON.stringify({
+                    recommendations: extensionRecommendations
+                })))
+            }
+
+            window.showInformationMessage('Runme added successfully to the recommended extensions')
+            TelemetryReporter.sendTelemetryEvent(TELEMETRY_EVENTS.RecommendExtension, { added: 'true', error: 'false' })
+
+        } catch (error) {
+            window.showErrorMessage('Failed to add Runme to the recommended extensions')
+            TelemetryReporter.sendTelemetryEvent(TELEMETRY_EVENTS.RecommendExtension, { added: 'false', error: 'true' })
+        }
+
+    }
+
+    dispose() { }
+}

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -543,3 +543,7 @@ export async function fileOrDirectoryExists(path: Uri): Promise<boolean> {
     () => false
   )
 }
+
+export function isMultiRootWorkspace(): boolean {
+  return (workspace.workspaceFolders && workspace.workspaceFolders.length > 1) || false
+}

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -534,3 +534,12 @@ export async function bootFile() {
   log.info(`Open file defined in "runme.flag.startFile" setting: ${startupFileUriConfig.fsPath}`)
   return commands.executeCommand('vscode.openWith', startupFileUriConfig, Kernel.type)
 }
+
+export async function fileOrDirectoryExists(path: Uri): Promise<boolean> {
+  return workspace.fs.stat(path).then(
+    async (file) => {
+      return file.type === FileType.File || file.type === FileType.Directory
+    },
+    () => false
+  )
+}

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -73,7 +73,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(23)
+  expect(commands.registerCommand).toBeCalledTimes(24)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)

--- a/tests/extension/messaging.test.ts
+++ b/tests/extension/messaging.test.ts
@@ -1,0 +1,183 @@
+import { expect, vi, test, suite, beforeEach } from 'vitest'
+import { Disposable, FileType, workspace, window, Uri, ExtensionContext } from 'vscode'
+import { TelemetryReporter } from 'vscode-telemetry'
+
+import { DisplayableMessage, MessagingBuilder, RecommendExtensionMessage } from '../../src/extension/messaging'
+
+vi.mock('vscode', async () => {
+    const vscode = await import('../../__mocks__/vscode')
+    return {
+        default: vscode,
+        ...vscode,
+        workspace: {
+            ...vscode.workspace,
+            openTextDocument: vi.fn().mockReturnValue({
+                getText: vi.fn().mockReturnValue(JSON.stringify({
+                    recommendations: ['stateful.runme']
+                }))
+            })
+        }
+    }
+})
+
+vi.mock('vscode')
+
+vi.mock('vscode-telemetry')
+
+vi.mock('../../src/extension/grpc/client', () => ({}))
+vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
+
+class MockMessage extends DisplayableMessage implements Disposable {
+    dispose(): void { }
+    display(): void { }
+}
+
+const contextMock: ExtensionContext = {
+    globalState: {
+        get: vi.fn().mockReturnValue(true),
+        update: vi.fn().mockResolvedValue({}),
+    }
+} as any
+
+suite('MessageBuilder', () => {
+
+    test('On Activate should display all displayable messages', () => {
+        const mockMessage = new MockMessage(contextMock)
+        const messageBuilder = new MessagingBuilder([mockMessage, mockMessage])
+        const mockMessageSpy = vi.spyOn(mockMessage, 'display')
+        messageBuilder.activate()
+        expect(mockMessageSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('On Dispose should dispose all displayable messages', () => {
+        const mockMessage = new MockMessage(contextMock)
+        const messageBuilder = new MessagingBuilder([mockMessage, mockMessage])
+        const mockMessageSpy = vi.spyOn(mockMessage, 'dispose')
+        messageBuilder.dispose()
+        expect(mockMessageSpy).toHaveBeenCalledTimes(2)
+    })
+})
+
+suite('RecommendExtensionMessage', () => {
+
+    beforeEach(() => {
+        vi.mocked(window.showInformationMessage).mockClear()
+        vi.mocked(workspace.fs.writeFile).mockClear()
+    })
+
+    test('It should not prompt the user to install the extension when already added', async () => {
+        const recommendExtension = new RecommendExtensionMessage(contextMock)
+        vi.mocked(workspace.fs.stat).mockResolvedValue({ type: FileType.File } as any)
+        await recommendExtension.display()
+        expect(window.showInformationMessage).toHaveBeenCalledTimes(0)
+        expect(workspace.fs.writeFile).toHaveBeenCalledTimes(0)
+    })
+
+    test('It should add the extension when selecting "Yes" option', async () => {
+        const recommendExtension = new RecommendExtensionMessage(contextMock)
+        vi.mocked(workspace.fs.stat).mockResolvedValue({ type: FileType.File } as any)
+        vi.mocked(workspace.openTextDocument as any).mockResolvedValue({
+            getText: vi.fn().mockReturnValue(JSON.stringify({
+                recommendations: ['microsoft.docker']
+            }))
+        })
+        vi.mocked(window.showInformationMessage).mockResolvedValueOnce('Yes' as any)
+        await recommendExtension.display()
+        expect(workspace.fs.writeFile).toBeCalledTimes(1)
+        expect(TelemetryReporter.sendTelemetryEvent)
+            .toBeCalledWith('runme.recommendExtension', { added: 'true', error: 'false' })
+        expect(window.showInformationMessage)
+            .toHaveBeenCalledWith('Runme added successfully to the recommended extensions')
+    })
+
+
+    test('It should create a .vscode folder when needed', async () => {
+        const recommendExtension = new RecommendExtensionMessage(contextMock)
+        vi.mocked(workspace.fs.stat).mockResolvedValue(false as any)
+        vi.mocked(workspace.openTextDocument as any).mockResolvedValue({
+            getText: vi.fn().mockReturnValue(JSON.stringify({
+                recommendations: ['microsoft.docker']
+            }))
+        })
+        vi.mocked(window.showInformationMessage).mockResolvedValueOnce('Yes' as any)
+        await recommendExtension.display()
+        expect(workspace.fs.createDirectory).toBeCalledTimes(1)
+        expect(workspace.fs.createDirectory).toHaveBeenCalledWith(Uri.parse('/runme/workspace/.vscode'))
+        expect(workspace.fs.writeFile).toBeCalledTimes(1)
+        expect(window.showInformationMessage)
+            .toHaveBeenCalledWith('Runme added successfully to the recommended extensions')
+        expect(TelemetryReporter.sendTelemetryEvent)
+            .toBeCalledWith('runme.recommendExtension', { added: 'true', error: 'false' })
+    })
+
+    test('It should create a .vscode/extensions.json file when needed', async () => {
+        const recommendExtension = new RecommendExtensionMessage(contextMock)
+        vi.mocked(workspace.fs.stat).mockImplementation(async (param: Uri) => {
+            return param.path === '/runme/workspace/.vscode/extensions.json'
+                ? { type: FileType.Unknown } :
+                { type: FileType.Directory } as any
+        })
+        vi.mocked(workspace.openTextDocument as any).mockResolvedValue({
+            getText: vi.fn().mockReturnValue(JSON.stringify({
+                recommendations: ['microsoft.docker']
+            }))
+        })
+        vi.mocked(window.showInformationMessage).mockResolvedValueOnce('Yes' as any)
+        await recommendExtension.display()
+        const writeFileCalls = vi.mocked(workspace.fs.writeFile).mock.calls[0]
+        expect(workspace.fs.writeFile).toHaveBeenCalledOnce()
+        expect((writeFileCalls[0] as Uri).path).toStrictEqual('/runme/workspace/.vscode/extensions.json')
+        expect((writeFileCalls[1] as Buffer).toString('utf-8')).toStrictEqual(JSON.stringify({
+            recommendations: ['stateful.runme']
+        }))
+        expect(window.showInformationMessage)
+            .toHaveBeenCalledWith('Runme added successfully to the recommended extensions')
+        expect(TelemetryReporter.sendTelemetryEvent)
+            .toBeCalledWith('runme.recommendExtension', { added: 'true', error: 'false' })
+    })
+
+    test('It should not add the extension when selecting "No" option', async () => {
+        const recommendExtension = new RecommendExtensionMessage(contextMock)
+        vi.mocked(workspace.fs.stat).mockResolvedValue({ type: FileType.File } as any)
+        vi.mocked(workspace.openTextDocument as any).mockResolvedValue({
+            getText: vi.fn().mockReturnValue(JSON.stringify({
+                recommendations: ['microsoft.docker']
+            }))
+        })
+        vi.mocked(window.showInformationMessage).mockResolvedValueOnce('No' as any)
+        await recommendExtension.display()
+        expect(workspace.fs.writeFile).toBeCalledTimes(0)
+        expect(window.showInformationMessage).toBeCalledTimes(1)
+        expect(TelemetryReporter.sendTelemetryEvent)
+            .toBeCalledWith('runme.recommendExtension', { added: 'false', error: 'false' })
+    })
+
+    test('It should report on failure and display a message', async () => {
+        const recommendExtension = new RecommendExtensionMessage(contextMock)
+        vi.mocked(workspace.openTextDocument as any).mockResolvedValue({
+            getText: vi.fn().mockImplementation(new Error('Failure') as any)
+        })
+        await recommendExtension.display()
+        expect(window.showErrorMessage)
+            .toHaveBeenCalledWith('Failed to add Runme to the recommended extensions')
+        expect(TelemetryReporter.sendTelemetryEvent)
+            .toBeCalledWith('runme.recommendExtension', { added: 'false', error: 'true' })
+    })
+
+    test('It should not prompt when selecting don\'t ask again', async () => {
+        const recommendExtension = new RecommendExtensionMessage(contextMock)
+        vi.mocked(workspace.fs.stat).mockResolvedValue({ type: FileType.File } as any)
+        vi.mocked(workspace.openTextDocument as any).mockResolvedValue({
+            getText: vi.fn().mockReturnValue(JSON.stringify({
+                recommendations: ['microsoft.docker']
+            }))
+        })
+        vi.mocked(window.showInformationMessage).mockResolvedValueOnce('Don\'t ask again' as any)
+        const spy = vi.spyOn(contextMock.globalState, 'update')
+        await recommendExtension.display()
+        expect(workspace.fs.writeFile).toBeCalledTimes(0)
+        expect(TelemetryReporter.sendTelemetryEvent)
+            .toBeCalledWith('runme.recommendExtension', { added: 'false', error: 'false' })
+        expect(spy).toHaveBeenCalledWith('runme.recommendExtension', false)
+    })
+})

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -24,9 +24,14 @@ import {
   setNotebookCategories,
   getNotebookCategories,
   getNamespacedMid,
+<<<<<<< HEAD
   bootFile,
   isShellLanguage,
   fileOrDirectoryExists
+=======
+  fileOrDirectoryExists,
+  isMultiRootWorkspace
+>>>>>>> e27bb6e (Save json file properly, validate multi-root workspace)
 } from '../../src/extension/utils'
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
 import { CellAnnotations } from '../../src/types'
@@ -683,5 +688,30 @@ suite('fileOrDirectoryExists', () => {
     const path = Uri.parse('.vscode-mango')
     const exists = await fileOrDirectoryExists(path)
     expect(exists).toBe(true)
+  })
+})
+
+suite('isMultiRootWorkspace', () => {
+  test('should return true when there are multiple workspace folders', () => {
+    // @ts-expect-error
+    workspace.workspaceFolders = [
+      { uri: Uri.file('/Users/user/Projects/project1') },
+      { uri: Uri.file('/Users/user/Projects/project2') }
+    ]
+    expect(isMultiRootWorkspace()).toStrictEqual(true)
+  })
+
+  test('should return false when there is one workspace folder', () => {
+    // @ts-expect-error
+    workspace.workspaceFolders = [
+      { uri: Uri.file('/Users/user/Projects/project1') }
+    ]
+    expect(isMultiRootWorkspace()).toStrictEqual(false)
+  })
+
+  test('should return false when workspaceFolders are not defined', () => {
+    // @ts-expect-error
+    workspace.workspaceFolders = undefined
+    expect(isMultiRootWorkspace()).toStrictEqual(false)
   })
 })

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -24,14 +24,10 @@ import {
   setNotebookCategories,
   getNotebookCategories,
   getNamespacedMid,
-<<<<<<< HEAD
   bootFile,
   isShellLanguage,
-  fileOrDirectoryExists
-=======
   fileOrDirectoryExists,
   isMultiRootWorkspace
->>>>>>> e27bb6e (Save json file properly, validate multi-root workspace)
 } from '../../src/extension/utils'
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
 import { CellAnnotations } from '../../src/types'

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -25,7 +25,8 @@ import {
   getNotebookCategories,
   getNamespacedMid,
   bootFile,
-  isShellLanguage
+  isShellLanguage,
+  fileOrDirectoryExists
 } from '../../src/extension/utils'
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
 import { CellAnnotations } from '../../src/types'
@@ -98,16 +99,16 @@ test('getTerminalByCell', () => {
   } as any))
     .toBeTruthy()
 
-    expect(getTerminalByCell({
-      metadata: { 'runme.dev/uuid': v4() },
-      kind: 2,
-    } as any))
-      .toBeUndefined()
+  expect(getTerminalByCell({
+    metadata: { 'runme.dev/uuid': v4() },
+    kind: 2,
+  } as any))
+    .toBeUndefined()
 
-    expect(getTerminalByCell({
-      kind: 1,
-    } as any))
-      .toBeUndefined()
+  expect(getTerminalByCell({
+    kind: 1,
+  } as any))
+    .toBeUndefined()
 })
 
 test('resetEnv', () => {
@@ -659,5 +660,28 @@ suite('bootFile', () => {
     expect(commands.executeCommand).toBeCalledWith('vscode.openWith', expect.objectContaining({
       path: '/foo/bar/foo/Settings.md'
     }), 'runme')
+  })
+})
+
+suite('fileOrDirectoryExists', () => {
+  test('should return false when file does not exists', async () => {
+    vi.mocked(workspace.fs.stat).mockResolvedValue({ type: FileType.Unknown } as any)
+    const path = Uri.parse('.vscode-mango')
+    const exists = await fileOrDirectoryExists(path)
+    expect(exists).toBe(false)
+  })
+
+  test('should return true when file does exists', async () => {
+    vi.mocked(workspace.fs.stat).mockResolvedValue({ type: FileType.File } as any)
+    const path = Uri.parse('.vscode-mango')
+    const exists = await fileOrDirectoryExists(path)
+    expect(exists).toBe(true)
+  })
+
+  test('should return true when directory does exists', async () => {
+    vi.mocked(workspace.fs.stat).mockResolvedValue({ type: FileType.Directory } as any)
+    const path = Uri.parse('.vscode-mango')
+    const exists = await fileOrDirectoryExists(path)
+    expect(exists).toBe(true)
   })
 })


### PR DESCRIPTION
Prompt the user to add the extension to recommended extensions

Note: It does not cover Multi-root workspace for now.
- It prompts the user on Extension Activation (unless disabled by the user)
- It supports don't ask again feature
- Added as a command in order to bring it back again

🎥 Demo 

https://github.com/stateful/vscode-runme/assets/4001529/f8085ef4-1a51-4c9b-b832-9b05bda15181

Fixes https://github.com/stateful/vscode-runme/issues/520

