### PR TITLE
Add missing time for cell execution

### DIFF
--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -574,7 +574,7 @@ export class Kernel implements Disposable {
       'cell.success': successfulCellExecution?.toString(),
       'cell.mimeType': annotations.mimeType,
     })
-    runmeExec.end(successfulCellExecution)
+    runmeExec.end(successfulCellExecution, Date.now())
   }
 
   useRunner(runner: IRunner) {


### PR DESCRIPTION
This fix allows cell execution inspection time via **cell.executionSummary.timing.endTime** and **cell.executionSummary.timing.startTime**, without an end execution, we were missing that data.