### PR TITLE
Introduce terminalRows annotation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -156,8 +156,8 @@ echo Columns: \$(tput cols)
 
 With [`antonmedv/fx`](https://github.com/antonmedv/fx) you can inspect JSON files interactively in Runme notebooks, e.g.:
 
-```sh
-curl "https://api.marquee.activecove.com/getWeather?lat=52&lon=10" | fx
+```sh { terminalRows=20 }
+curl -s "https://api.marquee.activecove.com/getWeather?lat=52&lon=10" | fx
 ```
 
 ## YAML

--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -151,8 +151,7 @@ export class Annotations extends LitElement {
     },
     terminalRows: {
       description: 'Number of rows to display in the notebook terminal.',
-      // FIXME: provide docs link
-      docs: '',
+      docs: 'https://docs.runme.dev/configuration#cell-options',
     },
   }
 

--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -149,6 +149,11 @@ export class Annotations extends LitElement {
       description: 'Prevent executing this cell during the "Run All" operation.',
       docs: 'https://docs.runme.dev/configuration#cell-options',
     },
+    terminalRows: {
+      description: 'Number of rows to display in the notebook terminal.',
+      // FIXME: provide docs link
+      docs: '',
+    },
   }
 
   // Declare reactive properties
@@ -437,6 +442,7 @@ export class Annotations extends LitElement {
             <div class="box">${this.renderCheckboxTabEntry('promptEnv')}</div>
             <div class="box">${this.renderTextFieldTabEntry('mimeType')}</div>
             <div class="box">${this.renderCategoryTabEntry('category')}</div>
+            <div class="box">${this.renderTextFieldTabEntry('terminalRows')}</div>
           </div>
         </vscode-panel-view>
       </vscode-panels>

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -151,7 +151,7 @@ export class NotebookCellOutputManager {
           return
         }
 
-        const cellId = getAnnotations(cell)['runme.dev/uuid']
+        const { 'runme.dev/uuid': cellId, terminalRows } = getAnnotations(cell)
         if (!cellId) {
           throw new Error('Cannot open cell terminal with invalid UUID!')
         }
@@ -172,7 +172,7 @@ export class NotebookCellOutputManager {
               terminalFontFamily,
               terminalFontSize,
               content: terminalState.serialize(),
-              initialRows: getNotebookTerminalRows(),
+              initialRows: terminalRows || getNotebookTerminalRows(),
               enableShareButton: isRunmeApiEnabled(),
             },
           }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -50,6 +50,16 @@ export const AnnotationSchema = {
   closeTerminalOnSuccess: boolify(true),
   promptEnv: boolify(true),
   excludeFromRunAll: boolify(false),
+  terminalRows: z.preprocess((subject) => {
+    if (typeof subject === 'string' && subject) {
+      const numeric = Number(subject)
+      if (Number.isFinite(numeric)) {
+        return numeric
+      }
+    }
+
+    return undefined
+  }, z.number().int().positive().optional()),
   name: z.preprocess(
     (value) => (typeof value === 'string' ? cleanAnnotation(value, ',') : value),
     z.string().default('')


### PR DESCRIPTION
Introduces `terminalRows` to select the number of rows for this cell.

In a future PR, we can consider syncing with the existing terminal, as well as edge validation cases.