### PR TITLE
Run CLI with index rather than cell name

### DIFF
--- a/package.json
+++ b/package.json
@@ -425,6 +425,11 @@
             "type": "boolean",
             "default": true,
             "markdownDescription": "Load environment files from workspace into all scripts"
+          },
+          "runme.cli.useIntegratedRunme": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Whether to use full path to integrated runme executable when running CLI commands. This is mostly useful for development purposes."
           }
         }
       }

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -48,7 +48,6 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
       workspace.onDidChangeNotebookDocument(
         this.handleNotebookChanged.bind(this)
       ),
-      // TODO(mxs): https://github.com/stateful/vscode-runme/issues/566#issuecomment-1574128419
       // workspace.onDidSaveNotebookDocument(
       //   this.handleNotebookSaved.bind(this)
       // )

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -12,6 +12,7 @@ const SERVER_SECTION_NAME = 'runme.server'
 const TERMINAL_SECTION_NAME = 'runme.terminal'
 const CODELENS_SECTION_NAME = 'runme.codelens'
 const ENV_SECTION_NAME = 'runme.env'
+const CLI_SECTION_NAME = 'runme.cli'
 
 export const DEFAULT_TLS_DIR = path.join(os.tmpdir(), 'runme', uuidv4(), 'tls')
 const DEFAULT_WORKSPACE_FILE_ORDER = ['.env.local', '.env']
@@ -52,6 +53,9 @@ const configurationSchema = {
     env: {
       workspaceFileOrder: z.array(z.string()).default(DEFAULT_WORKSPACE_FILE_ORDER),
       loadWorkspaceFiles: z.boolean().default(true),
+    },
+    cli: {
+      useIntegratedRunme: z.boolean().default(false),
     }
 }
 
@@ -89,6 +93,16 @@ const getEnvConfigurationValue = <T>(configName: keyof typeof configurationSchem
   const configurationSection = workspace.getConfiguration(ENV_SECTION_NAME)
   const configurationValue = configurationSection.get<T>(configName)!
   const parseResult = configurationSchema.env[configName].safeParse(configurationValue)
+  if (parseResult.success) {
+      return parseResult.data as T
+  }
+  return defaultValue
+}
+
+const getCLIConfigurationValue = <T>(configName: keyof typeof configurationSchema.cli, defaultValue: T) => {
+  const configurationSection = workspace.getConfiguration(CLI_SECTION_NAME)
+  const configurationValue = configurationSection.get<T>(configName)!
+  const parseResult = configurationSchema.cli[configName].safeParse(configurationValue)
   if (parseResult.success) {
       return parseResult.data as T
   }
@@ -185,6 +199,10 @@ const getEnvLoadWorkspaceFiles = (): boolean => {
   return getEnvConfigurationValue('loadWorkspaceFiles', true)
 }
 
+const getCLIUseIntegratedRunme = (): boolean => {
+  return getCLIConfigurationValue('useIntegratedRunme', false)
+}
+
 export {
     getPortNumber,
     getBinaryPath,
@@ -202,4 +220,5 @@ export {
     getCustomServerAddress,
     getEnvWorkspaceFileOrder,
     getEnvLoadWorkspaceFiles,
+    getCLIUseIntegratedRunme,
 }

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -12,7 +12,8 @@ import {
   DEFAULT_TLS_DIR,
   getNotebookTerminalFontFamily,
   getNotebookTerminalFontSize,
-  getCodeLensEnabled
+  getCodeLensEnabled,
+  getCLIUseIntegratedRunme
 } from '../../src/utils/configuration'
 import { SERVER_PORT } from '../../src/constants'
 
@@ -148,6 +149,10 @@ suite('Configuration', () => {
       expect(
         getCodeLensEnabled()
       ).toStrictEqual(true)
+    })
+
+    test('getCLIUseIntegratexRunme should return false by default', () => {
+      expect(getCLIUseIntegratedRunme()).toStrictEqual(false)
     })
 
     suite('posix', () => {


### PR DESCRIPTION
Requires stateful/runme#293

CLI button now uses cell index rather than cell name. Note that this feature will break for users who don't upgrade to the latest runme.

This unblocks us on [this issue](https://github.com/stateful/vscode-runme/issues/566#issuecomment-1574128419), though it doesn't solve it.

I also introduced `runme.cli.useIntegratedRunme`, which makes it easier to test the new version of runme (uses integrated path).