### PR TITLE
don't prompt for preexisting environment variables

### DIFF
--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -87,7 +87,12 @@ export async function executeRunner(
 
   let cellText = exec.cell.document.getText()
 
-  const commands = await parseCommandSeq(cellText, promptEnv, prepareCmdSeq)
+  const commands = await parseCommandSeq(
+    cellText,
+    promptEnv,
+    environment?.initialEnvs(),
+    prepareCmdSeq
+  )
   if (!commands) {
     return false
   }

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -90,7 +90,7 @@ export async function executeRunner(
   const commands = await parseCommandSeq(
     cellText,
     promptEnv,
-    environment?.initialEnvs(),
+    new Set([...(environment?.initialEnvs() ?? []), ...Object.keys(envs)]),
     prepareCmdSeq
   )
   if (!commands) {

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -557,6 +557,7 @@ export class Kernel implements Disposable {
           if (this.runner !== runner) {
             return
           }
+
           this.environment = env
         } catch (e: any) {
           window.showErrorMessage(`Failed to create environment for gRPC Runner: ${e.message}`)

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -128,17 +128,17 @@ export class RunmeTaskProvider implements TaskProvider {
       new CustomExecution(async () => {
         const cwd = options.cwd || (await getCellCwd(cell, notebook, Uri.file(filePath)))
 
+        const envs: Record<string, string> = {
+          ...(await getWorkspaceEnvs(Uri.file(filePath))),
+        }
+
         const cellContent = 'value' in cell ? cell.value : cell.document.getText()
         const commands = await parseCommandSeq(
           cellContent,
           undefined,
-          environment?.initialEnvs(),
+          new Set([...(environment?.initialEnvs() ?? []), ...Object.keys(envs)]),
           prepareCmdSeq
         )
-
-        const envs: Record<string, string> = {
-          ...(await getWorkspaceEnvs(Uri.file(filePath))),
-        }
 
         if (!environment) {
           Object.assign(envs, process.env)

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -129,7 +129,12 @@ export class RunmeTaskProvider implements TaskProvider {
         const cwd = options.cwd || (await getCellCwd(cell, notebook, Uri.file(filePath)))
 
         const cellContent = 'value' in cell ? cell.value : cell.document.getText()
-        const commands = await parseCommandSeq(cellContent, undefined, prepareCmdSeq)
+        const commands = await parseCommandSeq(
+          cellContent,
+          undefined,
+          environment?.initialEnvs(),
+          prepareCmdSeq
+        )
 
         const envs: Record<string, string> = {
           ...(await getWorkspaceEnvs(Uri.file(filePath))),

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -405,6 +405,7 @@ export function getWorkspaceFolder(uri?: Uri): WorkspaceFolder | undefined {
   } while (testPath !== path.dirname(testPath))
 }
 
+// TODO: use gRPC project mode for this
 export async function getWorkspaceEnvs(uri?: Uri): Promise<Record<string, string>> {
   const res: Record<string, string> = {}
   const workspaceFolder = getWorkspaceFolder(uri)

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -544,3 +544,12 @@ export async function fileOrDirectoryExists(path: Uri): Promise<boolean> {
 export function isMultiRootWorkspace(): boolean {
   return (workspace.workspaceFolders && workspace.workspaceFolders.length > 1) || false
 }
+
+export function convertEnvList(envs: string[]): Record<string, string | undefined> {
+  return envs.reduce((prev, curr) => {
+    const [key, value = ''] = curr.split(/\=(.*)/s)
+    prev[key] = value
+
+    return prev
+  }, {} as Record<string, string | undefined>)
+}

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -312,7 +312,7 @@ suite('parseCommandSeq', () => {
       'echo $TEST_MULTILINE'
     ]
 
-    const res = await parseCommandSeq(cmdLines.join('\n'), true, getCmdSeq)
+    const res = await parseCommandSeq(cmdLines.join('\n'), true, undefined, getCmdSeq)
 
     expect(res).toBeTruthy()
     expect(res).toStrictEqual([

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -26,7 +26,8 @@ import {
   bootFile,
   isShellLanguage,
   fileOrDirectoryExists,
-  isMultiRootWorkspace
+  isMultiRootWorkspace,
+  convertEnvList,
 } from '../../src/extension/utils'
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
 import { CellAnnotations } from '../../src/types'
@@ -669,5 +670,21 @@ suite('isMultiRootWorkspace', () => {
     // @ts-expect-error
     workspace.workspaceFolders = undefined
     expect(isMultiRootWorkspace()).toStrictEqual(false)
+  })
+})
+
+suite('convertEnvList', () => {
+  test('can handle basic example', () => {
+    expect(
+      convertEnvList([
+        'a=1',
+        'b=2',
+        'c=3\n4',
+      ])
+    ).toStrictEqual({
+      'a': '1',
+      'b': '2',
+      'c': '3\n4',
+    })
   })
 })


### PR DESCRIPTION
Ignores `export` lines if they would override an environment variable in the system store or `.env` files.

Solves #643