### PR TITLE
Project service integration

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -29,6 +29,7 @@ export class Uri extends URI {
 }
 
 export const workspace = {
+  asRelativePath: vi.fn(),
   getConfiguration: vi.fn().mockReturnValue(new Map()),
   onDidChangeConfiguration: vi.fn(),
   openNotebookDocument: vi.fn().mockReturnValue({ uri: 'new notebook uri' }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@apollo/client": "^3.8.3",
         "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.9.1-20230830152835-a5b3a068eb8c.1",
-        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20231201190151-043bb99c0a8f.2",
+        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.3-20231212160515-2c40ef1f3311.1",
         "@protobuf-ts/grpc-transport": "^2.9.1",
         "@protobuf-ts/runtime": "^2.9.1",
         "@protobuf-ts/runtime-rpc": "^2.9.1",
@@ -1564,11 +1564,11 @@
       }
     },
     "node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.9.1-20231201190151-043bb99c0a8f.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.1-20231201190151-043bb99c0a8f.2.tgz",
+      "version": "2.9.3-20231212160515-2c40ef1f3311.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.3-20231212160515-2c40ef1f3311.1.tgz",
       "peerDependencies": {
-        "@protobuf-ts/runtime": "^2.9.1",
-        "@protobuf-ts/runtime-rpc": "^2.9.1"
+        "@protobuf-ts/runtime": "^2.9.3",
+        "@protobuf-ts/runtime-rpc": "^2.9.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -4784,16 +4784,16 @@
       }
     },
     "node_modules/@protobuf-ts/runtime": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.1.tgz",
-      "integrity": "sha512-ZTc8b+pQ6bwxZa3qg9/IO/M/brRkvr0tic9cSGgAsDByfPrtatT2300wTIRLDk8X9WTW1tT+FhyqmcrbMHTeww=="
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.3.tgz",
+      "integrity": "sha512-nivzCpg/qYD0RX2OmHOahJALb8ndjGmUhNBcTJ0BbXoqKwCSM6vYA+vegzS3rhuaPgbyC7Ec8idlnizzUfIRuw=="
     },
     "node_modules/@protobuf-ts/runtime-rpc": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.1.tgz",
-      "integrity": "sha512-pzO20J6s07LTWcj8hKAXh/dAacU5HIVir6SANKXXH8G0pn0VIIB4FFECq5Hbv25/8PQoOGZ7iApq/DMHaSjGhg==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.3.tgz",
+      "integrity": "sha512-WelHpctvZeG8yhbb7tnsrLzotq9xjMCXuGuhJ8qMyEdNoBBEodbXseofAYFTebo2/PN2LzyEq3X6vwr5f8jqTA==",
       "dependencies": {
-        "@protobuf-ts/runtime": "^2.9.1"
+        "@protobuf-ts/runtime": "^2.9.3"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -146,6 +146,18 @@
         "icon": "$(search-expand-results)"
       },
       {
+        "command": "runme.tasksIncludeUnnamed",
+        "category": "Runme",
+        "title": "Include all tasks",
+        "icon": "$(bracket)"
+      },
+      {
+        "command": "runme.tasksExcludeUnnamed",
+        "category": "Runme",
+        "title": "Only named tasks",
+        "icon": "$(bracket-dot)"
+      },
+      {
         "command": "runme.welcome",
         "title": "Welcome",
         "category": "Runme",
@@ -241,6 +253,14 @@
           "when": "false"
         },
         {
+          "command": "runme.tasksIncludeUnnamed",
+          "when": "false"
+        },
+        {
+          "command": "runme.tasksExcludeUnnamed",
+          "when": "false"
+        },
+        {
           "command": "runme.codelens.action",
           "when": "false"
         },
