### PR TITLE
PHP shebang fix

### DIFF
--- a/examples/shebang.md
+++ b/examples/shebang.md
@@ -35,3 +35,19 @@ then run:
 const myVar: string = 'I am a typed string!'
 console.log(myVar)
 ```
+
+## and, of course, PHP
+
+Be sure to have the `php` interpreter in your `$PATH`:
+
+```php { interpreter=php }
+<?php
+$greeting = "Hello, World!";
+$currentDateTime = date('Y-m-d H:i:s');
+
+// Concatenate the greeting with the current date and time
+$fullGreeting = $greeting . " It's now " . $currentDateTime . "\n";
+
+echo $fullGreeting;
+?>
+```

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -25,7 +25,6 @@ import {
   getCmdShellSeq,
   getTerminalByCell,
   getWorkspaceEnvs,
-  prepareCmdSeq,
 } from '../utils'
 import { postClientMessage } from '../../utils/messaging'
 import { isNotebookTerminalEnabledForCell } from '../../utils/configuration'
@@ -96,8 +95,8 @@ export async function executeRunner(
   const commands = await parseCommandSeq(
     cellText,
     skipPromptEnvDocumentLevel === false ? promptEnv : false,
+    execKey, // same as languageId
     new Set([...(environment?.initialEnvs() ?? []), ...Object.keys(envs)]),
-    prepareCmdSeq,
   )
   if (!commands) {
     return false

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -19,13 +19,7 @@ import { ClientMessages } from '../../constants'
 import { ClientMessage } from '../../types'
 import { PLATFORM_OS } from '../constants'
 import { IRunner, IRunnerEnvironment, RunProgramExecution } from '../runner'
-import {
-  getAnnotations,
-  getCellRunmeId,
-  getCmdShellSeq,
-  getTerminalByCell,
-  getWorkspaceEnvs,
-} from '../utils'
+import { getAnnotations, getCellRunmeId, getTerminalByCell, getWorkspaceEnvs } from '../utils'
 import { postClientMessage } from '../../utils/messaging'
 import { isNotebookTerminalEnabledForCell } from '../../utils/configuration'
 import { Kernel } from '../kernel'
@@ -39,6 +33,7 @@ import {
   getCellCwd,
   getCellProgram,
   getNotebookSkipPromptEnvSetting,
+  getCmdShellSeq,
 } from './utils'
 import { handleVercelDeployOutput, isVercelDeployScript } from './vercel'
 

--- a/src/extension/executors/runner.ts
+++ b/src/extension/executors/runner.ts
@@ -89,8 +89,8 @@ export async function executeRunner(
 
   const commands = await parseCommandSeq(
     cellText,
-    skipPromptEnvDocumentLevel === false ? promptEnv : false,
     execKey, // same as languageId
+    skipPromptEnvDocumentLevel === false ? promptEnv : false,
     new Set([...(environment?.initialEnvs() ?? []), ...Object.keys(envs)]),
   )
   if (!commands) {

--- a/src/extension/executors/task.ts
+++ b/src/extension/executors/task.ts
@@ -14,12 +14,12 @@ import {
 
 import getLogger from '../logger'
 // import { ExperimentalTerminal } from "../terminal"
-import { getCmdShellSeq, getAnnotations, getTerminalRunmeId } from '../utils'
+import { getAnnotations, getTerminalRunmeId } from '../utils'
 import { PLATFORM_OS, ENV_STORE } from '../constants'
 import type { Kernel } from '../kernel'
 import { NotebookCellOutputManager } from '../cell'
 
-import { retrieveShellCommand } from './utils'
+import { getCmdShellSeq, retrieveShellCommand } from './utils'
 import { sh as inlineSh } from './shell'
 
 const BACKGROUND_TASK_HIDE_TIMEOUT = 2000

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -18,7 +18,7 @@ import { ENV_STORE } from '../constants'
 import { DEFAULT_PROMPT_ENV, OutputType } from '../../constants'
 import type { CellOutputPayload, Serializer, ShellType } from '../../types'
 import { NotebookCellOutputManager } from '../cell'
-import { getAnnotations, getWorkspaceFolder } from '../utils'
+import { getAnnotations, getWorkspaceFolder, prepareCmdSeq } from '../utils'
 import { CommandMode } from '../grpc/runnerTypes'
 
 const ENV_VAR_REGEXP = /(\$\w+)/g
@@ -366,10 +366,12 @@ function resolveOrAbsolute(parent?: string, child?: string): string | undefined 
 export async function parseCommandSeq(
   cellText: string,
   promptForEnv = DEFAULT_PROMPT_ENV,
-  skipEnvs?: Set<string>,
-  parseBlock?: (block: string) => string[],
+  languageId: string,
+  skipEnvs: Set<string>,
 ): Promise<string[] | undefined> {
-  parseBlock ??= (s) => (s ? s.split('\n') : [])
+  const parseBlock = isShellLanguage(languageId)
+    ? prepareCmdSeq
+    : (s: string) => (s ? s.split('\n') : [])
 
   const exportMatches = getCommandExportExtractMatches(cellText, false, promptForEnv)
 

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -18,9 +18,10 @@ import { ENV_STORE } from '../constants'
 import { DEFAULT_PROMPT_ENV, OutputType } from '../../constants'
 import type { CellOutputPayload, Serializer, ShellType } from '../../types'
 import { NotebookCellOutputManager } from '../cell'
-import { getAnnotations, getWorkspaceFolder, prepareCmdSeq } from '../utils'
+import { getAnnotations, getWorkspaceFolder } from '../utils'
 import { CommandMode } from '../grpc/runnerTypes'
 
+const HASH_PREFIX_REGEXP = /^\s*\#\s*/g
 const ENV_VAR_REGEXP = /(\$\w+)/g
 /**
  * for understanding post into https://jex.im/regulex/
@@ -355,6 +356,72 @@ function resolveOrAbsolute(parent?: string, child?: string): string | undefined 
   }
 
   return child
+}
+
+/**
+ * treat cells like a series of individual commands
+ * which need to be executed in sequence
+ */
+export function getCmdSeq(cellText: string): string[] {
+  return cellText
+    .trimStart()
+    .split('\\\n')
+    .map((l) => l.trim())
+    .join(' ')
+    .split('\n')
+    .map((l) => {
+      const hashPos = l.indexOf('#')
+      if (hashPos > -1) {
+        return l.substring(0, hashPos).trim()
+      }
+      const stripped = l.trim()
+
+      if (stripped.startsWith('$')) {
+        return stripped.slice(1).trim()
+      } else {
+        return stripped
+      }
+    })
+    .filter((l) => {
+      const hasPrefix = (l.match(HASH_PREFIX_REGEXP) || []).length > 0
+      return l !== '' && !hasPrefix
+    })
+}
+
+/**
+ * treat cells like like a series of individual commands
+ * which need to be executed in sequence
+ *
+ * packages command sequence into single callable script
+ */
+export function getCmdShellSeq(cellText: string, os: string): string {
+  const trimmed = getCmdSeq(cellText).join('; ')
+
+  if (['darwin'].find((entry) => entry === os)) {
+    return `set -e -o pipefail; ${trimmed}`
+  } else if (os.toLocaleLowerCase().startsWith('win')) {
+    return trimmed
+  }
+
+  return `set -e; ${trimmed}`
+}
+
+/**
+ * Does the following to a command list:
+ *
+ * - Splits by new lines
+ * - Removes trailing `$` characters
+ */
+export function prepareCmdSeq(cellText: string): string[] {
+  return cellText.split('\n').map((l) => {
+    const stripped = l.trimStart()
+
+    if (stripped.startsWith('$')) {
+      return stripped.slice(1).trimStart()
+    }
+
+    return l
+  })
 }
 
 /**

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -432,9 +432,9 @@ export function prepareCmdSeq(cellText: string): string[] {
  */
 export async function parseCommandSeq(
   cellText: string,
-  promptForEnv = DEFAULT_PROMPT_ENV,
   languageId: string,
-  skipEnvs: Set<string>,
+  promptForEnv = DEFAULT_PROMPT_ENV,
+  skipEnvs?: Set<string>,
 ): Promise<string[] | undefined> {
   const parseBlock = isShellLanguage(languageId)
     ? prepareCmdSeq

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -20,7 +20,7 @@ import {
 } from 'vscode'
 
 import getLogger from '../logger'
-import { getAnnotations, getWorkspaceEnvs, prepareCmdSeq } from '../utils'
+import { getAnnotations, getWorkspaceEnvs } from '../utils'
 import { Serializer, RunmeTaskDefinition } from '../../types'
 import { SerializerBase } from '../serializer'
 import type { IRunner, IRunnerEnvironment, RunProgramOptions } from '../runner'
@@ -139,8 +139,8 @@ export class RunmeTaskProvider implements TaskProvider {
         const commands = await parseCommandSeq(
           cellContent,
           promptEnv,
+          languageId,
           new Set([...(environment?.initialEnvs() ?? []), ...Object.keys(envs)]),
-          prepareCmdSeq,
         )
 
         if (!environment) {

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -138,8 +138,8 @@ export class RunmeTaskProvider implements TaskProvider {
         const cellContent = 'value' in cell ? cell.value : cell.document.getText()
         const commands = await parseCommandSeq(
           cellContent,
-          promptEnv,
           languageId,
+          promptEnv,
           new Set([...(environment?.initialEnvs() ?? []), ...Object.keys(envs)]),
         )
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -49,7 +49,6 @@ import { setCurrentCellExecutionDemo } from './handler/utils'
 
 declare var globalThis: any
 
-const HASH_PREFIX_REGEXP = /^\s*\#\s*/g
 const log = getLogger()
 
 /**
@@ -168,72 +167,6 @@ export function getKey(runningCell: vscode.TextDocument): string {
   }
 
   return languageId
-}
-
-/**
- * treat cells like a series of individual commands
- * which need to be executed in sequence
- */
-export function getCmdSeq(cellText: string): string[] {
-  return cellText
-    .trimStart()
-    .split('\\\n')
-    .map((l) => l.trim())
-    .join(' ')
-    .split('\n')
-    .map((l) => {
-      const hashPos = l.indexOf('#')
-      if (hashPos > -1) {
-        return l.substring(0, hashPos).trim()
-      }
-      const stripped = l.trim()
-
-      if (stripped.startsWith('$')) {
-        return stripped.slice(1).trim()
-      } else {
-        return stripped
-      }
-    })
-    .filter((l) => {
-      const hasPrefix = (l.match(HASH_PREFIX_REGEXP) || []).length > 0
-      return l !== '' && !hasPrefix
-    })
-}
-
-/**
- * Does the following to a command list:
- *
- * - Splits by new lines
- * - Removes trailing `$` characters
- */
-export function prepareCmdSeq(cellText: string): string[] {
-  return cellText.split('\n').map((l) => {
-    const stripped = l.trimStart()
-
-    if (stripped.startsWith('$')) {
-      return stripped.slice(1).trimStart()
-    }
-
-    return l
-  })
-}
-
-/**
- * treat cells like like a series of individual commands
- * which need to be executed in sequence
- *
- * packages command sequence into single callable script
- */
-export function getCmdShellSeq(cellText: string, os: string): string {
-  const trimmed = getCmdSeq(cellText).join('; ')
-
-  if (['darwin'].find((entry) => entry === os)) {
-    return `set -e -o pipefail; ${trimmed}`
-  } else if (os.toLocaleLowerCase().startsWith('win')) {
-    return trimmed
-  }
-
-  return `set -e; ${trimmed}`
 }
 
 export function normalizeLanguage(l?: string) {

--- a/tests/extension/__snapshots__/utils.test.ts.snap
+++ b/tests/extension/__snapshots__/utils.test.ts.snap
@@ -1,23 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`getCmdShellSeq > complex wrapped 1`] = `"set -e -o pipefail; curl \\"https://api-us-west-2.graphcms.com/v2/cksds5im94b3w01xq4hfka1r4/master?query=$(deno run -A query.ts)\\" --compressed 2>/dev/null | jq -r '.[].posts[] | \\"(.title) - by (.authors[0].name), id: (.id)\\"'"`;
-
-exports[`getCmdShellSeq > env only 1`] = `"set -e -o pipefail; export DENO_INSTALL=\\"$HOME/.deno\\"; export PATH=\\"$DENO_INSTALL/bin:$PATH\\""`;
-
-exports[`getCmdShellSeq > leading prompts 1`] = `"set -e -o pipefail; docker build -t runme/demo .; docker ps -qa"`;
-
-exports[`getCmdShellSeq > linux without pipefail 1`] = `"set -e; ls ~/"`;
-
-exports[`getCmdShellSeq > one command 1`] = `"set -e -o pipefail; deno task start"`;
-
-exports[`getCmdShellSeq > trailing comment 1`] = `"set -e -o pipefail; cd ..; ls /; cd ..; ls /"`;
-
-exports[`getCmdShellSeq > windows without shell flags 1`] = `"ls ~/"`;
-
-exports[`getCmdShellSeq > with comments 1`] = `"set -e -o pipefail; echo \\"Install deno via installer script\\"; curl -fsSL https://deno.land/x/install/install.sh | sh"`;
-
-exports[`getCmdShellSeq > wrapped command 1`] = `"set -e -o pipefail; deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts"`;
-
 exports[`resetEnv 1`] = `
 Map {
   "RUNME_TASK" => "true",

--- a/tests/extension/executors/__snapshots__/utils.test.ts.snap
+++ b/tests/extension/executors/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,19 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`getCmdShellSeq > complex wrapped 1`] = `"set -e -o pipefail; curl \\"https://api-us-west-2.graphcms.com/v2/cksds5im94b3w01xq4hfka1r4/master?query=$(deno run -A query.ts)\\" --compressed 2>/dev/null | jq -r '.[].posts[] | \\"(.title) - by (.authors[0].name), id: (.id)\\"'"`;
+
+exports[`getCmdShellSeq > env only 1`] = `"set -e -o pipefail; export DENO_INSTALL=\\"$HOME/.deno\\"; export PATH=\\"$DENO_INSTALL/bin:$PATH\\""`;
+
+exports[`getCmdShellSeq > leading prompts 1`] = `"set -e -o pipefail; docker build -t runme/demo .; docker ps -qa"`;
+
+exports[`getCmdShellSeq > linux without pipefail 1`] = `"set -e; ls ~/"`;
+
+exports[`getCmdShellSeq > one command 1`] = `"set -e -o pipefail; deno task start"`;
+
+exports[`getCmdShellSeq > trailing comment 1`] = `"set -e -o pipefail; cd ..; ls /; cd ..; ls /"`;
+
+exports[`getCmdShellSeq > windows without shell flags 1`] = `"ls ~/"`;
+
+exports[`getCmdShellSeq > with comments 1`] = `"set -e -o pipefail; echo \\"Install deno via installer script\\"; curl -fsSL https://deno.land/x/install/install.sh | sh"`;
+
+exports[`getCmdShellSeq > wrapped command 1`] = `"set -e -o pipefail; deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts"`;

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -13,8 +13,11 @@ import {
   getSystemShellPath,
   getCellCwd,
   isShellLanguage,
+  getCmdShellSeq,
+  prepareCmdSeq,
+  getCmdSeq,
 } from '../../../src/extension/executors/utils'
