### PR TITLE
Persist identity options in settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@apollo/client": "^3.8.3",
         "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.9.1-20230830152835-a5b3a068eb8c.1",
-        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20230721161725-b3ac1903dc85.1",
+        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20231108001143-5b6562ce6044.2",
         "@protobuf-ts/grpc-transport": "^2.9.1",
         "@protobuf-ts/runtime": "^2.9.1",
         "@protobuf-ts/runtime-rpc": "^2.9.1",
@@ -1562,8 +1562,8 @@
       }
     },
     "node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.9.1-20231023165751-d202d21adc55.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.1-20231023165751-d202d21adc55.1.tgz",
+      "version": "2.9.1-20231108001143-5b6562ce6044.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.1-20231108001143-5b6562ce6044.2.tgz",
       "peerDependencies": {
         "@protobuf-ts/runtime": "^2.9.1",
         "@protobuf-ts/runtime-rpc": "^2.9.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@apollo/client": "^3.8.3",
         "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.9.1-20230830152835-a5b3a068eb8c.1",
-        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20231108001143-5b6562ce6044.2",
+        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20231110144831-4699ec757527.2",
         "@protobuf-ts/grpc-transport": "^2.9.1",
         "@protobuf-ts/runtime": "^2.9.1",
         "@protobuf-ts/runtime-rpc": "^2.9.1",
@@ -1562,8 +1562,8 @@
       }
     },
     "node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.9.1-20231108001143-5b6562ce6044.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.1-20231108001143-5b6562ce6044.2.tgz",
+      "version": "2.9.1-20231110144831-4699ec757527.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.1-20231110144831-4699ec757527.2.tgz",
       "peerDependencies": {
         "@protobuf-ts/runtime": "^2.9.1",
         "@protobuf-ts/runtime-rpc": "^2.9.1"

--- a/package.json
+++ b/package.json
@@ -429,6 +429,24 @@
             ],
             "markdownDescription": "Connect to GRPC server via TCP or Unix Domain Socket (restart required - not available on Windows)"
           },
