### PR TITLE
title bar icon upgrade

### DIFF
--- a/assets/runme-logo-dark.svg
+++ b/assets/runme-logo-dark.svg
@@ -1,4 +1,0 @@
-<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M16 1H2C1.44772 1 1 1.44772 1 2V16C1 16.5523 1.44772 17 2 17H16C16.5523 17 17 16.5523 17 16V2C17 1.44772 16.5523 1 16 1Z" stroke="white" stroke-width="0.5"/>
-<path d="M6 11.9842V6.00137C6 5.92847 12 8.92125 12 8.9928C12 9.06434 6 12.0776 6 11.9842Z" fill="white" stroke="white" stroke-width="0.5"/>
-</svg>

--- a/assets/runme-logo-light.svg
+++ b/assets/runme-logo-light.svg
@@ -1,4 +1,0 @@
-<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M16 1H2C1.44772 1 1 1.44772 1 2V16C1 16.5523 1.44772 17 2 17H16C16.5523 17 17 16.5523 17 16V2C17 1.44772 16.5523 1 16 1Z" stroke="black" stroke-width="0.5"/>
-<path d="M6 11.9842V6.00137C6 5.92847 12 8.92125 12 8.9928C12 9.06434 6 12.0776 6 11.9842Z" fill="black" stroke="black" stroke-width="0.5"/>
-</svg>

--- a/assets/runme-logo-open.svg
+++ b/assets/runme-logo-open.svg
@@ -1,0 +1,11 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="16" height="16" fill="transparent" />
+  <mask id="border" fill="white">
+    <rect x="1" y="1" width="14" height="14" rx="1" />
+  </mask>
+  <rect x="1" y="1" width="14" height="14" rx="1" stroke="black" stroke-width="2"
+    mask="url(#border)" />
+  <path
+    d="M10.25 7.56699C10.5833 7.75944 10.5833 8.24056 10.25 8.43301L5.75 11.0311C5.41667 11.2235 5 10.983 5 10.5981L5 5.40192C5 5.01702 5.41667 4.77646 5.75 4.96891L10.25 7.56699Z"
+    fill="black" />
+</svg>

--- a/package.json
+++ b/package.json
@@ -112,10 +112,7 @@
         "command": "runme.openAsRunmeNotebook",
         "category": "Runme",
         "title": "Open markdown as Runme",
-        "icon": {
-          "light": "assets/runme-logo-light.svg",
-          "dark": "assets/runme-logo-dark.svg"
-        }
+        "icon": "assets/runme-logo-open.svg"
       },
       {
         "command": "runme.openSplitViewAsMarkdownText",


### PR DESCRIPTION
move to a single runme logo for the title bar, 16x16, seems to properly inherit the right colors