### PR TITLE
(bugfix): fix Vercel deployment workflow

### DIFF
--- a/src/extension/executors/vercel.ts
+++ b/src/extension/executors/vercel.ts
@@ -117,5 +117,5 @@ export async function handleVercelDeployOutput(
 }
 
 export function isVercelDeployScript(script: string): boolean {
-  return script.trim().endsWith('vercel')
+  return Boolean(script.split(';').pop()?.trim() === 'vercel')
 }

--- a/tests/extension/executors/vercel.test.ts
+++ b/tests/extension/executors/vercel.test.ts
@@ -1,0 +1,25 @@
+import { test, expect, vi } from 'vitest'
+
+import { isVercelDeployScript } from '../../../src/extension/executors/vercel.js'
+
+vi.mock('vscode')
+vi.mock('vscode-telemetry')
+vi.mock('../../../src/extension/executors/task.js', () => ({
+  bash: vi.fn(),
+  sh: vi.fn()
+}))
+vi.mock('../../../src/extension/executors/vercel/index.js', () => ({
+  deploy: vi.fn(),
+  login: vi.fn(),
+  logout: vi.fn()
+}))
+vi.mock('../../../src/extension/cell.js', () => ({
+  NotebookCellOutputManager: vi.fn(),
+  updateCellMetadata: vi.fn()
+}))
+
+test('isVercelDeployScript', () => {
+  expect(isVercelDeployScript('set -e -o pipefail; npm i -g vercel')).toBe(false)
+  expect(isVercelDeployScript('set -e -o pipefail; vercel login')).toBe(false)
+  expect(isVercelDeployScript('set -e -o pipefail; vercel')).toBe(true)
+})


### PR DESCRIPTION
The Vercel deployment view would appear even if calling `npm i vercel`:

![vercelerror](https://github.com/stateful/vscode-runme/assets/731337/1a6c24fe-5901-4932-a384-95855917d948)

This patch fixes this error.