### PR TITLE
Write separate session files for outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,13 @@
         "title": "Click to enable saving terminal output automatically",
         "icon": "$(play-circle)",
         "shortTitle": "Auto-Save (off)"
+      },
+      {
+        "command": "runme.notebookSessionOutputs",
+        "category": "Runme",
+        "title": "Click to open session outputs",
+        "icon": "$(output-view-icon)",
+        "shortTitle": "Session Outputs"
       }
     ],
     "menus": {
@@ -292,6 +299,11 @@
         }
       ],
       "notebook/toolbar": [
+        {
+          "command": "runme.notebookSessionOutputs",
+          "when": "notebookType == runme && notebookHasRunmeOutputs",
+          "group": "navigation"
+        },
         {
           "command": "runme.surveyFeedbackButton",
           "when": "notebookType == runme",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -145,6 +145,7 @@ export enum AuthenticationProviders {
 export const NOTEBOOK_AVAILABLE_CATEGORIES = 'notebookAvailableCategories'
 export const NOTEBOOK_HAS_CATEGORIES = 'notebookHasCategories'
 export const NOTEBOOK_AUTOSAVE_ON = 'notebookAutoSaveOn'
+export const NOTEBOOK_HAS_OUTPUTS = 'notebookHasRunmeOutputs'
 
 /**
  * https://gist.github.com/ppisarczyk/43962d06686722d26d176fad46879d41?permalink_comment_id=3949999#gistcomment-3949999

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -117,7 +117,8 @@ export class NotebookCellOutputManager {
 
         return new NotebookCellOutput([
           NotebookCellOutputItem.json(annotationJson, OutputType.annotations),
-          NotebookCellOutputItem.json(annotationJson),
+          // disable to prevent rendering in session outputs
+          // NotebookCellOutputItem.json(annotationJson),
         ])
       }
 

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -34,7 +34,7 @@ import {
   getTerminalByCell,
   openFileAsRunmeNotebook,
 } from '../utils'
-import RunmeServer from '../server/runmeServer'
+import IServer from '../server/runmeServer'
 import { NotebookToolbarCommand } from '../../types'
 import getLogger from '../logger'
 import { RecommendExtensionMessage } from '../messaging'
@@ -149,7 +149,7 @@ export function stopBackgroundTask(cell: NotebookCell) {
 export function runCLICommand(
   extensionBaseUri: Uri,
   grpcRunner: boolean,
-  server: RunmeServer,
+  server: IServer,
   kernel: Kernel,
 ) {
   return async function (cell: NotebookCell) {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -260,7 +260,7 @@ export class RunmeExtension {
           if (!e.ui || !sessionId) {
             return
           }
-          const outputFilePath = GrpcSerializer.getOutputsFile(
+          const outputFilePath = GrpcSerializer.getOutputsUri(
             e.notebookEditor.notebookUri,
             sessionId,
           )

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -1,4 +1,13 @@
-import { Disposable, workspace, notebooks, commands, ExtensionContext, tasks, window } from 'vscode'
+import {
+  Disposable,
+  workspace,
+  notebooks,
+  commands,
+  ExtensionContext,
+  tasks,
+  window,
+  Uri,
+} from 'vscode'
 import { TelemetryReporter } from 'vscode-telemetry'
 import Channel from 'tangle/webviews'
 
@@ -242,6 +251,21 @@ export class RunmeExtension {
       ),
       RunmeExtension.registerCommand('runme.notebookAutoSaveOff', () =>
         toggleAutosave(context, true),
+      ),
+      RunmeExtension.registerCommand(
+        'runme.notebookSessionOutputs',
+        (e: { notebookEditor: { notebookUri: Uri }; ui: boolean }) => {
+          const runnerEnv = kernel.getRunnerEnvironment()
+          const sessionId = runnerEnv?.getSessionId()
+          if (!e.ui || !sessionId) {
+            return
+          }
+          const outputFilePath = GrpcSerializer.getOutputsFile(
+            e.notebookEditor.notebookUri,
+            sessionId,
+          )
+          commands.executeCommand('markdown.showPreviewToSide', outputFilePath)
+        },
       ),
     )
     await await bootFile(context)

--- a/src/extension/provider/codelens.ts
+++ b/src/extension/provider/codelens.ts
@@ -29,7 +29,7 @@ import { Serializer } from '../../types'
 import { getCodeLensEnabled } from '../../utils/configuration'
 import { RunmeExtension } from '../extension'
 import type { SurveyWinCodeLensRun } from '../survey'
-import RunmeServer from '../server/runmeServer'
+import IServer from '../server/runmeServer'
 
 import { RunmeTaskProvider } from './runmeTask'
 
@@ -63,7 +63,7 @@ export class RunmeCodeLensProvider implements CodeLensProvider, Disposable {
     protected surveyWinCodeLensRun: SurveyWinCodeLensRun,
     protected runner?: IRunner,
     protected kernel?: Kernel,
-    protected server?: RunmeServer,
+    protected server?: IServer,
   ) {
     this.register(
       languages.registerCodeLensProvider(

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -24,7 +24,7 @@ import {
 } from './grpc/runnerTypes'
 import { RunnerServiceClient } from './grpc/client'
 import { getSystemShellPath } from './executors/utils'
-import RunmeServer from './server/runmeServer'
+import { IServer } from './server/runmeServer'
 import { convertEnvList } from './utils'
 
 type ExecuteDuplex = DuplexStreamingCall<ExecuteRequest, ExecuteResponse>
@@ -177,7 +177,7 @@ export class GrpcRunner implements IRunner {
   protected _onReady = this.register(new EventEmitter<void>())
   onReady = this._onReady.event
 
-  constructor(protected server: RunmeServer) {
+  constructor(protected server: IServer) {
     this.disposables.push(
       server.onTransportReady(({ transport }) => this.initRunnerClient(transport)),
     )

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -88,6 +88,7 @@ export interface IRunner extends Disposable {
 interface IRunnerChild extends DisposableAsync {}
 
 export interface IRunnerEnvironment extends IRunnerChild {
+  getSessionId(): string
   initialEnvs(): Set<string>
 }
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -39,7 +39,7 @@ import { initParserClient, ParserServiceClient } from './grpc/client'
 import Languages from './languages'
 import { PLATFORM_OS } from './constants'
 import { initWasm } from './utils'
-import RunmeServer from './server/runmeServer'
+import { IServer } from './server/runmeServer'
 import { Kernel } from './kernel'
 import { getCellByUuId } from './cell'
 import { IProcessInfoState } from './terminal/terminalState'
@@ -380,7 +380,7 @@ export class GrpcSerializer extends SerializerBase {
 
   constructor(
     protected context: ExtensionContext,
-    protected server: RunmeServer,
+    protected server: IServer,
     kernel: Kernel,
   ) {
     super(context, kernel)

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -428,18 +428,22 @@ export class GrpcSerializer extends SerializerBase {
       return
     }
 
-    const sessionFile = GrpcSerializer.getOutputsFile(doc.uri, sessionId)
+    const sessionFile = GrpcSerializer.getOutputsUri(doc.uri, sessionId)
     await workspace.fs.writeFile(sessionFile, bytes)
     await this.toggleSessionButton(true)
   }
 
-  public static getOutputsFile(docUri: Uri, sid: string): Uri {
-    const fileDir = path.dirname(docUri.fsPath)
-    const fileExt = path.extname(docUri.fsPath)
-    const fileBase = path.basename(docUri.fsPath, fileExt)
+  public static getOutputsFilePath(fsPath: string, sid: string): string {
+    const fileDir = path.dirname(fsPath)
+    const fileExt = path.extname(fsPath)
+    const fileBase = path.basename(fsPath, fileExt)
     const filePath = path.normalize(`${fileDir}/${fileBase}-${sid}${fileExt}`)
 
-    return Uri.parse(filePath)
+    return filePath
+  }
+
+  public static getOutputsUri(docUri: Uri, sid: string): Uri {
+    return Uri.parse(this.getOutputsFilePath(docUri.fsPath, sid))
   }
 
   protected applyIdentity(data: Notebook): Notebook {

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -428,8 +428,8 @@ export class GrpcSerializer extends SerializerBase {
       return
     }
 
-    const sessFile = GrpcSerializer.getOutputsFile(doc.uri, sessionId)
-    await workspace.fs.writeFile(sessFile, bytes)
+    const sessionFile = GrpcSerializer.getOutputsFile(doc.uri, sessionId)
+    await workspace.fs.writeFile(sessionFile, bytes)
     await this.toggleSessionButton(true)
   }
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -52,7 +52,7 @@ import getLogger from './logger'
 import { Kernel } from './kernel'
 import { ENV_STORE, DEFAULT_ENV, BOOTFILE, BOOTFILE_DEMO } from './constants'
 import { GrpcRunnerEnvironment } from './runner'
-import RunmeServer from './server/runmeServer'
+import { IServer } from './server/runmeServer'
 import { setCurrentCellExecutionDemo } from './handler/utils'
 import ContextState from './contextState'
 
@@ -511,7 +511,7 @@ export function fetchStaticHtml(appUrl: string) {
   return fetch(appUrl)
 }
 
-export function getRunnerSessionEnvs(extensionBaseUri: Uri, kernel: Kernel, server: RunmeServer) {
+export function getRunnerSessionEnvs(extensionBaseUri: Uri, kernel: Kernel, server: IServer) {
   const envs: Record<string, string> = {}
   envs['RUNME_SERVER_ADDR'] = server.address()
 

--- a/tests/extension/cell.test.ts
+++ b/tests/extension/cell.test.ts
@@ -222,7 +222,7 @@ describe('NotebookCellOutputManager', () => {
     await outputs.toggleOutput(OutputType.annotations)
     const result = replaceOutput.mock.calls[0][0]
     expect(result).toHaveLength(1)
-    expect(result[0].items).toHaveLength(2)
+    expect(result[0].items).toHaveLength(1)
     expect(result[0].items[0].mime).toBe(OutputType.annotations)
   })
 
@@ -239,7 +239,7 @@ describe('NotebookCellOutputManager', () => {
     const result = replaceOutput.mock.calls[0][0]
 
     expect(result).toHaveLength(1)
-    expect(result[0].items).toHaveLength(2)
+    expect(result[0].items).toHaveLength(1)
     expect(result[0].items[0].mime).toBe(OutputType.annotations)
   })
 

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -81,7 +81,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(29)
+  expect(commands.registerCommand).toBeCalledTimes(30)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)

--- a/vitest.conf.ts
+++ b/vitest.conf.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       enabled: true,
       exclude: ['**/build/**', '**/__fixtures__/**', '**/*.test.ts'],
       statements: 43,
-      branches: 85.5,
+      branches: 85,
       functions: 32,
       lines: 43
     }


### PR DESCRIPTION
Unlocks https://github.com/stateful/runme/issues/400.

In this PR the outputs (when the experiment is active: `"runme.experiments.outputPersistence": true`) will be written to a session file that's derived from the original source document in the notebook. The UX offers a "Session Outputs" button (see below) that will conveniently open the outputs in a split view.

E.g.`./examples/README-01HGX7HZVNV4R74X1N1YKKDBK4.md` is based off `./examples/README.md`.

What's not covered yet:
1. The lifecycle of a session is currently the same as the VS Code window. However, in a future version, we could make a "New Session" button available to allow users to decide.
2. The "copy with outputs" can be opened as Runme notebook itself which does not make much sense. We could gracefully error in a future version.
3. Saving outputs is currently only fired on explicit saved, as in CMD+S or picking it from the File menu. It is possible to write the file whenever VS Code runs the serializer (not up to the user) which will likely make both side track more real-time-ish.

<img width="2560" alt="Screenshot 2023-12-05 at 11 29 38 AM" src="https://github.com/stateful/vscode-runme/assets/250527/c014c5fd-9841-4713-ab3a-0bdc2357fdd7">