### PR TITLE
Enable / Disable toggle envPrompt for Notebook

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,8 +184,13 @@
         "category": "Runme"
       },
       {
-        "command": "runme.skipPromptEnv",
-        "title": "Skip prompt environment variables",
+        "command": "runme.enableSkipPromptEnv",
+        "title": "Enable: Skip prompt environment variables",
+        "category": "Runme"
+      },
+      {
+        "command": "runme.disableSkipPromptEnv",
+        "title": "Disable: Skip prompt environment variables",
         "category": "Runme"
       }
     ],
@@ -240,7 +245,11 @@
           "when": "false"
         },
         {
-          "command": "runme.skipPromptEnv",
+          "command": "runme.enableSkipPromptEnv",
+          "when": "notebookType == runme"
+        },
+        {
+          "command": "runme.disableSkipPromptEnv",
           "when": "notebookType == runme"
         }
       ],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -142,6 +142,7 @@ export enum AuthenticationProviders {
 }
 export const NOTEBOOK_AVAILABLE_CATEGORIES = 'notebookAvailableCategories'
 export const NOTEBOOK_HAS_CATEGORIES = 'notebookHasCategories'
+export const NOTEBOOK_SKIP_ENV_PROMPT = 'skipPromptEnv'
 
 /**
  * https://gist.github.com/ppisarczyk/43962d06686722d26d176fad46879d41?permalink_comment_id=3949999#gistcomment-3949999

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -26,6 +26,7 @@ import {
   getTerminalByCell,
   getWorkspaceEnvs,
   prepareCmdSeq,
+  skipPromptEnvironmentSetting,
 } from '../utils'
 import { postClientMessage } from '../../utils/messaging'
 import { isNotebookTerminalEnabledForCell } from '../../utils/configuration'
@@ -87,8 +88,7 @@ export async function executeRunner(
 
   let cellText = exec.cell.document.getText()
 
-  const skipPromptEnv = context.globalState.get<string>('promptEnv') || ({} as any)
-  const promptEnvForCell = skipPromptEnv[exec.cell.notebook.uri.path] ? false : promptEnv
+  const promptEnvForCell = skipPromptEnvironmentSetting(context, exec.cell) ? false : promptEnv
 
   const commands = await parseCommandSeq(
     cellText,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -190,8 +190,11 @@ export class RunmeExtension {
       ),
       RunmeExtension.registerCommand('runme.expandTreeView', treeViewer.expandAll.bind(treeViewer)),
       RunmeExtension.registerCommand('runme.authenticateWithGitHub', authenticateWithGitHub),
-      RunmeExtension.registerCommand('runme.skipPromptEnv', () => {
-        return toggleDocumentPromptEnvSettings(context)
+      RunmeExtension.registerCommand('runme.enableSkipPromptEnv', () => {
+        return toggleDocumentPromptEnvSettings(context, true)
+      }),
+      RunmeExtension.registerCommand('runme.disableSkipPromptEnv', () => {
+        return toggleDocumentPromptEnvSettings(context, false)
       }),
       /**
        * Uri handler

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -80,7 +80,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(26)
+  expect(commands.registerCommand).toBeCalledTimes(28)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)


### PR DESCRIPTION
This PR introduces two new commands that allows to enable /disable skip the promptEnv setting for all the Notebook cells, this will prevent going cell by cell to disable the setting when is needed in certain operations.

<img width="760" alt="Screenshot 2023-09-20 at 10 35 26 PM" src="https://github.com/stateful/vscode-runme/assets/4001529/2815a28e-1129-4478-b010-49556aad38d3">

