### PR TITLE
(fix): don't pass in 'null' when relying on defaults

### DIFF
--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -156,7 +156,6 @@ export class NotebookCellOutputManager {
 
         if (type === OutputType.terminal) {
           const terminalConfigurations = getNotebookTerminalConfigurations()
-
           const json: CellOutputPayload<OutputType.terminal> = {
             type: OutputType.terminal,
             output: {

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -29,16 +29,19 @@ const APP_LOOPBACK_MAPPING = new Map<string, string>([
 type NotebookTerminalValue = keyof typeof notebookTerminalSchema
 
 const editorSettings = workspace.getConfiguration('editor')
+const terminalSettings = workspace.getConfiguration('terminal.integrated')
 const notebookTerminalSchema = {
   backgroundTask: z.boolean().default(true),
   nonInteractive: z.boolean().default(false),
   interactive: z.boolean().default(true),
   fontSize: z.number().default(editorSettings.get<number>('fontSize', 10)),
-  fontFamily: z.string().default(editorSettings.get<string>('fontFamily', 'Arial')),
+  fontFamily: z
+    .string()
+    .default(editorSettings.get<string>('fontFamily', terminalSettings.get('fontFamily', 'Arial'))),
   rows: z.number().int().default(10),
   cursorStyle: z.enum(['block', 'bar', 'underline']).default('bar'),
   cursorBlink: z.boolean().default(true).optional(),
-  cursorWidth: z.number().optional(),
+  cursorWidth: z.number().min(1).optional(),
   smoothScrollDuration: z.number().optional(),
   scrollback: z.number().optional(),
 }
@@ -106,7 +109,9 @@ const getRunmeTerminalConfigurationValue = <T>(
 ) => {
   const configurationSection = workspace.getConfiguration(TERMINAL_SECTION_NAME)
   const configurationValue = configurationSection.get<T>(configName)!
-  const parseResult = notebookTerminalSchema[configName].safeParse(configurationValue)
+  const parseResult = notebookTerminalSchema[configName].safeParse(
+    configurationValue === null ? undefined : configurationValue,
+  )
   if (parseResult.success) {
     return parseResult.data as T
   }


### PR DESCRIPTION
I have introduced a side effect where passing in `null` into the Zod `safeParse` will fail return a default value. This patch fixes the problem.