### PR TITLE
persistent TLS certificate location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/e2e/logs
 tests/e2e/screenshots
 bin
 vscode-runme-CHANGELOG.txt
+/tls

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -184,7 +184,7 @@ export function runCLICommand(
       envs['RUNME_SERVER_ADDR'] = server.address()
 
       if (getTLSEnabled()) {
-        envs['RUNME_TLS_DIR'] = getTLSDir()
+        envs['RUNME_TLS_DIR'] = getTLSDir(extensionBaseUri)
       } else {
         args.push('--insecure')
       }

--- a/src/extension/server/runmeServer.ts
+++ b/src/extension/server/runmeServer.ts
@@ -55,7 +55,7 @@ class RunmeServer implements Disposable {
   readonly onTransportReady = this.#onTransportReady.event
 
   constructor(
-    extBasePath: Uri,
+    protected readonly extBasePath: Uri,
     options: IServerConfig,
     externalServer: boolean,
     protected readonly enableRunner = false
@@ -125,12 +125,16 @@ class RunmeServer implements Disposable {
     }
   }
 
+  protected getTLSDir(): string {
+    return getTLSDir(this.extBasePath)
+  }
+
   protected async channelCredentials(): Promise<ChannelCredentials> {
     if (!getTLSEnabled()) {
       return ChannelCredentials.createInsecure()
     }
 
-    const { certPEM, privKeyPEM } = await RunmeServer.getTLS(getTLSDir())
+    const { certPEM, privKeyPEM } = await RunmeServer.getTLS(this.getTLSDir())
 
     return ChannelCredentials.createSsl(certPEM, privKeyPEM, certPEM)
   }
@@ -184,7 +188,7 @@ class RunmeServer implements Disposable {
     }
 
     if (getTLSEnabled()) {
-      args.push('--tls', getTLSDir())
+      args.push('--tls', this.getTLSDir())
     } else {
       args.push('--insecure')
     }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -3,7 +3,6 @@ import os from 'node:os'
 
 import { ExtensionContext, NotebookCell, Uri, workspace } from 'vscode'
 import { z } from 'zod'
-import { v4 as uuidv4 } from 'uuid'
 
 import { getAnnotations, isWindows } from '../extension/utils'
 import { SERVER_PORT } from '../constants'
@@ -17,7 +16,6 @@ const CLI_SECTION_NAME = 'runme.cli'
 const APP_SECTION_NAME = 'runme.app'
 
 export const OpenViewInEditorAction = z.enum(['split', 'toggle'])
-export const DEFAULT_TLS_DIR = path.join(os.tmpdir(), 'runme', uuidv4(), 'tls')
 const DEFAULT_WORKSPACE_FILE_ORDER = ['.env.local', '.env']
 const DEFAULT_RUNME_APP_API_URL = 'https://api.runme.dev/graphql'
 
@@ -32,7 +30,7 @@ const configurationSchema = {
     binaryPath: z.string().optional(),
     enableLogger: z.boolean().default(false),
     enableTLS: z.boolean().default(true),
-    tlsDir: z.string().nonempty().default(DEFAULT_TLS_DIR),
+    tlsDir: z.string().optional(),
   },
   notebookTerminal: {
     backgroundTask: z.boolean().default(true),
@@ -166,8 +164,10 @@ const getTLSEnabled = (): boolean => {
   return getServerConfigurationValue('enableTLS', true)
 }
 
-const getTLSDir = (): string => {
-  return getServerConfigurationValue('tlsDir', DEFAULT_TLS_DIR)
+const getTLSDir = (extensionsDir: Uri): string => {
+  return (
+    getServerConfigurationValue('tlsDir', undefined) || Uri.joinPath(extensionsDir, 'tls').fsPath
+  )
 }
 
 const getBinaryPath = (extensionBaseUri: Uri, platform: string): Uri => {

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -9,7 +9,6 @@ import {
   getBinaryPath,
   getServerConfigurationValue,
   getTLSDir,
-  DEFAULT_TLS_DIR,
   getNotebookTerminalFontFamily,
   getNotebookTerminalFontSize,
   getCodeLensEnabled,
@@ -121,12 +120,12 @@ suite('Configuration', () => {
 
     test('Should get default TLS dir by default', () => {
       SETTINGS_MOCK.tlsDir = undefined
-      expect(getTLSDir()).toBe(DEFAULT_TLS_DIR)
+      expect(getTLSDir(Uri.file('/ext/base'))).toBe(Uri.file('/ext/base/tls').fsPath)
     })
 
     test('Should get set TLS dir if set', () => {
       SETTINGS_MOCK.tlsDir = '/tmp/runme/tls'
-      expect(getTLSDir()).toBe('/tmp/runme/tls')
+      expect(getTLSDir(Uri.file('/ext/base'))).toBe('/tmp/runme/tls')
     })
 
     test('getServerConfigurationValue Should default to undefined binaryPath', () => {


### PR DESCRIPTION
Makes TLS location persistent. Required for certificate rotation to make a difference on the extension-side.