### PR TITLE
Support custom cell executions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,10 @@ This markdown file contains some custom examples to test the execution within a 
 echo "Hello World!"
 ```
 
+```javascript { name=echo-hello-js }
+console.log('Hello World!')
+```
+
 ## More Shell
 
 ```sh { interactive=false }
@@ -164,6 +168,6 @@ curl -s "https://api.marquee.activecove.com/getWeather?lat=52&lon=10" | fx
 
 ```yaml
 config:
-  netsed:
+  nested:
     para: true
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,10 +17,6 @@ This markdown file contains some custom examples to test the execution within a 
 echo "Hello World!"
 ```
 
-```javascript { name=echo-hello-js }
-console.log('Hello World!')
-```
-
 ## More Shell
 
 ```sh { interactive=false }
@@ -170,4 +166,10 @@ curl -s "https://api.marquee.activecove.com/getWeather?lat=52&lon=10" | fx
 config:
   nested:
     para: true
+```
+
+## JavaScript
+
+```javascript { name=echo-hello-js }
+console.log('Hello World!')
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -128,13 +128,30 @@ You can copy also results from the inline executed shell:
 openssl rand -base64 32
 ```
 
-## Non-Supported Languages
+## Non-Shell Languages
 
-These are shown as simple markdowns, e.g:
+These are sometimes executable by default, like for python:
 
-```py { readonly=true }
-def hello():
-    print("Hello World")
+```py
+print("Hello World")
+```
+
+Otherwise, execution can be set with the `interpreter` annotation, like so:
+
+```yaml { interpreter=cat }
+config:
+  nested:
+    para: true
+```
+
+Non-shell scripts can also access environment variables, and are run from the current working directory:
+
+```sh
+export YOUR_NAME=enter your name
+```
+
+```javascript { name=echo-hello-js }
+console.log(`Hello, ${process.env.YOUR_NAME}, from ${__dirname}!`)
 ```
 
 ## Curl an image
@@ -158,22 +175,4 @@ With [`antonmedv/fx`](https://github.com/antonmedv/fx) you can inspect JSON file
 
 ```sh { terminalRows=20 }
 curl -s "https://api.marquee.activecove.com/getWeather?lat=52&lon=10" | fx
-```
-
-## YAML
-
-```yaml
-config:
-  nested:
-    para: true
-```
-
-## JavaScript
-
-```sh
-export YOUR_NAME=enter your name
-```
-
-```javascript { name=echo-hello-js }
-console.log(`Hello, ${process.env.YOUR_NAME}!`)
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,6 +170,10 @@ config:
 
 ## JavaScript
 
+```sh
+export YOUR_NAME=enter your name
+```
+
 ```javascript { name=echo-hello-js }
-console.log('Hello World!')
+console.log(`Hello, ${process.env.YOUR_NAME}!`)
 ```

--- a/package.json
+++ b/package.json
@@ -623,7 +623,6 @@
     "test:format:fix": "prettier --write .",
     "test:unit": "vitest -c ./vitest.conf.ts",
     "test:e2e": "wdio run ./tests/e2e/wdio.conf.ts",
-    "pretest:e2e": "npm run download:binary",
     "watch": "npm run build:dev -- --watch",
     "vscode:prepublish": "npm run prepare-binary",
     "download:binary": "npm run prepare-binary",

--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -145,6 +145,11 @@ export class Annotations extends LitElement {
       description: "Cell's canonical name for easy referencing in the CLI.",
       docs: 'https://docs.runme.dev/configuration#cell-options',
     },