@@ -288,6 +308,16 @@
         {
           "command": "runme.expandTreeView",
           "when": "view == runme.launcher && !runme.launcher.isExpanded",
+          "group": "navigation"
+        },
+        {
+          "command": "runme.tasksIncludeUnnamed",
+          "when": "view == runme.launcher && !runme.launcher.includeUnnamed",
+          "group": "navigation"
+        },
+        {
+          "command": "runme.tasksExcludeUnnamed",
+          "when": "view == runme.launcher && runme.launcher.includeUnnamed",
           "group": "navigation"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -929,7 +929,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.3",
     "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.9.1-20230830152835-a5b3a068eb8c.1",
-    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.1-20231201190151-043bb99c0a8f.2",
+    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.3-20231212160515-2c40ef1f3311.1",
     "@protobuf-ts/grpc-transport": "^2.9.1",
     "@protobuf-ts/runtime": "^2.9.1",
     "@protobuf-ts/runtime-rpc": "^2.9.1",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -90,6 +90,11 @@ export class RunmeExtension {
       ? new GrpcSerializer(context, server, kernel)
       : new WasmSerializer(context, kernel)
 
+    const runmeTaskProvider = tasks.registerTaskProvider(
+      RunmeTaskProvider.id,
+      new RunmeTaskProvider(context, serializer, kernel, server, runner),
+    )
+
     /**
      * Start the Runme server
      */
@@ -216,10 +221,7 @@ export class RunmeExtension {
       RunmeExtension.registerCommand('runme.openRunmeFile', RunmeLauncherProvider.openFile),
       RunmeExtension.registerCommand('runme.keybinding.noop', () => {}),
       RunmeExtension.registerCommand('runme.file.openInRunme', openFileInRunme),
-      tasks.registerTaskProvider(
-        RunmeTaskProvider.id,
-        new RunmeTaskProvider(context, serializer, runner, kernel),
-      ),
+      runmeTaskProvider,
       notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new CliProvider()),
 
       /**

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -90,9 +90,10 @@ export class RunmeExtension {
       ? new GrpcSerializer(context, server, kernel)
       : new WasmSerializer(context, kernel)
 
+    const treeViewer = new RunmeLauncherProvider(getDefaultWorkspace())
     const runmeTaskProvider = tasks.registerTaskProvider(
       RunmeTaskProvider.id,
-      new RunmeTaskProvider(context, serializer, kernel, server, runner),
+      new RunmeTaskProvider(context, treeViewer, serializer, kernel, server, runner),
     )
 
     /**
@@ -133,7 +134,6 @@ export class RunmeExtension {
       )
     }
 
-    const treeViewer = new RunmeLauncherProvider(getDefaultWorkspace())
     const uriHandler = new RunmeUriHandler(context, kernel, getForceNewWindowConfig())
     const winCodeLensRunSurvey = new survey.SurveyWinCodeLensRun(context)
     const surveys: Disposable[] = [
@@ -233,6 +233,14 @@ export class RunmeExtension {
         treeViewer.collapseAll.bind(treeViewer),
       ),
       RunmeExtension.registerCommand('runme.expandTreeView', treeViewer.expandAll.bind(treeViewer)),
+      RunmeExtension.registerCommand(
+        'runme.tasksIncludeUnnamed',
+        treeViewer.includeUnnamed.bind(treeViewer),
+      ),
+      RunmeExtension.registerCommand(
+        'runme.tasksExcludeUnnamed',
+        treeViewer.excludeUnnamed.bind(treeViewer),
+      ),
       RunmeExtension.registerCommand('runme.authenticateWithGitHub', authenticateWithGitHub),
       /**
        * Uri handler

--- a/src/extension/grpc/client.ts
+++ b/src/extension/grpc/client.ts
@@ -3,6 +3,8 @@ import { RpcError } from '@protobuf-ts/runtime-rpc'
 import { ParserServiceClient } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/parser/v1/parser_pb.client'
 // eslint-disable-next-line max-len
 import { RunnerServiceClient } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/runner/v1/runner_pb.client'
+// eslint-disable-next-line max-len
+import { ProjectServiceClient } from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/project/v1/project_pb.client'
 import { HealthClient } from '@buf/grpc_grpc.community_timostamm-protobuf-ts/grpc/health/v1/health_pb.client'
 import { GrpcTransport } from '@protobuf-ts/grpc-transport'
 
@@ -10,4 +12,19 @@ function initParserClient(transport: GrpcTransport): ParserServiceClient {
   return new ParserServiceClient(transport)
 }
 
-export { ParserServiceClient, RunnerServiceClient, initParserClient, HealthClient, RpcError }
+function initProjectClient(transport: GrpcTransport): ProjectServiceClient {
+  return new ProjectServiceClient(transport)
+}
+
+type ReadyPromise = Promise<void | Error>
+
+export {
+  ParserServiceClient,
+  RunnerServiceClient,
+  ProjectServiceClient,
+  initParserClient,
+  initProjectClient,
+  HealthClient,
+  ReadyPromise,
+  RpcError,
+}

--- a/src/extension/grpc/projectTypes.ts
+++ b/src/extension/grpc/projectTypes.ts
@@ -1,0 +1,1 @@
+export * from '@buf/stateful_runme.community_timostamm-protobuf-ts/runme/project/v1/project_pb'

--- a/src/extension/provider/codelens.ts
+++ b/src/extension/provider/codelens.ts
@@ -208,7 +208,7 @@ export class RunmeCodeLensProvider implements CodeLensProvider, Disposable {
             break
           }
 
-          const task = await RunmeTaskProvider.getRunmeTask(
+          const task = await RunmeTaskProvider.newRunmeTask(
             document.uri.fsPath,
             getAnnotations(cell.metadata).name,
             notebook,

--- a/src/extension/provider/launcher.ts
+++ b/src/extension/provider/launcher.ts
@@ -58,6 +58,8 @@ export class RunmeFile extends TreeItem {
 export class RunmeLauncherProvider implements TreeDataProvider<RunmeFile>, Disposable {
   #disposables: Disposable[] = []
 
+  private _includeUnnamedTasks = false
+
   private filesTree: Map<string, TreeFile> = new Map()
   private defaultItemState: TreeItemCollapsibleState = TreeItemCollapsibleState.Collapsed
 
@@ -67,6 +69,10 @@ export class RunmeLauncherProvider implements TreeDataProvider<RunmeFile>, Dispo
       watcher.onDidCreate((file) => this.#onFileChange(file, true)),
       watcher.onDidDelete((file) => this.#onFileChange(file)),
     )
+  }
+
+  public get includeUnnamedTasks(): boolean {
+    return this._includeUnnamedTasks
   }
 
   private _onDidChangeTreeData: EventEmitter<RunmeFile | undefined> = new EventEmitter<
@@ -154,6 +160,24 @@ export class RunmeLauncherProvider implements TreeDataProvider<RunmeFile>, Dispo
     this.defaultItemState = TreeItemCollapsibleState.Expanded
     await commands.executeCommand('setContext', 'runme.launcher.isExpanded', true)
     this.refresh()
+  }
+
+  async includeUnnamed() {
+    this._includeUnnamedTasks = true
+    await commands.executeCommand(
+      'setContext',
+      'runme.launcher.includeUnnamed',
+      this._includeUnnamedTasks,
+    )
+  }
+
+  async excludeUnnamed() {
+    this._includeUnnamedTasks = false
+    await commands.executeCommand(
+      'setContext',
+      'runme.launcher.includeUnnamed',
+      this._includeUnnamedTasks,
+    )
   }
 
   private async _scanWorkspace() {

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -173,7 +173,9 @@ export class RunmeTaskProvider implements TaskProvider {
 
   public resolveTask(task: Task): ProviderResult<Task> {
     /**
-     * ToDo(Christian) fetch terminal from Kernel
+     * ToDo(sebastian): Implement refresh.
+     * This only occurs if the task is no longer known.
+     * Likely a side effect that the markdown file was modified.
      */
     return task
   }

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -119,11 +119,6 @@ export class RunmeTaskProvider implements TaskProvider {
       return []
     }
 
-    if (!this.client) {
-      log.error('gRPC client not initialized')
-      return []
-    }
-
     const current =
       (window.activeNotebookEditor?.notebook.uri.fsPath.endsWith('md') &&
         window.activeNotebookEditor?.notebook.uri) ||

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -19,7 +19,6 @@ import {
 } from 'vscode'
 import { ServerStreamingCall } from '@protobuf-ts/runtime-rpc'
 import { GrpcTransport } from '@protobuf-ts/grpc-transport'
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Observable, of, scan, takeLast, lastValueFrom } from 'rxjs'
 
 import getLogger from '../logger'

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -145,25 +145,24 @@ export class RunmeTaskProvider implements TaskProvider {
     }
 
     const environment = this.kernel?.getRunnerEnvironment()
