### PR TITLE
Keep stdout & stderr separate and standalone

### DIFF
--- a/src/extension/messages/cloudApiRequest/saveCellExecution.ts
+++ b/src/extension/messages/cloudApiRequest/saveCellExecution.ts
@@ -55,8 +55,8 @@ export default async function saveCellExecution(
       mutation: CreateCellExecutionDocument,
       variables: {
         data: {
-          stdout: exitCode === 0 ? terminalContents : Array.from([]),
-          stderr: exitCode !== 0 ? terminalContents : Array.from([]),
+          stdout: terminalContents,
+          stderr: Array.from([]), // stderr will become applicable for non-terminal
           exitCode,
           pid,
           input: encodeURIComponent(cell.document.getText()),


### PR DESCRIPTION
We should be able to merge this independently from the terminal-based error code fix.