### PR TITLE
Avoid race condition when dispose is called on terminals

### DIFF
--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -640,7 +640,7 @@ export class Kernel implements Disposable {
     // Dispose previously attached terminal
     const activeTerminal = this.activeTerminals.find((t) => t.runmeId === runmeId)
     if (activeTerminal) {
-      // activeTerminal.dispose()
+      activeTerminal.dispose()
       this.activeTerminals.splice(this.activeTerminals.indexOf(activeTerminal), 1)
     }
     const exists = this.activeTerminals.find((t) => t.executionId === executionId)

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -8,6 +8,7 @@ import {
   EventEmitter,
   window,
 } from 'vscode'
+import { interval, take, takeWhile, map } from 'rxjs'
 import { RpcError } from '@protobuf-ts/runtime-rpc'
 
 import type { DisposableAsync } from '../types'
@@ -660,15 +661,27 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
    * please use `_close` internally
    */
   close() {
-    if (this.hasExited()) {
-      return
-    }
-
-    this.session.requests.send(
-      ExecuteRequest.create({
-        stop: this.isPseudoterminal() ? ExecuteStop.INTERRUPT : ExecuteStop.KILL,
-      }),
+    let reason = this.hasExited()
+    // avoid race by giving it 1s to have a reason
+    const reasonInterval$ = interval(50).pipe(
+      take(20),
+      map(() => this.hasExited()),
+      takeWhile((r) => !Boolean(r)),
     )
+
+    reasonInterval$.subscribe({
+      next: (r) => (reason = r),
+      complete: () => {
+        if (reason) {
+          return
+        }
+        this.session.requests.send(
+          ExecuteRequest.create({
+            stop: this.isPseudoterminal() ? ExecuteStop.INTERRUPT : ExecuteStop.KILL,
+          }),
+        )
+      },
+    })
   }
 
   /**

--- a/tests/e2e/specs/basic.e2e.ts
+++ b/tests/e2e/specs/basic.e2e.ts
@@ -73,9 +73,11 @@ describe('Runme VS Code Extension', async () => {
       await tryExecuteCommand(workbench, 'clear all notifications')
     })
 
-    it('basic hello world shell execution', async () => {
+    it('basic hello world, run twice back-to-back', async () => {
       const cell = await notebook.getCell('echo "Hello World!')
 
+      // running 2x to avoid regression with terminal/process disposal
+      await cell.run()
       await cell.run()
 
       expect(await cell.getCellOutput(OutputType.TerminalView)).toStrictEqual([


### PR DESCRIPTION
Unfortunately, since we have to adhere to the pseudo terminal interface, calling `dispose` on a terminal will cause a race condition where for a period of time it's unclear whether or not the underlying process has exited. Stopping an already exited process breaking every "second" successive runs of back-to-back runs of a cell.

https://github.com/stateful/vscode-runme/pull/829/files#diff-61fe624cda28319d214d5b79f135f89003df9be2b56ee99ddd05978827d9b40bR627

This PR introduces a timeout of 1s which only occurs when background tasks are being stopped. Since they are a lot less common and stopping them is infrequent it feels like the right tradeoff to me.

Steps to repro: run same cell (background=false) multiple times consecutively. Please note that `main` currently forgoes `dispose` to unbreak cell execution.