### PR TITLE
Fix Terminal state

### DIFF
--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -345,7 +345,7 @@ export async function executeRunner(
       }
 
       terminal.runnerSession = program
-      kernel.registerTerminal(terminal, executionId)
+      kernel.registerTerminal(terminal, executionId, RUNME_ID)
 
       // proxy pid value
       Object.defineProperty(terminal, 'processId', {

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -620,10 +620,16 @@ export class Kernel implements Disposable {
     return this.#controller.supportedLanguages
   }
 
-  registerTerminal(terminal: RunmeTerminal, executionId: number) {
+  registerTerminal(terminal: RunmeTerminal, executionId: number, runmeId: string) {
+    // Dispose previously attached terminal
+    const activeTerminal = this.activeTerminals.find((t) => t.runmeId === runmeId)
+    if (activeTerminal) {
+      activeTerminal.dispose()
+      this.activeTerminals.splice(this.activeTerminals.indexOf(activeTerminal), 1)
+    }
     const exists = this.activeTerminals.find((t) => t.executionId === executionId)
     if (!exists) {
-      this.activeTerminals.push({ ...terminal, executionId })
+      this.activeTerminals.push({ ...terminal, executionId, runmeId })
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,4 +315,4 @@ export interface IApiMessage<T extends ClientMessage<ClientMessages>> {
 
 export type ShellType = 'sh' | 'powershell' | 'cmd' | 'fish'
 
-export type ActiveTerminal = RunmeTerminal & { executionId: number }
+export type ActiveTerminal = RunmeTerminal & { executionId: number; runmeId: string }


### PR DESCRIPTION
Each time a new cell execution is triggered, if there is any existing executed integrated terminal, it should be removed and disposed, otherwise, it can create inconsistencies when referencing an active terminal by runme id.

We only need one single reference to the last active terminal per cell.