### PR TITLE
Allow to define a start-up file to be opened by Runme when extension activates

### DIFF
--- a/__mocks__/vscode-telemetry.ts
+++ b/__mocks__/vscode-telemetry.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest'
 
 export const TelemetryReporter = {
-  sendTelemetryEvent: vi.fn()
+  sendTelemetryEvent: vi.fn(),
+  sendTelemetryErrorEvent: vi.fn()
 }

--- a/package.json
+++ b/package.json
@@ -313,6 +313,11 @@
             "default": true,
             "markdownDescription": "If enabled, Runme's save restriction on non checked-in files will be lifted."
           },
+          "runme.flags.startFile": {
+            "type": "string",
+            "scope": "window",
+            "markdownDescription": "Relative path to a file within the workspace to open within a Runme notebook view, when VS Code starts (e.g. `./CONTRIBUTING.md`)."
+          },
           "runme.experiments.grpcSerializer": {
             "type": "boolean",
             "scope": "machine",

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@buf/grpc_grpc.community_timostamm-protobuf-ts/grpc/health/v1/health_pb'
 
 import { RunmeExtension } from '../../src/extension/extension'
+import { bootFile } from '../../src/extension/utils'
 import RunmeServer from '../../src/extension/server/runmeServer'
 import { testCertPEM, testPrivKeyPEM } from '../testTLSCert'
 
@@ -38,6 +39,15 @@ vi.mock('../../src/extension/grpc/client', () => {
   })
 })
 
+vi.mock('../../src/extension/utils', async () => ({
+  getDefaultWorkspace: vi.fn(),
+  resetEnv: vi.fn(),
+  initWasm: vi.fn(),
+  getNamespacedMid: vi.fn(),
+  isWindows: vi.fn().mockReturnValue(false),
+  bootFile: vi.fn().mockResolvedValue(undefined)
+}))
+
 vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
 
 test('initializes all providers', async () => {
@@ -66,8 +76,5 @@ test('initializes all providers', async () => {
   expect(commands.registerCommand).toBeCalledTimes(23)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
-
-  expect(commands.executeCommand).toBeCalledWith('vscode.openWith', dummyFilePath, 'runme')
-  expect(workspace.fs.stat).toBeCalledWith(dummyFilePath)
-  expect(workspace.fs.delete).toBeCalledWith(dummyFilePath)
+  expect(bootFile).toBeCalledTimes(1)
 })


### PR DESCRIPTION
> As a repository maintainer I want to have developers open an e.g. `CONTRIBUTING.md` file every time they start the project. 

This patch adds a `runme.flags.startFile` setting that allows to define a file to be opened by Runme at application start. This would be helpful for anyone that has an important file for contributor to look at to have it opened when VS Code starts. Especially for developers defining a `devcontainer.json` file it could allow new contributors to see all important documentation and commands to start get productive.

If the file is not existing in the repository, it will just return silently. This allows devs to have a global configuration to always open e.g. a `CONTRIBUTING.md` file if existing. Otherwise this option is meant to be used mainly in `.vscode/settings.json` files.

I am not entirely sure if it is a desired behavior for experienced developers to have the same file over and over opened again when starting their IDE. I could think of adding a confirmation popup asking to open again on start up. Feedback on this would be appreciated.