+          "runme.server.persistIdentity": {
+            "type": "number",
+            "scope": "window",
+            "default": 1,
+            "enum": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "enumItemLabels": [
+              "None",
+              "All",
+              "Document",
+              "Cell"
+            ],
+            "markdownDescription": "Select whether or not identities of document and/or cells should be presistent inside markdown"
+          },
           "runme.terminal.backgroundTask": {
             "type": "boolean",
             "scope": "machine",

--- a/package.json
+++ b/package.json
@@ -432,7 +432,7 @@
           "runme.server.persistIdentity": {
             "type": "number",
             "scope": "window",
-            "default": 1,
+            "default": 0,
             "enum": [
               0,
               1,
@@ -842,7 +842,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.3",
     "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.9.1-20230830152835-a5b3a068eb8c.1",
-    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20230721161725-b3ac1903dc85.1",
+    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20231108001143-5b6562ce6044.2",
     "@protobuf-ts/grpc-transport": "^2.9.1",
     "@protobuf-ts/runtime": "^2.9.1",
     "@protobuf-ts/runtime-rpc": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -842,7 +842,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.3",
     "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.9.1-20230830152835-a5b3a068eb8c.1",
-    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20231108001143-5b6562ce6044.2",
+    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20231110144831-4699ec757527.2",
     "@protobuf-ts/grpc-transport": "^2.9.1",
     "@protobuf-ts/runtime": "^2.9.1",
     "@protobuf-ts/runtime-rpc": "^2.9.1",

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -307,7 +307,7 @@ export class GrpcSerializer extends SerializerBase {
   private client?: ParserServiceClient
   protected ready: ReadyPromise
   protected readonly persistIdentity: ServerPersistIdentity =
-    getServerConfigurationValue<ServerPersistIdentity>('persistIdentity', RunmeIdentity.ALL)
+    getServerConfigurationValue<ServerPersistIdentity>('persistIdentity', RunmeIdentity.UNSPECIFIED)
 
   private serverReadyListener: Disposable | undefined
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -341,7 +341,7 @@ export class GrpcSerializer extends SerializerBase {
   ): Promise<Uint8Array> {
     const identity = this.persistIdentity
     const notebook = Notebook.clone(data as any)
-    const serialRequest = <SerializeRequest>{ notebook, identity }
+    const serialRequest = <SerializeRequest>{ notebook, options: { identity } }
 
     const request = await this.client!.serialize(serialRequest)
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -19,8 +19,14 @@ import { GrpcTransport } from '@protobuf-ts/grpc-transport'
 
 import { Serializer } from '../types'
 import { VSCODE_LANGUAGEID_MAP } from '../constants'
+import { ServerPersistIdentity, getServerConfigurationValue } from '../utils/configuration'
 
-import { DeserializeRequest, SerializeRequest, Notebook } from './grpc/serializerTypes'
+import {
+  DeserializeRequest,
+  SerializeRequest,
+  Notebook,
+  RunmeIdentity,
+} from './grpc/serializerTypes'
 import { initParserClient, ParserServiceClient } from './grpc/client'
 import Languages from './languages'
 import { PLATFORM_OS } from './constants'
@@ -300,6 +306,8 @@ export class WasmSerializer extends SerializerBase {
 export class GrpcSerializer extends SerializerBase {
   private client?: ParserServiceClient
   protected ready: ReadyPromise
+  protected readonly persistIdentity: ServerPersistIdentity =
+    getServerConfigurationValue<ServerPersistIdentity>('persistIdentity', RunmeIdentity.ALL)
 
   private serverReadyListener: Disposable | undefined
 
@@ -331,9 +339,9 @@ export class GrpcSerializer extends SerializerBase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     token: CancellationToken,
   ): Promise<Uint8Array> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const identity = this.persistIdentity
     const notebook = Notebook.clone(data as any)
-    const serialRequest = <SerializeRequest>{ notebook }
+    const serialRequest = <SerializeRequest>{ notebook, identity }
 
     const request = await this.client!.serialize(serialRequest)
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -358,7 +358,8 @@ export class GrpcSerializer extends SerializerBase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     token: CancellationToken,
   ): Promise<Serializer.Notebook> {
-    const deserialRequest = DeserializeRequest.create({ source: content })
+    const identity = this.persistIdentity
+    const deserialRequest = DeserializeRequest.create({ source: content, options: { identity } })
     const request = await this.client!.deserialize(deserialRequest)
 
     const { notebook } = request.response

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 
 import { getAnnotations, isWindows } from '../extension/utils'
 import { SERVER_PORT } from '../constants'
+import { RunmeIdentity } from '../extension/grpc/serializerTypes'
 
 const ACTIONS_SECTION_NAME = 'runme.actions'
 const SERVER_SECTION_NAME = 'runme.server'
@@ -57,6 +58,7 @@ const configurationSchema = {
     enableTLS: z.boolean().default(true),
     tlsDir: z.string().optional(),
     transportType: z.enum(['TCP', 'UDS']).default('TCP'),
+    persistIdentity: z.nativeEnum(RunmeIdentity).default(RunmeIdentity.ALL),
   },
   codelens: {
     enable: z.boolean().default(true),
@@ -79,6 +81,7 @@ const configurationSchema = {
 const notebookTerminalSchemaObject = z.object(notebookTerminalSchema)
 export type TerminalConfiguration = z.infer<typeof notebookTerminalSchemaObject>
 export type ServerTransportType = z.infer<typeof configurationSchema.server.transportType>
+export type ServerPersistIdentity = z.infer<typeof configurationSchema.server.persistIdentity>
 
 const getActionsConfigurationValue = <T>(
   configName: keyof typeof configurationSchema.actions,

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -58,7 +58,7 @@ const configurationSchema = {
     enableTLS: z.boolean().default(true),
     tlsDir: z.string().optional(),
     transportType: z.enum(['TCP', 'UDS']).default('TCP'),
-    persistIdentity: z.nativeEnum(RunmeIdentity).default(RunmeIdentity.ALL),
+    persistIdentity: z.nativeEnum(RunmeIdentity).default(RunmeIdentity.UNSPECIFIED),
   },
   codelens: {
     enable: z.boolean().default(true),

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -16,6 +16,7 @@ import {
   getCLIUseIntegratedRunme,
 } from '../../src/utils/configuration'
 import { SERVER_PORT } from '../../src/constants'
+import { RunmeIdentity } from '../../src/extension/grpc/serializerTypes'
 
 vi.mock('../../src/extension/grpc/client', () => ({}))
 vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
@@ -115,7 +116,7 @@ suite('Configuration', () => {
     expect(getTLSDir(Uri.file('/ext/base'))).toBe('/tmp/runme/tls')
   })
 
-  test('getServerConfigurationValue Should default to undefined binaryPath', () => {
+  test('getServerConfigurationValue should default to undefined binaryPath', () => {
     workspace.getConfiguration().update('binaryPath', undefined)
 
     expect(getServerConfigurationValue<string | undefined>('binaryPath', undefined)).toStrictEqual(
@@ -123,7 +124,7 @@ suite('Configuration', () => {
     )
   })
 
-  test('getServerConfigurationValue Should give proper binaryPath if defined', () => {
+  test('getServerConfigurationValue should give proper binaryPath if defined', () => {
     workspace.getConfiguration().update('binaryPath', '/binary/path')
 
     expect(getServerConfigurationValue<string | undefined>('binaryPath', undefined)).toStrictEqual(
@@ -131,11 +132,17 @@ suite('Configuration', () => {
     )
   })
 
+  test('getServerConfigurationValue should give default persist identity', () => {
+    expect(
+      getServerConfigurationValue<number>('persistIdentity', RunmeIdentity.UNSPECIFIED),
+    ).toStrictEqual(RunmeIdentity.ALL)
+  })
+
   test('getCodeLensEnabled should return true by default', () => {
     expect(getCodeLensEnabled()).toStrictEqual(true)
   })
 
-  test('getCLIUseIntegratexRunme should return false by default', () => {
+  test('getCLIUseIntegratedRunme should return false by default', () => {
     expect(getCLIUseIntegratedRunme()).toStrictEqual(false)
   })
 

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -133,9 +133,9 @@ suite('Configuration', () => {
   })
 
   test('getServerConfigurationValue should give default persist identity', () => {
-    expect(
-      getServerConfigurationValue<number>('persistIdentity', RunmeIdentity.UNSPECIFIED),
-    ).toStrictEqual(RunmeIdentity.ALL)
+    expect(getServerConfigurationValue<number>('persistIdentity', RunmeIdentity.ALL)).toStrictEqual(
+      RunmeIdentity.UNSPECIFIED,
+    )
   })
 
   test('getCodeLensEnabled should return true by default', () => {

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -24,6 +24,10 @@ vi.mock('vscode', () => ({
     onDidChangeNotebookDocument: vi.fn().mockReturnValue({ dispose: vi.fn() }),
     onDidSaveNotebookDocument: vi.fn().mockReturnValue({ dispose: vi.fn() }),
     applyEdit: vi.fn(),
+    getConfiguration: vi.fn().mockReturnValue({
+      update: vi.fn(),
+      get: vi.fn(),
+    }),
   },
   commands: { executeCommand: vi.fn() },
   WorkspaceEdit: Map<Uri, NotebookEdit[]>,


### PR DESCRIPTION
Depends on: https://github.com/stateful/runme/pull/416

The tests will fail until the proto changes are published to NPM. See trace below, this is expected.

```
ERROR in ./src/extension/serializer.ts:28:3
TS2305: Module '"./grpc/serializerTypes"' has no exported member 'RunmeIdentity'.
    26 |   SerializeRequest,
    27 |   Notebook,
  > 28 |   RunmeIdentity,
       |   ^^^^^^^^^^^^^
    29 | } from './grpc/serializerTypes'
    30 | import { initParserClient, ParserServiceClient } from './grpc/client'
    31 | import Languages from './languages'
```