### PR TITLE
(test): add e2e test for github workflow usecase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           run: npx runme run configureNPM setup build test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNME_TEST_TOKEN: ${{ secrets.RUNME_TEST_TOKEN }}
           RUNME_PROJECT: ${{ github.workspace }}
           SHELL: bash
       - name: 🔼 Upload Artifacts

--- a/examples/test.md
+++ b/examples/test.md
@@ -11,3 +11,9 @@ This markdown file contains some custom examples to test the execution within a 
 ```sh { background=false interactive=false }
 echo "Hello World!"
 ```
+
+# GitHub Action Integration
+
+```yaml
+https://github.com/stateful/runme-canary/actions/workflows/test-inputs.yml
+```

--- a/src/extension/executors/github.ts
+++ b/src/extension/executors/github.ts
@@ -1,10 +1,10 @@
-import { NotebookCellExecution, TextDocument, authentication, window } from 'vscode'
+import { NotebookCellExecution, TextDocument, window } from 'vscode'
 
 import type { Kernel } from '../kernel'
 import { NotebookCellOutputManager } from '../cell'
-import { AuthenticationProviders, OutputType } from '../../constants'
+import { OutputType } from '../../constants'
 
-import { parseGitHubURL, getYamlFileContents } from './github/workflows'
+import { parseGitHubURL, getYamlFileContents, getService } from './github/workflows'
 
 export async function github(
   this: Kernel,
@@ -13,9 +13,7 @@ export async function github(
   outputs: NotebookCellOutputManager
 ): Promise<boolean> {
   try {
-    await authentication.getSession(AuthenticationProviders.GitHub, ['repo'], {
-      createIfNone: true,
-    })
+    await getService(true)
     const { owner, repo, path, ref } = parseGitHubURL(doc.getText())
     const json = await getYamlFileContents({ owner, repo, path })
     outputs.setState({

--- a/src/extension/executors/github/workflows.ts
+++ b/src/extension/executors/github/workflows.ts
@@ -51,11 +51,14 @@ export async function deployWorkflow(
 }
 
 export async function getService(createIfNone?: boolean) {
-  const session = (
+  const session =
     // @ts-expect-error test token only for testing purposes
     globalThis._RUNME_TEST_TOKEN ||
-    await authentication.getSession(AuthenticationProviders.GitHub, ['repo'], createIfNone ? { createIfNone } : {})
-  )
+    (await authentication.getSession(
+      AuthenticationProviders.GitHub,
+      ['repo'],
+      createIfNone ? { createIfNone } : {}
+    ))
   if (!session) {
     throw new Error('Missing a valid GitHub session')
   }

--- a/src/extension/executors/github/workflows.ts
+++ b/src/extension/executors/github/workflows.ts
@@ -2,6 +2,7 @@ import { authentication } from 'vscode'
 
 import { GitHubService } from '../../services'
 import { IWorkflowDispatchOptions, IWorkflowRun } from '../../services/types'
+import { AuthenticationProviders } from '../../../constants'
 
 export type IGitHubURLParts = {
   owner: string
@@ -49,8 +50,12 @@ export async function deployWorkflow(
   }
 }
 
-export async function getService() {
-  const session = await authentication.getSession('github', ['repo'])
+export async function getService(createIfNone?: boolean) {
+  const session = (
+    // @ts-expect-error test token only for testing purposes
+    globalThis._RUNME_TEST_TOKEN ||
+    await authentication.getSession(AuthenticationProviders.GitHub, ['repo'], createIfNone ? { createIfNone } : {})
+  )
   if (!session) {
     throw new Error('Missing a valid GitHub session')
   }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -83,7 +83,7 @@ export class RunmeExtension {
       TelemetryReporter.sendTelemetryErrorEvent('extension.server', { data: (e as Error).message })
       return window.showErrorMessage(
         'Failed to start Runme server, please try to reload the window. ' +
-          `Reason: ${(e as any).message}`
+        `Reason: ${(e as any).message}`
       )
     }
 
@@ -168,8 +168,8 @@ export class RunmeExtension {
       RunmeExtension.registerCommand('runme.welcome', welcome),
       RunmeExtension.registerCommand('runme.try', () => tryIt(context)),
       RunmeExtension.registerCommand('runme.openRunmeFile', RunmeLauncherProvider.openFile),
-      RunmeExtension.registerCommand('runme.keybinding.m', () => {}),
-      RunmeExtension.registerCommand('runme.keybinding.y', () => {}),
+      RunmeExtension.registerCommand('runme.keybinding.m', () => { }),
+      RunmeExtension.registerCommand('runme.keybinding.y', () => { }),
       RunmeExtension.registerCommand('runme.file.openInRunme', openFileInRunme),
       tasks.registerTaskProvider(
         RunmeTaskProvider.id,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -83,7 +83,7 @@ export class RunmeExtension {
       TelemetryReporter.sendTelemetryErrorEvent('extension.server', { data: (e as Error).message })
       return window.showErrorMessage(
         'Failed to start Runme server, please try to reload the window. ' +
-        `Reason: ${(e as any).message}`
+          `Reason: ${(e as any).message}`
       )
     }
 
@@ -168,8 +168,8 @@ export class RunmeExtension {
       RunmeExtension.registerCommand('runme.welcome', welcome),
       RunmeExtension.registerCommand('runme.try', () => tryIt(context)),
       RunmeExtension.registerCommand('runme.openRunmeFile', RunmeLauncherProvider.openFile),
-      RunmeExtension.registerCommand('runme.keybinding.m', () => { }),
-      RunmeExtension.registerCommand('runme.keybinding.y', () => { }),
+      RunmeExtension.registerCommand('runme.keybinding.m', () => {}),
+      RunmeExtension.registerCommand('runme.keybinding.y', () => {}),
       RunmeExtension.registerCommand('runme.file.openInRunme', openFileInRunme),
       tasks.registerTaskProvider(
         RunmeTaskProvider.id,

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -3,7 +3,7 @@ import { Key } from 'webdriverio'
 import { RunmeNotebook } from '../pageobjects/notebook.page.js'
 import type { NotebookCell } from '../pageobjects/cell.page.js'
 
-describe('Runme Codelense Support', async () => {
+describe('Runme GitHub Workflow Integration', async () => {
   const notebook = new RunmeNotebook()
   const token = process.env.RUNME_TEST_TOKEN
 

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -5,6 +5,13 @@ describe('Runme Codelense Support', async () => {
   const notebook = new RunmeNotebook()
   const token = process.env.RUNME_TEST_TOKEN
 
+  /**
+   * Skip GitHub Action tests for local testing due to missing token
+   */
+  if (!token && !process.env.CI) {
+    return
+  }
+
   it('has GitHub test token defined in the environment', async () => {
     expect(token).toBeDefined()
   })

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -1,3 +1,5 @@
+import { Key } from 'webdriverio'
+
 import { RunmeNotebook } from '../pageobjects/notebook.page.js'
 import type { NotebookCell } from '../pageobjects/cell.page.js'
 
@@ -37,6 +39,10 @@ describe('Runme Codelense Support', async () => {
     })
 
     it('should open GitHub Action trigger view', async () => {
+      await browser.action('key')
+        .down(Key.Ctrl).down(Key.Subtract)
+        .pause(100)
+        .perform()
       await cell.run()
       await cell.switchIntoCellFrame()
       await expect($('>>>.github-workflow-item-container')).toBePresent()

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -8,7 +8,7 @@ describe('Runme Codelense Support', async () => {
   /**
    * Skip GitHub Action tests for local testing due to missing token
    */
-  if (!token && !process.env.CI) {
+  if ((!token && !process.env.CI) || process.env.NODE_ENV === 'production') {
     return
   }
 

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -11,7 +11,7 @@ describe('Runme Codelense Support', async () => {
 
   it('open test markdown file', async () => {
     await browser.executeWorkbench(async (vscode, accessToken) => {
-      // @ts-expect-error
+      // @ts-expect-error inject test token
       globalThis._RUNME_TEST_TOKEN = { accessToken }
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/examples/test.md`)

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -1,0 +1,54 @@
+import { RunmeNotebook } from '../pageobjects/notebook.page.js'
+import type { NotebookCell } from '../pageobjects/cell.page.js'
+
+describe('Runme Codelense Support', async () => {
+  const notebook = new RunmeNotebook()
+  const token = process.env.RUNME_TEST_TOKEN
+
+  it('has GitHub test token defined in the environment', async () => {
+    expect(token).toBeDefined()
+  })
+
+  it('open test markdown file', async () => {
+    await browser.executeWorkbench(async (vscode, accessToken) => {
+      // @ts-expect-error
+      globalThis._RUNME_TEST_TOKEN = { accessToken }
+      const doc = await vscode.workspace.openTextDocument(
+        vscode.Uri.file(`${vscode.workspace.rootPath}/examples/test.md`)
+      )
+      return vscode.window.showNotebookDocument(doc, {
+        viewColumn: vscode.ViewColumn.Active
+      })
+    }, token)
+  })
+
+  describe('trigger workflow', () => {
+    let cell: NotebookCell
+    before(async () => {
+      await notebook.focusDocument()
+      cell = await notebook.getCell('https://github.com/stateful/runme-canary/actions/workflows/test-inputs.yml')
+    })
+
+    it('should open GitHub Action trigger view', async () => {
+      await cell.run()
+      await cell.switchIntoCellFrame()
+      await expect($('>>>.github-workflow-item-container')).toBePresent()
+    })
+
+    it('should trigger GitHub Action', async () => {
+      const outputContainer = $('>>>.github-workflow-item-container')
+      await outputContainer.$('aria/Run Workflow').click()
+      await outputContainer
+        .$('github-workflow-run[status="queued"]')
+        .waitForExist({ timeout: 60000 })
+      await outputContainer
+        .$('github-workflow-run[status="in_progress"]')
+        .waitForExist({ timeout: 60000 })
+      await outputContainer
+        .$('github-workflow-run[status="completed"][conclusion="success"]')
+        .waitForExist({ timeout: 60000 })
+    })
+
+    after(() => cell.switchOutOfCellFrame())
+  })
+})

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -3,8 +3,17 @@ import path from 'node:path'
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin'
 import { Configuration, DefinePlugin } from 'webpack'
 
+enum Mode {
+  PRODUCTION = 'production',
+  DEVELOPMENT = 'development'
+}
+const mode = process.env.NODE_ENV !== Mode.DEVELOPMENT
+  ? Mode.PRODUCTION
+  : Mode.DEVELOPMENT
+const testToken = 'globalThis._RUNME_TEST_TOKEN'
+
 const baseConfig: Partial<Configuration> = {
-  mode: process.env.NODE_ENV ? 'production' : 'development',
+  mode,
   devtool: 'source-map',
   externals: {
     vscode: 'commonjs vscode',
@@ -66,7 +75,10 @@ const extensionConfig: Configuration = {
   },
   plugins: [
     new DefinePlugin({
-      INSTRUMENTATION_KEY: JSON.stringify(process.env.INSTRUMENTATION_KEY || 'invalid')
+      INSTRUMENTATION_KEY: JSON.stringify(process.env.INSTRUMENTATION_KEY || 'invalid'),
+      [testToken]: mode === Mode.DEVELOPMENT
+        ? testToken
+        : 'false'
     })
   ]
 }


### PR DESCRIPTION
fixes #748

The test injects an environment variable to the global scope during test that helps to circumvent the GitHub authentication process. I made sure that this loophole is not available when compiling the extension in production.