### PR TITLE
Improve serialization behavior/timing to avoid accidental data-loss

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -62,7 +62,7 @@
       },
     },
     {
-      "name": "run selected e2e spec",
+      "name": "Run Selected E2E Spec",
       "type": "node",
       "request": "launch",
       "args": ["wdio.conf.ts", "--spec", "${file}"],

--- a/src/extension/constants.ts
+++ b/src/extension/constants.ts
@@ -13,3 +13,5 @@ export const ENV_STORE = new Map<string, string>(Object.entries(DEFAULT_ENV))
 export const BOOTFILE = '.runme_bootstrap'
 
 export const BOOTFILE_DEMO = '.runme_bootstrap_demo'
+
+export const RUNME_TRANSIENT_REVISION = 'runme.dev/revision'

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -92,7 +92,7 @@ export class Kernel implements Disposable {
   protected environment?: IRunnerEnvironment
   protected runnerReadyListener?: Disposable
 
-  protected cellManager = new NotebookCellManager(this.#controller)
+  protected cellManager: NotebookCellManager
   protected activeTerminals: ActiveTerminal[] = []
   protected category?: string
   protected panelManager: PanelManager
@@ -106,6 +106,10 @@ export class Kernel implements Disposable {
 
     this.#shebangComingSoon = new survey.SurveyShebangComingSoon(context)
 
+    this.cellManager = new NotebookCellManager(
+      this.#controller,
+      this.hasExperimentEnabled('outputPersistence') ?? false,
+    )
     this.#controller.supportsExecutionOrder = false
     this.#controller.description = 'Run your Markdown'
     this.#controller.executeHandler = this._executeAll.bind(this)

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -379,6 +379,7 @@ export class GrpcSerializer extends SerializerBase {
   protected readonly outputPersistence: boolean
   // todo(sebastian): naive cache for now, consider use lifecycle events for gc
   protected readonly cache: Map<string, Uint8Array> = new Map<string, Uint8Array>()
+  protected readonly mapping: Map<string, Uri> = new Map<string, Uri>()
 
   private serverReadyListener: Disposable | undefined
 
@@ -405,6 +406,7 @@ export class GrpcSerializer extends SerializerBase {
 
     this.disposables.push(
       workspace.onDidSaveNotebookDocument(this.handleSaveNotebookOutputs.bind(this)),
+      workspace.onDidOpenNotebookDocument(this.handleOpenNotebook.bind(this)),
     )
   }
 
@@ -416,23 +418,44 @@ export class GrpcSerializer extends SerializerBase {
     this.client = initParserClient(transport ?? (await this.server.transport()))
   }
 
-  protected async handleSaveNotebookOutputs(doc: NotebookDocument) {
+  protected async handleOpenNotebook(doc: NotebookDocument) {
     const lid = GrpcSerializer.getDocumentLifecycleId(doc.metadata)
-    const bytes = this.cache.get(lid ?? '')
 
-    if (!bytes) {
+    if (!lid) {
       this.toggleSessionButton(false)
       return
     }
 
     const runnerEnv = this.kernel.getRunnerEnvironment()
     const sessionId = runnerEnv?.getSessionId()
+
     if (!sessionId) {
       this.toggleSessionButton(false)
       return
     }
 
     const sessionFile = GrpcSerializer.getOutputsUri(doc.uri, sessionId)
+    this.mapping.set(lid, sessionFile)
+  }
+
+  protected async handleSaveNotebookOutputs(doc: NotebookDocument) {
+    const lid = GrpcSerializer.getDocumentLifecycleId(doc.metadata)
+    const bytes = this.cache.get(lid ?? '')
+    await this.saveNotebookOutputs(lid, bytes)
+  }
+
+  protected async saveNotebookOutputs(lid: string | undefined, bytes: Uint8Array | undefined) {
+    if (!bytes) {
+      this.toggleSessionButton(false)
+      return
+    }
+
+    const sessionFile = this.mapping.get(lid ?? '')
+    if (!sessionFile) {
+      this.toggleSessionButton(false)
+      return
+    }
+
     await workspace.fs.writeFile(sessionFile, bytes)
     await this.toggleSessionButton(true)
   }
@@ -495,9 +518,11 @@ export class GrpcSerializer extends SerializerBase {
     const request = this.client!.serialize(serialRequest)
 
     // run in parallel
-    await Promise.all([output, request])
+    const [, serialResult] = await Promise.all([output, request])
 
-    const { result } = (await request).response
+    // await this.saveNotebookOutputs(lid, outputResult)
+
+    const { result } = serialResult.response
     if (result === undefined) {
       throw new Error('serialization of notebook failed')
     }
@@ -505,9 +530,12 @@ export class GrpcSerializer extends SerializerBase {
     return result
   }
 
-  private async cacheNotebookOutputs(notebook: Notebook, lid: string | undefined) {
+  private async cacheNotebookOutputs(
+    notebook: Notebook,
+    lid: string | undefined,
+  ): Promise<Uint8Array | undefined> {
     if (!this.outputPersistence) {
-      return Promise.resolve()
+      return Promise.resolve(undefined)
     }
 
     const options = <SerializeRequestOptions>{ outputs: { enabled: true, summary: true } }
@@ -526,6 +554,8 @@ export class GrpcSerializer extends SerializerBase {
     } else {
       this.cache.set(lid, bytes)
     }
+
+    return bytes
   }
 
   public static marshalNotebook(data: NotebookData): Notebook {

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -518,9 +518,9 @@ export class GrpcSerializer extends SerializerBase {
     const request = this.client!.serialize(serialRequest)
 
     // run in parallel
-    const [, serialResult] = await Promise.all([output, request])
+    const [outputResult, serialResult] = await Promise.all([output, request])
 
-    // await this.saveNotebookOutputs(lid, outputResult)
+    await this.saveNotebookOutputs(lid, outputResult)
 
     const { result } = serialResult.response
     if (result === undefined) {

--- a/tests/extension/cell.test.ts
+++ b/tests/extension/cell.test.ts
@@ -80,6 +80,10 @@ describe('NotebookCellOutputManager', () => {
     const { controller, createExecution } = mockNotebookController(cell)
 
     const outputs = new NotebookCellOutputManager(cell, controller, true)
+    await outputs.showTerminal(true)
+    const serialize = vi.fn().mockImplementation(() => 'terminal test output')
+    ;(outputs as any).terminalState = { serialize, write: vi.fn() } as any
+
     const exec = mockCellExecution(cell)
     createExecution.mockReturnValue(exec)
 

--- a/tests/extension/cell.test.ts
+++ b/tests/extension/cell.test.ts
@@ -29,7 +29,7 @@ vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
 
 describe('NotebookCellManager', () => {
   it('can register cells', () => {
-    const manager = new NotebookCellManager({} as any)
+    const manager = new NotebookCellManager({} as any, false)
     const cell = {} as any
 
     manager.registerCell(cell)
@@ -79,7 +79,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, createExecution } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     const exec1 = mockCellExecution(cell)
     createExecution.mockReturnValue(exec1)
@@ -105,7 +105,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, createExecution } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     const runmeExec = await outputs.createNotebookCellExecution()
     expect(runmeExec).toBeTruthy()
@@ -137,7 +137,7 @@ describe('NotebookCellOutputManager', () => {
     })
     vi.mocked(window.showInformationMessage).mockResolvedValueOnce({} as any)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     const runmeExec = await outputs.createNotebookCellExecution()
     expect(runmeExec).toBeUndefined()
@@ -157,7 +157,7 @@ describe('NotebookCellOutputManager', () => {
     })
     vi.mocked(window.showInformationMessage).mockResolvedValueOnce(undefined)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     const runmeExec = await outputs.createNotebookCellExecution()
     expect(runmeExec).toBeUndefined()
@@ -177,7 +177,7 @@ describe('NotebookCellOutputManager', () => {
 
     vi.mocked(commands.getCommands).mockResolvedValueOnce([])
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     const runmeExec = await outputs.createNotebookCellExecution()
     expect(runmeExec).toBeUndefined()
@@ -192,7 +192,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, createExecution, exec } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     await outputs.toggleOutput(OutputType.annotations)
     expect(createExecution).toHaveBeenCalledOnce()
@@ -206,7 +206,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, replaceOutput } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     await outputs.toggleOutput(OutputType.annotations)
     expect(replaceOutput).toBeCalledWith([], undefined)
@@ -217,7 +217,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, replaceOutput } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     await outputs.toggleOutput(OutputType.annotations)
     const result = replaceOutput.mock.calls[0][0]
@@ -231,7 +231,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, replaceOutput } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     await outputs.showOutput(OutputType.annotations)
 
@@ -248,7 +248,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, replaceOutput } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     const outputSpy = vi.spyOn(outputs, 'getCellState')
     await outputs.showOutput(OutputType.vercel)
@@ -268,7 +268,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, replaceOutput } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     await outputs.showOutput(OutputType.deno)
 
@@ -285,7 +285,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, replaceOutput } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     const outputSpy = vi.spyOn(outputs, 'getCellState')
     await outputs.showOutput(OutputType.github)
@@ -305,7 +305,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     outputs.setState({
       type: OutputType.vercel,
@@ -323,7 +323,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, replaceOutput } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     await outputs.refreshOutput(OutputType.annotations)
     expect(replaceOutput).toHaveBeenCalledTimes(0)
@@ -334,7 +334,7 @@ describe('NotebookCellOutputManager', () => {
 
     const { controller, replaceOutput } = mockNotebookController(cell)
 
-    const outputs = new NotebookCellOutputManager(cell, controller)
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
 
     await outputs.refreshOutput(OutputType.annotations)
     expect(replaceOutput).toHaveBeenCalledTimes(1)
@@ -342,6 +342,28 @@ describe('NotebookCellOutputManager', () => {
 })
 
 describe('RunmeNotebookCellExecution', () => {
+  it('runs onWillEnd ahead of onEnd when end is called', async () => {
+    const exec = mockedNotebookCellExecution()
+    const runmeExec = new RunmeNotebookCellExecution(exec)
+
+    runmeExec.start(100)
+    expect(vi.mocked(exec.start)).toBeCalledTimes(1)
+    expect(vi.mocked(exec.start)).toBeCalledWith(100)
+
+    const onWillEndFunc = vi.fn()
+    runmeExec.onWillEnd(onWillEndFunc)
+    const onEndFunc = vi.fn()
+    runmeExec.onEnd(onEndFunc)
+
+    await runmeExec.end(false, 200)
+    expect(vi.mocked(exec.end)).toBeCalledTimes(1)
+    expect(vi.mocked(exec.end)).toBeCalledWith(false, 200)
+
+    expect(onWillEndFunc).toBeCalledTimes(1)
+    expect(onEndFunc).toBeCalledTimes(1)
+    expect(onEndFunc).toBeCalledWith({ success: false, endTime: 200 })
+  })
+
   it('runs onEnd when end is called', async () => {
     const exec = mockedNotebookCellExecution()
     const runmeExec = new RunmeNotebookCellExecution(exec)

--- a/tests/extension/cell.test.ts
+++ b/tests/extension/cell.test.ts
@@ -74,6 +74,26 @@ function mockNotebookController(cell: NotebookCell) {
 }
 
 describe('NotebookCellOutputManager', () => {
+  it('marks document as dirty as part of refreshing the terminal state', async () => {
+    const cell = mockCell()
+
+    const { controller, createExecution } = mockNotebookController(cell)
+
+    const outputs = new NotebookCellOutputManager(cell, controller, true)
+    const exec = mockCellExecution(cell)
+    createExecution.mockReturnValue(exec)
+
+    const runmeExec = await outputs.createNotebookCellExecution()
+    expect(runmeExec).toBeDefined()
+
+    const spy = vi.spyOn(outputs, 'refreshTerminal')
+
+    runmeExec!.start()
+    runmeExec!.end(undefined)
+
+    expect(spy).toBeCalledTimes(1)
+  })
+
   it('uses current execution for outputs', async () => {
     const cell = mockCell()
 

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -280,6 +280,23 @@ describe('GrpcSerializer', () => {
 
     const fakeOutputFileUri = { fsPath: '/tmp/fake/outputs.md' } as any
 
+    it('maps document lifecylce ids to document URIs on notebook opening', async () => {
+      const fixture = deepCopyFixture()
+      const lid = fixture.metadata['runme.dev/frontmatterParsed'].runme.id
+
+      const serializer: any = new GrpcSerializer(context, new Server(), new Kernel())
+      serializer.outputPersistence = true
+
+      vi.spyOn(GrpcSerializer, 'getOutputsUri').mockReturnValue(fakeOutputFileUri)
+
+      await serializer.handleOpenNotebook({
+        metadata: fixture.metadata,
+      })
+
+      const sessionFileUri = serializer.sessionFileMapping.get(lid)
+      expect(sessionFileUri).toStrictEqual(fakeOutputFileUri)
+    })
+
     it('writes cached bytes to session file on serialization and save', async () => {
       const fixture = deepCopyFixture()
 

--- a/vitest.conf.ts
+++ b/vitest.conf.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       enabled: true,
       exclude: ['**/build/**', '**/__fixtures__/**', '**/*.test.ts'],
       statements: 43,
-      branches: 85,
+      branches: 84.5,
       functions: 32,
       lines: 43
     }


### PR DESCRIPTION
The VS Code API provides limited control over serialization timing; however, this PR improves two things that were possible:

1. The session outputs file will be written on saving and serializing. The latter is new. This allows a near real-time (vscode debounces/throttles serialization, which introduces a slight lag) tracking of state side-by-side. This still feels more natural.
2. The notebook document is marked "dirty" (needs to be saved before closing/exiting) after every successful execution. This makes it explicit always to save when a "mutation" happens.

The changes feel natural and fix the problems described [here](https://github.com/stateful/runme/issues/400#issuecomment-1849030175) where serializing outputs to the session file do not match (out of sync) the latest notebook state on closing/exiting.

To test this: without this PR the last run of a cell won't be written to the session file after the execution completes until the user explicitly triggers save (CTRL+S / CMD+S). With this PR, the document will be marked dirty as part of completing a cell run requiring a save/discard by the user, making the save-requirement explicit.