+    program: {
+      description: "Program with which to run this cell's script.",
+      // FIXME: update docs link
+      docs: '',
+    },
     category: {
       description: 'Execute this code cell within a category.',
       docs: 'https://docs.runme.dev/configuration#run-all-cells-by-category',

--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -451,6 +451,7 @@ export class Annotations extends LitElement {
             <div class="box">${this.renderTextFieldTabEntry('mimeType')}</div>
             <div class="box">${this.renderCategoryTabEntry('category')}</div>
             <div class="box">${this.renderTextFieldTabEntry('terminalRows')}</div>
+            <div class="box">${this.renderTextFieldTabEntry('program')}</div>
           </div>
         </vscode-panel-view>
       </vscode-panels>

--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -145,8 +145,8 @@ export class Annotations extends LitElement {
       description: "Cell's canonical name for easy referencing in the CLI.",
       docs: 'https://docs.runme.dev/configuration#cell-options',
     },
-    program: {
-      description: "Program with which to run this cell's script.",
+    interpreter: {
+      description: 'Script shebang line',
       // FIXME: update docs link
       docs: '',
     },
@@ -451,7 +451,7 @@ export class Annotations extends LitElement {
             <div class="box">${this.renderTextFieldTabEntry('mimeType')}</div>
             <div class="box">${this.renderCategoryTabEntry('category')}</div>
             <div class="box">${this.renderTextFieldTabEntry('terminalRows')}</div>
-            <div class="box">${this.renderTextFieldTabEntry('program')}</div>
+            <div class="box">${this.renderTextFieldTabEntry('interpreter')}</div>
           </div>
         </vscode-panel-view>
       </vscode-panels>

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -35,7 +35,7 @@ import { toggleTerminal } from '../commands'
 import { NotebookCellOutputManager } from '../cell'
 
 import { closeTerminalByEnvID } from './task'
-import { getCellShellPath, parseCommandSeq, getCellCwd } from './utils'
+import { parseCommandSeq, getCellCwd, getCellProgram } from './utils'
 import { handleVercelDeployOutput, isVercelDeployScript } from './vercel'
 
 import type { IEnvironmentManager } from '.'
@@ -124,8 +124,10 @@ export async function executeRunner(
     }
   }
 
+  const { programName, commandMode } = getCellProgram(exec.cell, exec.cell.notebook, execKey)
+
   const program = await runner.createProgramSession({
-    programName: getCellShellPath(exec.cell, exec.cell.notebook, execKey) ?? execKey,
+    programName,
     environment,
     exec: execution,
     envs: Object.entries(envs).map(([k, v]) => `${k}=${v}`),
@@ -134,6 +136,8 @@ export async function executeRunner(
     tty: interactive,
     convertEol: !mimeType || mimeType === 'text/plain',
     storeLastOutput: true,
+    languageId: exec.cell.document.languageId,
+    commandMode,
   })
 
   context.subscriptions.push(program)

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -269,7 +269,7 @@ export function getCellProgram(
   execKey: string
 ): { programName: string; commandMode: CommandMode } {
   let result: { programName: string; commandMode: CommandMode }
-  const { program } = getAnnotations(cell.metadata)
+  const { interpreter } = getAnnotations(cell.metadata)
 
   if (isShellLanguage(execKey)) {
     const shellPath = getCellShellPath(cell, notebook, execKey) ?? execKey
@@ -286,8 +286,8 @@ export function getCellProgram(
     }
   }
 
-  if (program) {
-    result.programName = program
+  if (interpreter) {
+    result.programName = interpreter
   }
 
   return result

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -415,7 +415,7 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
         if (error.message.includes('invalid LanguageId')) {
           window.showErrorMessage(
             // eslint-disable-next-line max-len
-            'Unable to automatically execute cell. To execute this cell, set the "program" field in the configuration foldout!'
+            'Unable to automatically execute cell. To execute this cell, set the "interpreter" field in the configuration foldout!'
           )
         }
 

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -420,7 +420,7 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
         }
 
         if (error.message.includes('invalid ProgramName')) {
-          window.showErrorMessage(`Unable to locate program "${this.opts.programName}"`)
+          window.showErrorMessage(`Unable to locate interpreter "${this.opts.programName}"`)
         }
 
         console.error(

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -21,13 +21,7 @@ import { v5 as uuidv5 } from 'uuid'
 import getPort from 'get-port'
 import dotenv from 'dotenv'
 
-import {
-  CellAnnotations,
-  CellAnnotationsErrorResult,
-  RunmeTerminal,
-  Serializer,
-  ShellType,
-} from '../types'
+import { CellAnnotations, CellAnnotationsErrorResult, RunmeTerminal, Serializer } from '../types'
 import { SafeCellAnnotationsSchema, CellAnnotationsSchema } from '../schema'
 import {
   AuthenticationProviders,
@@ -165,31 +159,6 @@ export function getKey(runningCell: vscode.TextDocument): string {
   }
 
   return languageId
-}
-
-export function isShellLanguage(languageId: string): ShellType | undefined {
-  switch (languageId.toLowerCase()) {
-    case 'sh':
-    case 'bash':
-    case 'zsh':
-    case 'ksh':
-    case 'shell':
-      return 'sh'
-
-    case 'bat':
-    case 'cmd':
-      return 'cmd'
-
-    case 'powershell':
-    case 'pwsh':
-      return 'powershell'
-
-    case 'fish':
-      return 'fish'
-
-    default:
-      return undefined
-  }
 }
 
 /**

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -74,6 +74,7 @@ export const AnnotationSchema = {
       return true
     }, 'mime type specification invalid format')
     .default('text/plain'),
+  program: z.string().optional().default(''),
   cwd: z.string().nonempty().optional(),
   category: z.preprocess(
     (value) => (typeof value === 'string' ? cleanAnnotation(value, ',') : value),

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -74,7 +74,7 @@ export const AnnotationSchema = {
       return true
     }, 'mime type specification invalid format')
     .default('text/plain'),
-  program: z.string().optional().default(''),
+  interpreter: z.string().optional().default(''),
   cwd: z.string().nonempty().optional(),
   category: z.preprocess(
     (value) => (typeof value === 'string' ? cleanAnnotation(value, ',') : value),

--- a/tests/e2e/specs/basic.e2e.ts
+++ b/tests/e2e/specs/basic.e2e.ts
@@ -83,13 +83,25 @@ describe('Runme VS Code Extension', async () => {
       ])
     })
 
-    it('basic hello world javascript execution', async () => {
-      const cell = await notebook.getCell('console.log(\'Hello World!\')')
+    it('basic hello world python execution', async () => {
+      const cell = await notebook.getCell('print("Hello World")')
 
       await cell.run()
 
       expect(await cell.getCellOutput(OutputType.TerminalView)).toStrictEqual([
-        'Hello World!\n'
+        'Hello World\n'
+      ])
+    })
+
+    it('basic yaml example', async () => {
+      const cell = await notebook.getCell('config:\n  nested:\n    para: true')
+
+      await cell.run()
+
+      await tryExecuteCommand(await browser.getWorkbench(), 'focus active cell output')
+
+      expect(await cell.getCellOutput(OutputType.TerminalView)).toStrictEqual([
+        'config:\nnested:\npara: true\n'
       ])
     })
 

--- a/tests/e2e/specs/basic.e2e.ts
+++ b/tests/e2e/specs/basic.e2e.ts
@@ -83,6 +83,16 @@ describe('Runme VS Code Extension', async () => {
       ])
     })
 
+    it('basic hello world javascript execution', async () => {
+      const cell = await notebook.getCell('console.log(\'Hello World!\')')
+
+      await cell.run()
+
+      expect(await cell.getCellOutput(OutputType.TerminalView)).toStrictEqual([
+        'Hello World!\n'
+      ])
+    })
+
     it('more shell example', async () => {
       const cell = await notebook.getCell('echo "Foo 👀"\nsleep 2\necho "Bar 🕺"\nsleep 2\necho "Loo 🚀"')
       await cell.run()

--- a/tests/extension/commands/index.test.ts
+++ b/tests/extension/commands/index.test.ts
@@ -67,6 +67,8 @@ vi.mock('../../../src/extension/runner', () => ({
   GrpcRunnerEnvironment: class { }
 }))
 
+vi.mock('../../../src/extension/grpc/runnerTypes', () => ({}))
+
 beforeEach(() => {
   vi.mocked(window.showWarningMessage).mockClear()
   vi.mocked(window.showInformationMessage).mockClear()

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -387,19 +387,19 @@ suite('getCellProgram', () => {
     })
   })
 
-  test('respects custom program in shell mode', async () => {
-    vi.mocked(getAnnotations).mockImplementationOnce(((x: any) => ({ program: x.program })) as any)
+  test('respects custom interpreter in shell mode', async () => {
+    vi.mocked(getAnnotations).mockImplementationOnce(((x: any) => ({ interpreter: x.interpreter })) as any)
 
-    expect(getCellProgram({ metadata: { program: 'fish' } } as any, {} as any, 'sh')).toStrictEqual({
+    expect(getCellProgram({ metadata: { interpreter: 'fish' } } as any, {} as any, 'sh')).toStrictEqual({
       commandMode: COMMAND_MODE_INLINE_SHELL,
       programName: 'fish'
     })
   })
 
-  test('respects custom program in temp file mode', async () => {
-    vi.mocked(getAnnotations).mockImplementationOnce(((x: any) => ({ program: x.program })) as any)
+  test('respects custom interpreter in temp file mode', async () => {
+    vi.mocked(getAnnotations).mockImplementationOnce(((x: any) => ({ interpreter: x.interpreter })) as any)
 
-    expect(getCellProgram({ metadata: { program: 'bun' } } as any, {} as any, 'javascript')).toStrictEqual({
+    expect(getCellProgram({ metadata: { interpreter: 'bun' } } as any, {} as any, 'javascript')).toStrictEqual({
       commandMode: COMMAND_MODE_TEMP_FILE,
       programName: 'bun'
     })

--- a/tests/extension/kernel.test.ts
+++ b/tests/extension/kernel.test.ts
@@ -24,6 +24,8 @@ vi.mock('../../src/extension/executors/index.js', () => ({
 }))
 vi.mock('../../src/extension/runner', () => ({}))
 
+vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
+
 const getCells = (cnt: number, metadata: Record<string, any> = {}) => ([...new Array(cnt)]).map((_, i) => ({
   document: { getText: vi.fn().mockReturnValue(`Cell #${i}`) },
   notebook: {
@@ -208,7 +210,7 @@ suite('_doExecuteCell', () => {
 
   test('shows error window if language is not supported', async () => {
     const k = new Kernel({} as any)
-    k['runner'] = {} as any
+    k['runner'] = undefined
 
     k.createCellExecution = vi.fn().mockResolvedValue({
       start: vi.fn(),
@@ -221,10 +223,14 @@ suite('_doExecuteCell', () => {
       languageId: 'barfoo'
     } as any)
 
-    await k['_doExecuteCell']({
-      document: { uri: { fsPath: '/foo/bar' } },
-      metadata: { 'runme.dev/uuid': '849448b2-3c41-4323-920e-3098e71302ce' }
-    } as any)
+    try {
+      await k['_doExecuteCell']({
+        document: { uri: { fsPath: '/foo/bar' } },
+        metadata: { 'runme.dev/uuid': '849448b2-3c41-4323-920e-3098e71302ce' }
+      } as any)
+    } catch(e) {
+
+    }
 
     expect(TelemetryReporter.sendTelemetryEvent).toHaveBeenCalledWith(
       'cell.startExecute'

--- a/tests/extension/messages/cellOutput.test.ts
+++ b/tests/extension/messages/cellOutput.test.ts
@@ -9,6 +9,8 @@ vi.mock('vscode')
 vi.mock('vscode-telemetry')
 vi.mock('../../../src/extension/runner', () => ({}))
 
+vi.mock('../../../src/extension/grpc/runnerTypes', () => ({}))
+
 suite('Handle CellOutput messages', () => {
 
     const mockOutput = (type: OutputType) => {

--- a/tests/extension/provider/annotations.test.ts
+++ b/tests/extension/provider/annotations.test.ts
@@ -32,6 +32,7 @@ vi.mock('../../../src/extension/utils', () => ({
 }))
 
 vi.mock('../../../src/extension/runner', () => ({ }))
+vi.mock('../../../src/extension/grpc/runnerTypes', () => ({}))
 
 describe('Runme Annotations', () => {
   const kernel = new Kernel({} as any)

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -568,8 +568,12 @@ suite('grpc Runner', () => {
     test('grpc program failure gives info message', async () => {
       const { duplex } = await createNewSession()
 
-      duplex._onError.fire(new RpcError('unable to infer file program'))
+      duplex._onError.fire(new RpcError('invalid LanguageId'))
+      expect(window.showErrorMessage).toBeCalledTimes(1)
 
+      vi.mocked(window.showErrorMessage).mockClear()
+
+      duplex._onError.fire(new RpcError('invalid ProgramName'))
       expect(window.showErrorMessage).toBeCalledTimes(1)
     })
   })

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -2,7 +2,8 @@ import path from 'node:path'
 
 import { vi, suite, test, expect, beforeEach } from 'vitest'
 import { type GrpcTransport } from '@protobuf-ts/grpc-transport'
-import { EventEmitter, NotebookCellKind, Position, tasks, commands, EndOfLine } from 'vscode'
+import { EventEmitter, NotebookCellKind, Position, tasks, commands, EndOfLine, window } from 'vscode'
+import { RpcError } from '@protobuf-ts/runtime-rpc'
 
 import {
   GrpcRunner,
@@ -199,6 +200,10 @@ suite('grpc Runner', () => {
   })
 
   suite('grpc program session', () => {
+    beforeEach(() => {
+      vi.mocked(window.showErrorMessage).mockClear()
+    })
+
     test('session dispose is called on runner dispose', async () => {
       const { runner, session, duplex } = await createNewSession()
 
@@ -558,6 +563,14 @@ suite('grpc Runner', () => {
 
       expect(writeListener).toBeCalledTimes(1)
       expect(writeListener).toBeCalledWith('test\n')
+    })
+
+    test('grpc program failure gives info message', async () => {
+      const { duplex } = await createNewSession()
+
+      duplex._onError.fire(new RpcError('unable to infer file program'))
+
+      expect(window.showErrorMessage).toBeCalledTimes(1)
     })
   })
 })

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../src/extension/languages', () => ({
   default: {
     fromContext: vi.fn(),
   },
+    NotebookData: class {}
 }))
 
 vi.mock('../../src/extension/utils', () => ({

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -24,7 +24,6 @@ import {
   getNotebookCategories,
   getNamespacedMid,
   bootFile,
-  isShellLanguage,
   fileOrDirectoryExists,
   isMultiRootWorkspace,
   convertEnvList,
@@ -134,12 +133,6 @@ test('getKey', () => {
     getText: vi.fn().mockReturnValue(''),
     languageId: 'shellscript'
   } as any)).toBe('sh')
-})
-
-test('isShellLanguage', () => {
-  for (const shell of ['bash', 'sh', 'fish', 'ksh', 'zsh', 'shell', 'bat', 'cmd', 'powershell', 'pwsh']) {
-    expect(isShellLanguage(shell)).toBeTruthy()
-  }
 })
 
 suite('getCmdShellSeq', () => {
@@ -285,7 +278,8 @@ suite('#getAnnotations', () => {
         category: '',
         excludeFromRunAll: false,
         promptEnv: true,
-        'runme.dev/uuid': '48d86c43-84a4-469d-8c78-963513b0f9d0'
+        'runme.dev/uuid': '48d86c43-84a4-469d-8c78-963513b0f9d0',
+        program: '',
       }
     )
   })
@@ -306,7 +300,8 @@ suite('#getAnnotations', () => {
       name: 'echo-hello',
       promptEnv: true,
       excludeFromRunAll: false,
-      category: ''
+      category: '',
+      program: '',
     })
   })
 })

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -279,7 +279,7 @@ suite('#getAnnotations', () => {
         excludeFromRunAll: false,
         promptEnv: true,
         'runme.dev/uuid': '48d86c43-84a4-469d-8c78-963513b0f9d0',
-        program: '',
+        interpreter: '',
       }
     )
   })
@@ -301,7 +301,7 @@ suite('#getAnnotations', () => {
       promptEnv: true,
       excludeFromRunAll: false,
       category: '',
-      program: '',
+      interpreter: '',
     })
   })
 })


### PR DESCRIPTION
Allows running cells with custom languages. Provides new `program` cell annotation, with which the cell will run.

Requires runme with stateful/runme#302

Depends on #590

![2023-06-13_16-53-02](https://github.com/stateful/vscode-runme/assets/16108792/ea8b9e24-cb92-4947-9151-dc33adc63c42)
