### PR TITLE
Reactive stable and remove version pinning

### DIFF
--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -93,7 +93,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: '1.81.1',
+      browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
         workspacePath: extensionPath,


### PR DESCRIPTION
Try latest stable removing pinned version. Is this still an issue?