-    const tasks = await this.tasks
+    const all = await this.tasks
     const includeGenerated = this.treeView.includeUnnamedTasks
 
     try {
-      const runmeTasks = tasks
-        .filter((prjTask) => {
-          return prjTask.isNameGenerated === includeGenerated
-        })
-        .map(
-          async (prjTask) =>
-            await RunmeTaskProvider.newRunmeProjectTask(
-              prjTask,
-              {},
-              token,
-              this.serializer,
-              this.runner!,
-              environment,
-            ),
-        )
+      const filtered = all.filter((prjTask) => prjTask.isNameGenerated === includeGenerated)
+      // show all if there isn't a single named task
+      const listed = filtered.length > 0 ? filtered : all
+      const runmeTasks = listed.map(
+        async (prjTask) =>
+          await RunmeTaskProvider.newRunmeProjectTask(
+            prjTask,
+            {},
+            token,
+            this.serializer,
+            this.runner!,
+            environment,
+          ),
+      )
       return Promise.all(runmeTasks)
     } catch (e) {
       console.error(e)

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -35,7 +35,7 @@ import {
   CellOutput,
   SerializeRequestOptions,
 } from './grpc/serializerTypes'
-import { initParserClient, ParserServiceClient } from './grpc/client'
+import { initParserClient, ParserServiceClient, type ReadyPromise } from './grpc/client'
 import Languages from './languages'
 import { PLATFORM_OS } from './constants'
 import { initWasm } from './utils'
@@ -46,8 +46,6 @@ import { IProcessInfoState } from './terminal/terminalState'
 
 declare var globalThis: any
 const DEFAULT_LANG_ID = 'text'
-
-type ReadyPromise = Promise<void | Error>
 
 type NotebookCellOutputWithProcessInfo = NotebookCellOutput & {
   processInfo?: IProcessInfoState

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -28,9 +28,15 @@ vi.mock('../../src/extension/grpc/client', () => {
   return {
     ParserServiceClient: MockedParserServiceClient,
     RunnerServiceClient: vi.fn(),
+    ProjectServiceClient: vi.fn(),
     initParserClient: vi.fn(() => ({
       deserialize: vi.fn(() => {
         return { status: { code: 'OK' } }
+      }),
+    })),
+    initProjectClient: vi.fn(() => ({
+      load: vi.fn(() => {
+        return { responses: { onMessage: vi.fn() } }
       }),
     })),
     HealthClient: class {

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -11,6 +11,13 @@ import { testCertPEM, testPrivKeyPEM } from '../testTLSCert'
 vi.mock('vscode')
 vi.mock('vscode-telemetry')
 
+vi.mock('../../src/extension/provider/runmeTask', () => {
+  class RunmeTaskProvider {
+    static id = 'runme'
+  }
+  return { RunmeTaskProvider }
+})
+
 vi.mock('../../src/extension/panels/panel', () => {
   class Panel {
     registerBus = vi.fn()

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -94,7 +94,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(31)
+  expect(commands.registerCommand).toBeCalledTimes(32)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -94,7 +94,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(30)
+  expect(commands.registerCommand).toBeCalledTimes(31)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)

--- a/tests/extension/runner.test.ts
+++ b/tests/extension/runner.test.ts
@@ -137,7 +137,7 @@ class MockedRunmeServer {
 vi.mock('../../src/extension/provider/runmeTask', async () => {
   return {
     RunmeTaskProvider: {
-      getRunmeTask: vi.fn().mockResolvedValue({}),
+      newRunmeTask: vi.fn().mockResolvedValue({}),
     },
   }
 })
@@ -720,7 +720,7 @@ suite('RunmeCodeLensProvider', () => {
       'run',
     )
 
-    expect(RunmeTaskProvider.getRunmeTask).toBeCalledTimes(1)
+    expect(RunmeTaskProvider.newRunmeTask).toBeCalledTimes(1)
 
     expect(isWindows).toBeCalledTimes(1)
 


### PR DESCRIPTION
Replace old/unfinished task provider integration with GRPC project service.

This is an intermediate step to make tasks more integral between "project mode" and VS Code's task system. What's missing but slated for follow up PRs:
- [ ] Reconcile task `newRunmeProjectTask` vs `newRunmeTask` should be able to have a single impl.
- [ ] Remodel the `runme` TaskDefinition to closer match what cells are now.
- [ ] Integrate tasks with "Runme Notebooks" tree view.
- [ ] Refresh cached tasks when fs changes occur and implement `resolveTask` to trigger a refresh.

To test this: Open the command palette and search for "Tasks: Run Task", select "runme" from the list. The list should match what you'd see (only named commands) if you run `runme ls` in the root of the repo. Select an entry to execute.