### PR TITLE
Add save status icon and fix buttons color

### DIFF
--- a/src/client/components/copyButton.ts
+++ b/src/client/components/copyButton.ts
@@ -10,12 +10,12 @@ export class CopyButton extends LitElement {
   /* eslint-disable */
   static styles = css`
     vscode-button {
-      background: transparent;
-      color: #ccc;
+      color: var(--vscode-button-foreground);
+      background-color: var(--vscode-button-background);
       transform: scale(0.9);
     }
     vscode-button:hover {
-      background: var(--button-secondary-background);
+      background: var(--vscode-button-hoverBackground);
     }
     vscode-button:focus {
       outline: #007fd4 1px solid;

--- a/src/client/components/icons/save.ts
+++ b/src/client/components/icons/save.ts
@@ -1,0 +1,24 @@
+import { html } from 'lit'
+
+/* eslint-disable max-len */
+export const SaveIcon = html`
+  <svg
+    class="icon"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M13.353 1.146L14.853 2.646L15 3V14.5L14.5 15H1.5L1 14.5V1.5L1.5 1H13L13.353 1.146ZM2 2V14H14V3.208L12.793 2H11V6H4V2H2ZM8 2V5H10V2H8Z"
+      fill="#C5C5C5"
+    />
+  </svg>
+`
+
+export default {
+  SaveIcon,
+}

--- a/src/client/components/icons/share.ts
+++ b/src/client/components/icons/share.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit'
 
 /* eslint-disable max-len */
-export const ShareIcon = html` <svg
+export const ShareIcon = html`<svg
   class="icon"
   width="16"
   height="16"

--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -710,6 +710,7 @@ export class TerminalView extends LitElement {
           () =>
             html` <share-cell
               ?disabled=${this.isCloudApiLoading}
+              ?displayShareIcon=${this.isShareReady}
               shareText="${this.isCloudApiLoading ? 'Saving ...' : this.shareText}"
               @onShare="${this.#shareCellOutput}"
             >

--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -24,7 +24,7 @@ interface IWindowSize {
 }
 
 enum MessageOptions {
-  OpenLink = 'Open link',
+  OpenLink = 'Open',
   CopyToClipboard = 'Copy to clipboard',
   Cancel = 'Cancel',
 }
@@ -65,7 +65,8 @@ const ANSI_COLORS = [
 @customElement(RENDERERS.TerminalView)
 export class TerminalView extends LitElement {
   protected copyText = 'Copy'
-  protected shareText = 'Share'
+  protected shareText = 'Save'
+  protected shareEnabledText = 'Share'
 
   static styles = css`
     .xterm {
@@ -255,12 +256,12 @@ export class TerminalView extends LitElement {
     }
 
     vscode-button {
-      background: transparent;
-      color: #ccc;
+      color: var(--vscode-button-foreground);
+      background-color: var(--vscode-button-background);
       transform: scale(0.9);
     }
     vscode-button:hover {
-      background: var(--button-secondary-background);
+      background: var(--vscode-button-hoverBackground);
     }
     vscode-button:focus {
       outline: #007fd4 1px solid;
@@ -332,6 +333,9 @@ export class TerminalView extends LitElement {
   @property({ type: Boolean })
   enableShareButton: boolean = false
 
+  @property()
+  isShareReady: boolean = false
+
   constructor() {
     super()
     this.windowSize = {
@@ -397,7 +401,10 @@ export class TerminalView extends LitElement {
                 return
               }
               if (e.type === ClientMessages.terminalStdout) {
+                this.shareText = 'Save'
+                this.isShareReady = false
                 this.terminal!.write(data)
+                this.requestUpdate()
               }
             }
             break
@@ -416,7 +423,8 @@ export class TerminalView extends LitElement {
                 },
               } = e.output.data
               this.shareUrl = htmlUrl
-              await this.#displayShareDialog()
+              this.shareText = this.shareEnabledText
+              this.isShareReady = true
             }
             break
 
@@ -635,6 +643,8 @@ export class TerminalView extends LitElement {
     if (!ctx.postMessage || !this.shareUrl) {
       return
     }
+    this.shareText = this.shareEnabledText
+    this.isShareReady = true
     return postClientMessage(ctx, ClientMessages.optionsMessage, {
       title: 'Share link created',
       options: Object.values(MessageOptions),
@@ -648,6 +658,10 @@ export class TerminalView extends LitElement {
       return
     }
     try {
+      if (this.isShareReady) {
+        return this.#displayShareDialog()
+      }
+
       this.isCloudApiLoading = true
       const contentWithAnsi =
         this.serializer?.serialize({ excludeModes: true, excludeAltBuffer: true }) ?? ''
@@ -696,7 +710,7 @@ export class TerminalView extends LitElement {
           () =>
             html` <share-cell
               ?disabled=${this.isCloudApiLoading}
-              shareText="${this.isCloudApiLoading ? 'Generating link ...' : this.shareText}"
+              shareText="${this.isCloudApiLoading ? 'Saving ...' : this.shareText}"
               @onShare="${this.#shareCellOutput}"
             >
             </share-cell>`,

--- a/src/client/components/terminal/share.ts
+++ b/src/client/components/terminal/share.ts
@@ -13,6 +13,9 @@ export class ShareCell extends LitElement {
   @property({ type: Boolean, reflect: true })
   disabled: boolean = false
 
+  @property({ type: Boolean, reflect: true })
+  displayShareIcon: boolean = false
+
   /* eslint-disable */
   static styles = css`
     vscode-button {
@@ -46,12 +49,12 @@ export class ShareCell extends LitElement {
       this.disabled,
       () => html`
         <vscode-button disabled appearance="secondary" @click=${this.onShareClick}>
-          ${SaveIcon} ${this.shareText}
+          ${ShareIcon} ${this.shareText}
         </vscode-button>
       `,
       () => html`
         <vscode-button appearance="secondary" @click=${this.onShareClick}>
-          ${ShareIcon} ${this.shareText}
+          ${this.displayShareIcon ? ShareIcon : SaveIcon} ${this.shareText}
         </vscode-button>
       `
     )

--- a/src/client/components/terminal/share.ts
+++ b/src/client/components/terminal/share.ts
@@ -3,6 +3,7 @@ import { customElement, property } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
 import { ShareIcon } from '../icons/share'
+import { SaveIcon } from '../icons/save'
 
 @customElement('share-cell')
 export class ShareCell extends LitElement {
@@ -15,12 +16,12 @@ export class ShareCell extends LitElement {
   /* eslint-disable */
   static styles = css`
     vscode-button {
-      background: transparent;
-      color: #ccc;
+      color: var(--vscode-button-foreground);
+      background-color: var(--vscode-button-background);
       transform: scale(0.9);
     }
     vscode-button:hover {
-      background: var(--button-secondary-background);
+      background: var(--vscode-button-hoverBackground);
     }
     vscode-button:focus {
       outline: #007fd4 1px solid;
@@ -45,7 +46,7 @@ export class ShareCell extends LitElement {
       this.disabled,
       () => html`
         <vscode-button disabled appearance="secondary" @click=${this.onShareClick}>
-          ${ShareIcon} ${this.shareText}
+          ${SaveIcon} ${this.shareText}
         </vscode-button>
       `,
       () => html`


### PR DESCRIPTION
This PR introduces a saving state icon and fixes button color theme inconsistency.

🎥  Saving state

![share-icon](https://github.com/stateful/vscode-runme/assets/4001529/b4c57641-3354-49fd-baee-203a6fece434)


🎥  Color fix

![colors-runme](https://github.com/stateful/vscode-runme/assets/4001529/6b628cd2-ec51-46e7-8069-6f7ce4786c84)

Solves https://github.com/stateful/vscode-runme/issues/675
