### PR TITLE
Follow up fix to active terminal disposal race condition

### DIFF
--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -640,7 +640,6 @@ export class Kernel implements Disposable {
     // Dispose previously attached terminal
     const activeTerminal = this.activeTerminals.find((t) => t.runmeId === runmeId)
     if (activeTerminal) {
-      // activeTerminal.dispose()
       this.activeTerminals.splice(this.activeTerminals.indexOf(activeTerminal), 1)
     }
     const exists = this.activeTerminals.find((t) => t.executionId === executionId)


### PR DESCRIPTION
This is a follow-up to https://github.com/stateful/vscode-runme/pull/900.

After doing some research, it appears the best course of action is to only explicitly dispose resources Runme is actively creating to prevent negative side effects.