### PR TITLE
keep track of languageId changes

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -107,6 +107,8 @@ export class RunmeExtension {
       ['runme.dev/name']: undefined,
       ['runme.dev/uuid']: undefined,
       ['runme.dev/textRange']: undefined,
+      // ['runme.dev/originalLanguageId']: undefined,
+      // ['runme.dev/originalDocumentLanguageId']: undefined,
     }
     const transientCellMetadata = Object.fromEntries(Object.keys(omitKeys).map((k) => [k, true]))
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,8 @@ export namespace Serializer {
     ['runme.dev/githubState']?: GitHubState
     ['runme.dev/frontmatterParsed']?: Grpc.Frontmatter
     ['runme.dev/textRange']?: Grpc.Cell['textRange']
+    ['runme.dev/originalLanguageId']?: string
+    ['runme.dev/originalDocumentLanguageId']?: string
   }
 }
 


### PR DESCRIPTION
This PR keeps track of changes to `languageId`, allowing us to only update it in the document when it changes. Most of the time, this will prevent us from adding `sh` to fenced code blocks that originally didn't have languages.

Currently the drawback is that this will add two keys to the `metadata` property of diffs, which is a problem. Since this information is needed at document save time, it can't be considered transient, or else it will not be added to the cells' `metadata` property in the `NotebookData`. Currently looking into solutions here...