### PR TITLE
Fix cursor width for terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -470,6 +470,7 @@
           },
           "runme.terminal.cursorWidth": {
             "type": "number",
+            "default": 1,
             "markdownDescription": "The width of the cursor in CSS pixels when `cursorStyle` is set to 'bar'."
           },
           "runme.terminal.smoothScrollDuration": {


### PR DESCRIPTION
The default cursor width should be 1 instead of 0