### PR TITLE
Add support to sharing a token to visualize a runme block

### DIFF
--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -415,7 +415,7 @@ export class TerminalView extends LitElement {
                   createCellExecution: { htmlUrl },
                 },
               } = e.output.data
-              this.shareUrl = htmlUrl
+              this.shareUrl = `${htmlUrl}?share_token=${e.output.shareToken}`
               await this.#displayShareDialog()
             }
             break

--- a/src/extension/messages/cloudApiRequest/saveCellExecution.ts
+++ b/src/extension/messages/cloudApiRequest/saveCellExecution.ts
@@ -68,6 +68,7 @@ export default async function saveCellExecution(
     return postClientMessage(messaging, ClientMessages.cloudApiResponse, {
       data: result,
       uuid: message.output.uuid,
+      shareToken: runmeTokenResponse.token,
     })
   } catch (error) {
     TelemetryReporter.sendTelemetryEvent('runme-app-error')

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,7 @@ export interface ClientMessagePayload {
     data: any
     uuid: string
     hasErrors?: boolean
+    shareToken?: string | undefined
   }
   [ClientMessages.optionsMessage]: {
     title: string


### PR DESCRIPTION
This PR allows a user to open a shared block without authenticating, this provides a better UX 
