### PR TITLE
Presave check is no longer required

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -8,7 +8,6 @@ import vscode, {
   Uri,
   workspace,
   env,
-  NotebookDocument,
   NotebookCell,
   NotebookCellExecution,
   NotebookCellOutput,
@@ -290,40 +289,6 @@ export async function verifyCheckedInFile(filePath: string) {
       () => false
     )
   return isCheckedIn
-}
-
-export async function canEditFile(
-  notebook: NotebookDocument,
-  // for testing purposes only
-  verifyCheckedInFileFn = verifyCheckedInFile
-): Promise<boolean> {
-  const config = vscode.workspace.getConfiguration('runme.flags')
-  const disableSaveRestriction = config.get<boolean>('disableSaveRestriction')
-  const currentDocumentPath = notebook.uri.fsPath
-  const isNewFile = notebook.isUntitled && notebook.notebookType === Kernel.type
-
-  /**
-   * allow serializing files if:
-   */
-  if (
-    /**
-     * the user has disabled this restriction
-     */
-    disableSaveRestriction ||
-    /**
-     * the user just created a new file
-     */
-    isNewFile ||
-    /**
-     * the user works on a checked in file
-     */
-    !currentDocumentPath ||
-    (await verifyCheckedInFileFn(currentDocumentPath))
-  ) {
-    return true
-  }
-
-  return false
 }
 
 export async function initWasm(wasmUri: Uri) {

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -2,7 +2,6 @@ import { NotebookData, NotebookDocument, NotebookEdit, window, workspace } from 
 import { expect, vi, it, describe, beforeEach } from 'vitest'
 
 import { SerializerBase, WasmSerializer } from '../../src/extension/serializer'
-import { canEditFile } from '../../src/extension/utils'
 import type { Kernel } from '../../src/extension/kernel'
 import { EventEmitter, Uri } from '../../__mocks__/vscode'
 import { Serializer } from '../../src/types'
@@ -44,7 +43,6 @@ vi.mock('../../src/extension/languages', () => ({
 }))
 
 vi.mock('../../src/extension/utils', () => ({
-    canEditFile: vi.fn().mockResolvedValue(false),
     initWasm: vi.fn()
 }))
 
@@ -163,34 +161,9 @@ describe('WasmSerializer', () => {
     }
 
     describe('serializeNotebook', () => {
-        it('fails when notebook is not active', async () => {
-            const s = new WasmSerializer(context, newKernel())
-            await expect(() => s.serializeNotebook({} as any, {} as any))
-                .rejects.toThrow(/not active/)
-        })
-
-        it('prevents saving if canEditFile returns false', async () => {
-            // @ts-ignore readonly
-            window.activeNotebookEditor = {} as any
-            const s = new WasmSerializer(context, newKernel())
-            await expect(() => s.serializeNotebook({} as any, {} as any))
-                .rejects.toThrow(/saving non version controlled notebooks is disabled/)
-        })
-
-        it('throws if wasm fails to laod', async () => {
-            // @ts-ignore readonly
-            window.activeNotebookEditor = {} as any
-            vi.mocked(canEditFile).mockResolvedValue(true)
-            const s = new WasmSerializer(context, newKernel())
-            // @ts-ignore readonly
-            s['ready'] = Promise.reject('ups')
-            await expect(() => s.serializeNotebook({} as any, {} as any)).rejects.toThrow(/ups/)
-        })
-
         it('uses Runme wasm to save the file', async () => {
             // @ts-ignore readonly
             window.activeNotebookEditor = {} as any
-            vi.mocked(canEditFile).mockResolvedValue(true)
             const s = new WasmSerializer(context, newKernel())
             // @ts-ignore readonly
             s['ready'] = Promise.resolve()

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -8,7 +8,6 @@ import {
   getKey,
   getCmdShellSeq,
   normalizeLanguage,
-  canEditFile,
   getAnnotations,
   mapGitIgnoreToGlobFolders,
   hashDocumentUri,
@@ -209,45 +208,6 @@ suite('normalizeLanguage', () => {
   test('with sh', () => {
     const lang = normalizeLanguage('sh')
     expect(lang).toBe('sh')
-  })
-})
-
-suite('canEditFile', () => {
-  const verifyCheckedInFile = vi.fn().mockResolvedValue(false)
-  const notebook: any = {
-    isUntitled: false,
-    notebookType: 'runme',
-    uri: { fsPath: '/foo/bar' }
-  }
-
-  beforeEach(() => {
-    vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
-      get: vi.fn().mockReturnValue(false)
-    } as any)
-  })
-
-  test('can not edit by default', async () => {
-    expect(await canEditFile(notebook, verifyCheckedInFile)).toBe(false)
-  })
-
-  test('can edit if ignore flag is enabled', async () => {
-    const notebookMock: any = JSON.parse(JSON.stringify(notebook))
-    vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
-      get: vi.fn().mockReturnValue(true)
-    } as any)
-    expect(await canEditFile(notebookMock, verifyCheckedInFile)).toBe(true)
-  })
-
-  test('can edit file if new', async () => {
-    const notebookMock: any = JSON.parse(JSON.stringify(notebook))
-    notebookMock.isUntitled = true
-    expect(await canEditFile(notebookMock, verifyCheckedInFile)).toBe(true)
-  })
-
-  test('can edit file if checked in', async () => {
-    const notebookMock: any = JSON.parse(JSON.stringify(notebook))
-    verifyCheckedInFile.mockResolvedValue(true)
-    expect(await canEditFile(notebookMock, verifyCheckedInFile)).toBe(true)
   })
 })
 


### PR DESCRIPTION
It dates back to when the serializer part of the parser was "experimental".

Also, tests coupled with WASM Serializer are obsolete. Serialization testing is now covered in https://github.com/stateful/runme.

PS: Relevant code makes saving fail when the markdown diff editor is active.