### PR TITLE
Add alternatives to *.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,6 +305,15 @@
           },
           {
             "filenamePattern": "*.mdi"
+          },
+          {
+            "filenamePattern": "*.mdr"
+          },
+          {
+            "filenamePattern": "*.run"
+          },
+          {
+            "filenamePattern": "*.runme"
           }
         ]
       }


### PR DESCRIPTION
To make it easier for users who want to use Runme but not for all markdown files everywhere.