### PR TITLE
Fix editor codelens execution for shebang

### DIFF
--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -127,17 +127,17 @@ export async function executeRunner(
   const { programName, commandMode } = getCellProgram(exec.cell, exec.cell.notebook, execKey)
 
   const program = await runner.createProgramSession({
-    programName,
-    environment,
-    exec: execution,
-    envs: Object.entries(envs).map(([k, v]) => `${k}=${v}`),
-    cwd,
     background,
-    tty: interactive,
-    convertEol: !mimeType || mimeType === 'text/plain',
-    storeLastOutput: true,
-    languageId: exec.cell.document.languageId,
     commandMode,
+    convertEol: !mimeType || mimeType === 'text/plain',
+    cwd,
+    environment,
+    envs: Object.entries(envs).map(([k, v]) => `${k}=${v}`),
+    exec: execution,
+    languageId: exec.cell.document.languageId,
+    programName,
+    storeLastOutput: true,
+    tty: interactive,
   })
 
   context.subscriptions.push(program)

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -118,11 +118,8 @@ export class RunmeTaskProvider implements TaskProvider {
 
     const isBackground = options.isBackground || background
 
-    const { programName, commandMode } = getCellProgram(
-      cell,
-      notebook,
-      ('languageId' in cell && cell.languageId) || 'sh'
-    )
+    const languageId = ('languageId' in cell && cell.languageId) || 'sh'
+    const { programName, commandMode } = getCellProgram(cell, notebook, languageId)
 
     const name = `${command}`
 
@@ -151,18 +148,16 @@ export class RunmeTaskProvider implements TaskProvider {
         }
 
         const runOpts: RunProgramOptions = {
-          programName,
-          exec: {
-            type: 'commands',
-            commands: commands ?? [''],
-          },
+          commandMode,
+          convertEol: true,
           cwd,
           environment,
-          tty: interactive,
-          convertEol: true,
           envs: Object.entries(envs).map(([k, v]) => `${k}=${v}`),
+          exec: { type: 'commands', commands: commands ?? [''] },
+          languageId,
+          programName,
           storeLastOutput: true,
-          commandMode,
+          tty: interactive,
         }
 
         const program = await runner.createProgramSession(runOpts)


### PR DESCRIPTION
Pass `languageId` down into the execution when present to avoid fallback behavior. "Mirrors" notebook execution.

Fixes: https://github.com/stateful/vscode-runme/issues/723