-import { getCmdSeq, getWorkspaceFolder, getAnnotations } from '../../../src/extension/utils'
+import { getWorkspaceFolder, getAnnotations } from '../../../src/extension/utils'
 import { getCellProgram } from '../../../src/extension/executors/utils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
@@ -25,13 +28,6 @@ vi.mock('vscode')
 
 vi.mock('../../../src/extension/utils', () => ({
   replaceOutput: vi.fn(),
-  // TODO: this should use importActual
-  getCmdSeq: vi.fn((cellText: string) =>
-    cellText
-      .trim()
-      .split('\n')
-      .filter((x) => x),
-  ),
   getWorkspaceFolder: vi.fn(),
   getAnnotations: vi.fn(),
 }))
@@ -236,7 +232,12 @@ suite('parseCommandSeq', () => {
   test('single-line export', async () => {
     vi.mocked(window.showInputBox).mockImplementationOnce(async () => 'test value')
 
-    const res = await parseCommandSeq(['export TEST="<placeholder>"'].join('\n'))
+    const res = await parseCommandSeq(
+      ['export TEST="<placeholder>"'].join('\n'),
+      true,
+      'sh',
+      new Set(),
+    )
 
     expect(res).toBeTruthy()
     expect(res).toHaveLength(1)
@@ -246,7 +247,12 @@ suite('parseCommandSeq', () => {
   test('single-line export with prompt disabled', async () => {
     vi.mocked(window.showInputBox).mockImplementationOnce(async () => 'test value')
 
-    const res = await parseCommandSeq(['export TEST="placeholder"'].join('\n'), false)
+    const res = await parseCommandSeq(
+      ['export TEST="placeholder"'].join('\n'),
+      false,
+      'sh',
+      new Set(),
+    )
 
     expect(window.showInputBox).toBeCalledTimes(0)
 
@@ -258,7 +264,12 @@ suite('parseCommandSeq', () => {
   test('single line export with cancelled prompt', async () => {
     vi.mocked(window.showInputBox).mockImplementationOnce(async () => undefined)
 
-    const res = await parseCommandSeq(['export TEST="<placeholder>"'].join('\n'))
+    const res = await parseCommandSeq(
+      ['export TEST="<placeholder>"'].join('\n'),
+      true,
+      'sh',
+      new Set(),
+    )
 
     expect(res).toBe(undefined)
   })
@@ -266,7 +277,7 @@ suite('parseCommandSeq', () => {
   test('multiline export', async () => {
     const exportLines = ['export TEST="I', 'am', 'doing', 'well!"']
 
-    const res = await parseCommandSeq(exportLines.join('\n'))
+    const res = await parseCommandSeq(exportLines.join('\n'), true, 'sh', new Set())
 
     expect(res).toBeTruthy
     expect(res).toHaveLength(4)
@@ -289,7 +300,7 @@ suite('parseCommandSeq', () => {
       'echo $TEST_MULTILINE',
     ]
 
-    const res = await parseCommandSeq(cmdLines.join('\n'))
+    const res = await parseCommandSeq(cmdLines.join('\n'), true, 'sh', new Set())
 
     expect(res).toBeTruthy()
     expect(res).toStrictEqual([
@@ -303,34 +314,35 @@ suite('parseCommandSeq', () => {
     ])
   })
 
-  test('exports between normal command sequences with getCmdSeq', async () => {
-    vi.mocked(window.showInputBox).mockImplementationOnce(async () => 'test value')
+  // todo(seb): Not being used directly anywhere - deactivate for now and remove in future
+  // test('exports between normal command sequences with getCmdSeq', async () => {
+  //   vi.mocked(window.showInputBox).mockImplementationOnce(async () => 'test value')
 
-    const cmdLines = [
-      'echo "Hello!"',
-      'echo "Hi!"',
-      'export TEST="<placeholder>"',
-      'echo $TEST',
-      'export TEST_MULTILINE="This',
-      'is',
-      'a',
-      'multiline',
-      'env!"',
-      'echo $TEST_MULTILINE',
-    ]
+  //   const cmdLines = [
+  //     'echo "Hello!"',
+  //     'echo "Hi!"',
+  //     'export TEST="<placeholder>"',
+  //     'echo $TEST',
+  //     'export TEST_MULTILINE="This',
+  //     'is',
+  //     'a',
+  //     'multiline',
+  //     'env!"',
+  //     'echo $TEST_MULTILINE',
+  //   ]
 
-    const res = await parseCommandSeq(cmdLines.join('\n'), true, undefined, getCmdSeq)
+  //   const res = await parseCommandSeq(cmdLines.join('\n'), true, undefined, getCmdSeq)
 
-    expect(res).toBeTruthy()
-    expect(res).toStrictEqual([
-      'echo "Hello!"',
-      'echo "Hi!"',
-      'export TEST="test value"',
-      'echo $TEST',
-      ...['export TEST_MULTILINE="This', 'is', 'a', 'multiline', 'env!"'],
-      'echo $TEST_MULTILINE',
-    ])
-  })
+  //   expect(res).toBeTruthy()
+  //   expect(res).toStrictEqual([
+  //     'echo "Hello!"',
+  //     'echo "Hi!"',
+  //     'export TEST="test value"',
+  //     'echo $TEST',
+  //     ...['export TEST_MULTILINE="This', 'is', 'a', 'multiline', 'env!"'],
+  //     'echo $TEST_MULTILINE',
+  //   ])
+  // })
 })
 
 suite('getCellShellPath', () => {
@@ -525,5 +537,86 @@ suite('getCellCwd', () => {
     expect(await testGetCellCwd(frntmtr, '../', files)).toStrictEqual('/')
 
     expect(await testGetCellCwd(frntmtr, '/opt', files)).toStrictEqual('/opt')
+  })
+})
+
+suite('getCmdShellSeq', () => {
+  test('one command', () => {
+    const cellText = 'deno task start'
+    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
+  })
+
+  test('wrapped command', () => {
+    // eslint-disable-next-line max-len
+    const cellText = Buffer.from(
+      // eslint-disable-next-line max-len
+      'ZGVubyBpbnN0YWxsIFwKICAgICAgLS1hbGxvdy1yZWFkIC0tYWxsb3ctd3JpdGUgXAogICAgICAtLWFsbG93LWVudiAtLWFsbG93LW5ldCAtLWFsbG93LXJ1biBcCiAgICAgIC0tbm8tY2hlY2sgXAogICAgICAtciAtZiBodHRwczovL2Rlbm8ubGFuZC94L2RlcGxveS9kZXBsb3ljdGwudHMK',
+      'base64',
+    ).toString('utf-8')
+
+    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
+  })
+
+  test('env only', () => {
+    const cellText = `export DENO_INSTALL="$HOME/.deno"
+      export PATH="$DENO_INSTALL/bin:$PATH"
+    `
+    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
+  })
+
+  test('complex wrapped', () => {
+    // eslint-disable-next-line max-len
+    const cellText =
+      // eslint-disable-next-line max-len
+      'curl "https://api-us-west-2.graphcms.com/v2/cksds5im94b3w01xq4hfka1r4/master?query=$(deno run -A query.ts)" --compressed 2>/dev/null \\\n| jq -r \'.[].posts[] | "(.title) - by (.authors[0].name), id: (.id)"\''
+    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
+  })
+
+  test('linux without pipefail', () => {
+    const cellText = 'ls ~/'
+    expect(getCmdShellSeq(cellText, 'linux')).toMatchSnapshot()
+  })
+
+  test('windows without shell flags', () => {
+    const cellText = 'ls ~/'
+    expect(getCmdShellSeq(cellText, 'win32')).toMatchSnapshot()
+  })
+
+  test('with comments', () => {
+    const cellText =
+      // eslint-disable-next-line max-len
+      'echo "Install deno via installer script"\n# macOS or Linux\ncurl -fsSL https://deno.land/x/install/install.sh | sh'
+    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
+  })
+
+  test('trailing comment', () => {
+    const cellText = 'cd ..\nls / # list dir contents\ncd ..\nls /'
+    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
+  })
+
+  test('leading prompts', () => {
+    const cellText = '$ docker build -t runme/demo .\n$ docker ps -qa'
+    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
+  })
+})
+
+suite('prepareCmdSeq', () => {
+  test('should eliminate leading dollar signs', () => {
+    expect(prepareCmdSeq('$ echo hi')).toStrictEqual(['echo hi'])
+    expect(prepareCmdSeq('  $  echo hi')).toStrictEqual(['echo hi'])
+    expect(prepareCmdSeq('echo 1\necho 2\n $ echo 4')).toStrictEqual(['echo 1', 'echo 2', 'echo 4'])
+  })
+})
+
+suite('getCmdSeq', () => {
+  test('Rejects invalid deno command', () => {
+    const cellText = `export DENO_INSTALL="$HOME/.deno"
+    export PATH="$DENO_INSTALL/bin:$PATH"
+  `
+    const result = getCmdSeq(cellText)
+    expect(result).toStrictEqual([
+      'export DENO_INSTALL="$HOME/.deno"',
+      'export PATH="$DENO_INSTALL/bin:$PATH"',
+    ])
   })
 })

--- a/tests/extension/executors/utils.test.ts
+++ b/tests/extension/executors/utils.test.ts
@@ -240,8 +240,8 @@ suite('parseCommandSeq', () => {
     )
 
     expect(res).toBeTruthy()
-    expect(res).toHaveLength(1)
-    expect(res?.[0]).toBe('export TEST="test value"')
+    expect(res).toHaveLength(3)
+    expect(res?.[1]).toBe('export TEST="test value"')
   })
 
   test('single-line export with prompt disabled', async () => {

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -6,19 +6,16 @@ import {
   getTerminalByCell,
   resetEnv,
   getKey,
-  getCmdShellSeq,
   normalizeLanguage,
   getAnnotations,
   mapGitIgnoreToGlobFolders,
   hashDocumentUri,
   getGrpcHost,
-  prepareCmdSeq,
   openFileAsRunmeNotebook,
   getWorkspaceFolder,
   getWorkspaceEnvs,
   isGitHubLink,
   isDenoScript,
-  getCmdSeq,
   validateAnnotations,
   setNotebookCategories,
   getNotebookCategories,
@@ -149,66 +146,6 @@ test('getKey', () => {
   ).toBe('sh')
 })
 
-suite('getCmdShellSeq', () => {
-  test('one command', () => {
-    const cellText = 'deno task start'
-    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
-  })
-
-  test('wrapped command', () => {
-    // eslint-disable-next-line max-len
-    const cellText = Buffer.from(
-      // eslint-disable-next-line max-len
-      'ZGVubyBpbnN0YWxsIFwKICAgICAgLS1hbGxvdy1yZWFkIC0tYWxsb3ctd3JpdGUgXAogICAgICAtLWFsbG93LWVudiAtLWFsbG93LW5ldCAtLWFsbG93LXJ1biBcCiAgICAgIC0tbm8tY2hlY2sgXAogICAgICAtciAtZiBodHRwczovL2Rlbm8ubGFuZC94L2RlcGxveS9kZXBsb3ljdGwudHMK',
-      'base64',
-    ).toString('utf-8')
-
-    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
-  })
-
-  test('env only', () => {
-    const cellText = `export DENO_INSTALL="$HOME/.deno"
-      export PATH="$DENO_INSTALL/bin:$PATH"
-    `
-    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
-  })
-
-  test('complex wrapped', () => {
-    // eslint-disable-next-line max-len
-    const cellText =
-      // eslint-disable-next-line max-len
-      'curl "https://api-us-west-2.graphcms.com/v2/cksds5im94b3w01xq4hfka1r4/master?query=$(deno run -A query.ts)" --compressed 2>/dev/null \\\n| jq -r \'.[].posts[] | "(.title) - by (.authors[0].name), id: (.id)"\''
-    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
-  })
-
-  test('linux without pipefail', () => {
-    const cellText = 'ls ~/'
-    expect(getCmdShellSeq(cellText, 'linux')).toMatchSnapshot()
-  })
-
-  test('windows without shell flags', () => {
-    const cellText = 'ls ~/'
-    expect(getCmdShellSeq(cellText, 'win32')).toMatchSnapshot()
-  })
-
-  test('with comments', () => {
-    const cellText =
-      // eslint-disable-next-line max-len
-      'echo "Install deno via installer script"\n# macOS or Linux\ncurl -fsSL https://deno.land/x/install/install.sh | sh'
-    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
-  })
-
-  test('trailing comment', () => {
-    const cellText = 'cd ..\nls / # list dir contents\ncd ..\nls /'
-    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
-  })
-
-  test('leading prompts', () => {
-    const cellText = '$ docker build -t runme/demo .\n$ docker ps -qa'
-    expect(getCmdShellSeq(cellText, 'darwin')).toMatchSnapshot()
-  })
-})
-
 suite('normalizeLanguage', () => {
   test('with zsh', () => {
     const lang = normalizeLanguage('zsh')
@@ -336,14 +273,6 @@ suite('#getGrpcHost', () => {
       get: vi.fn().mockReturnValue(7863),
     } as any)
     expect(getGrpcHost()).toStrictEqual('localhost:7863')
-  })
-})
-
-suite('prepareCmdSeq', () => {
-  test('should eliminate trailing dollar signs', () => {
-    expect(prepareCmdSeq('$ echo hi')).toStrictEqual(['echo hi'])
-    expect(prepareCmdSeq('  $  echo hi')).toStrictEqual(['echo hi'])
-    expect(prepareCmdSeq('echo 1\necho 2\n $ echo 4')).toStrictEqual(['echo 1', 'echo 2', 'echo 4'])
   })
 })
 
@@ -485,19 +414,6 @@ suite('isDenoScript', () => {
       getText: vi.fn().mockReturnValue('deployctl deploy'),
     }
     expect(isDenoScript(cell)).toBe(true)
-  })
-})
-
-suite('getCmdSeq', () => {
-  test('Rejects invalid deno command', () => {
-    const cellText = `export DENO_INSTALL="$HOME/.deno"
-    export PATH="$DENO_INSTALL/bin:$PATH"
-  `
-    const result = getCmdSeq(cellText)
-    expect(result).toStrictEqual([
-      'export DENO_INSTALL="$HOME/.deno"',
-      'export PATH="$DENO_INSTALL/bin:$PATH"',
-    ])
   })
 })
 


### PR DESCRIPTION
Fixes https://github.com/stateful/runme/issues/418 by skipping shell/bash normalization for non-shell.

Completed an over-due refactor of the utility functions, which will avoid circular dependencies in dev.

Cc @edeediong. Once, https://github.com/stateful/runme/pull/419, ships we can remove `interpreter=php` from the shebang example.