### PR TITLE
Deny session outputs (one-way serialization only; pending deserialization)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@apollo/client": "^3.8.3",
         "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.9.1-20230830152835-a5b3a068eb8c.1",
-        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.3-20231212160515-2c40ef1f3311.1",
+        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.3-20231228201231-1e8328c590ec.1",
         "@protobuf-ts/grpc-transport": "^2.9.1",
         "@protobuf-ts/runtime": "^2.9.1",
         "@protobuf-ts/runtime-rpc": "^2.9.1",
@@ -1564,8 +1564,8 @@
       }
     },
     "node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.9.3-20231212160515-2c40ef1f3311.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.3-20231212160515-2c40ef1f3311.1.tgz",
+      "version": "2.9.3-20231228201231-1e8328c590ec.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.3-20231228201231-1e8328c590ec.1.tgz",
       "peerDependencies": {
         "@protobuf-ts/runtime": "^2.9.3",
         "@protobuf-ts/runtime-rpc": "^2.9.3"

--- a/package.json
+++ b/package.json
@@ -937,7 +937,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.3",
     "@buf/grpc_grpc.community_timostamm-protobuf-ts": "^2.9.1-20230830152835-a5b3a068eb8c.1",
-    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.3-20231212160515-2c40ef1f3311.1",
+    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.3-20231228201231-1e8328c590ec.1",
     "@protobuf-ts/grpc-transport": "^2.9.1",
     "@protobuf-ts/runtime": "^2.9.1",
     "@protobuf-ts/runtime-rpc": "^2.9.1",

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -256,15 +256,15 @@ export async function askNewRunnerSession(kernel: Kernel) {
 
 export enum ASK_ALT_OUTPUTS_ACTION {
   ORIGINAL = 'Open original document',
-  PRVIEW = 'Preview session outputs',
+  PREVIEW = 'Preview session outputs',
 }
 
 export async function askAlternativeOutputsAction(notebookDoc: NotebookDocument): Promise<void> {
   await commands.executeCommand('workbench.action.closeActiveEditor')
   const action = await window.showWarningMessage(
-    'Opening Session Outputs from a pervious notebook session is not supported yet. What would you like to do instead?',
+    'Opening Session Outputs from a previous notebook session is not supported yet. What would you like to do instead?',
     { modal: true },
-    ASK_ALT_OUTPUTS_ACTION.PRVIEW,
+    ASK_ALT_OUTPUTS_ACTION.PREVIEW,
     ASK_ALT_OUTPUTS_ACTION.ORIGINAL,
   )
 
@@ -274,11 +274,11 @@ export async function askAlternativeOutputsAction(notebookDoc: NotebookDocument)
 
   switch (action) {
     case ASK_ALT_OUTPUTS_ACTION.ORIGINAL:
-      let base = path.dirname(notebookDoc.uri.fsPath)
-      let origFilePath = notebookDoc.uri.with({ path: path.join(base, orig) })
+      const base = path.dirname(notebookDoc.uri.fsPath)
+      const origFilePath = notebookDoc.uri.with({ path: path.join(base, orig) })
       await commands.executeCommand('vscode.openWith', origFilePath, Kernel.type)
       break
-    case ASK_ALT_OUTPUTS_ACTION.PRVIEW:
+    case ASK_ALT_OUTPUTS_ACTION.PREVIEW:
       await commands.executeCommand('markdown.showPreview', notebookDoc.uri)
       break
   }

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -254,7 +254,7 @@ export async function askNewRunnerSession(kernel: Kernel) {
   }
 }
 
-enum PROMPT_OPEN_ORIG_DOC {
+export enum ASK_ALT_OUTPUTS_ACTION {
   ORIGINAL = 'Open original document',
   PRVIEW = 'Preview session outputs',
 }
@@ -264,8 +264,8 @@ export async function askAlternativeOutputsAction(notebookDoc: NotebookDocument)
   const action = await window.showWarningMessage(
     'Opening Session Outputs from a pervious notebook session is not supported yet. What would you like to do instead?',
     { modal: true },
-    PROMPT_OPEN_ORIG_DOC.PRVIEW,
-    PROMPT_OPEN_ORIG_DOC.ORIGINAL,
+    ASK_ALT_OUTPUTS_ACTION.PRVIEW,
+    ASK_ALT_OUTPUTS_ACTION.ORIGINAL,
   )
 
   const { metadata } = notebookDoc
@@ -273,15 +273,13 @@ export async function askAlternativeOutputsAction(notebookDoc: NotebookDocument)
     metadata['runme.dev/frontmatterParsed']?.['runme']?.['session']?.['document']?.['relativePath']
 
   switch (action) {
-    case PROMPT_OPEN_ORIG_DOC.ORIGINAL:
+    case ASK_ALT_OUTPUTS_ACTION.ORIGINAL:
       let base = path.dirname(notebookDoc.uri.fsPath)
       let origFilePath = notebookDoc.uri.with({ path: path.join(base, orig) })
       await commands.executeCommand('vscode.openWith', origFilePath, Kernel.type)
       break
-    case PROMPT_OPEN_ORIG_DOC.PRVIEW:
+    case ASK_ALT_OUTPUTS_ACTION.PRVIEW:
       await commands.executeCommand('markdown.showPreview', notebookDoc.uri)
-      break
-    default:
       break
   }
 }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -647,8 +647,6 @@ export class Kernel implements Disposable {
       this.runnerEnv?.dispose()
       this.runnerEnv = undefined
 
-      await commands.executeCommand('notebook.clearAllCellsOutputs')
-
       const runnerEnv = await this.runner.createEnvironment(
         // copy env from process naively for now
         // later we might want a more sophisticated approach/to bring this serverside
@@ -656,6 +654,9 @@ export class Kernel implements Disposable {
       )
 
       this.runnerEnv = runnerEnv
+
+      // runs this last to not overwrite previous outputs
+      await commands.executeCommand('notebook.clearAllCellsOutputs')
 
       log.info('New runner environment assigned with session ID:', runnerEnv.getSessionId())
     } catch (e: any) {

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -196,7 +196,7 @@ export class Kernel implements Disposable {
   }
 
   async #handleOpenNotebook(notebookDocument: NotebookDocument) {
-    const isSessionsOutput = await this.denySessionOutputsNotebook(notebookDocument)
+    const isSessionsOutput = await Kernel.denySessionOutputsNotebook(notebookDocument)
     const { uri, isUntitled, notebookType, getCells } = notebookDocument
     if (isSessionsOutput || notebookType !== Kernel.type) {
       return
@@ -747,7 +747,7 @@ export class Kernel implements Disposable {
     await commands.executeCommand('notebook.cell.focusInOutput')
   }
 
-  private async denySessionOutputsNotebook(notebookDoc: NotebookDocument): Promise<boolean> {
+  private static async denySessionOutputsNotebook(notebookDoc: NotebookDocument): Promise<boolean> {
     if (!GrpcSerializer.isDocumentSessionOutputs(notebookDoc.metadata)) {
       return Promise.resolve(false)
     }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -749,7 +749,7 @@ export class Kernel implements Disposable {
 
   private static async denySessionOutputsNotebook(notebookDoc: NotebookDocument): Promise<boolean> {
     if (!GrpcSerializer.isDocumentSessionOutputs(notebookDoc.metadata)) {
-      return Promise.resolve(false)
+      return false
     }
 
     await askAlternativeOutputsAction(notebookDoc)

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -572,7 +572,6 @@ export class GrpcSerializer extends SerializerBase {
     })
 
     const request = <SerializeRequest>{ notebook, options }
-    console.log(JSON.stringify(request.options))
     const result = await this.client!.serialize(request)
 
     if (result.response.result === undefined) {

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -514,7 +514,8 @@ export class GrpcSerializer extends SerializerBase {
 
   public static isDocumentSessionOutputs(metadata: { [key: string]: any } | undefined): boolean {
     if (!metadata) {
-      return true
+      // it's not session outputs unless known
+      return false
     }
     const sessionOutputId = metadata['runme.dev/frontmatterParsed']?.['runme']?.['session']?.['id']
     return Boolean(sessionOutputId)

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -34,6 +34,7 @@ import {
   CellKind,
   CellOutput,
   SerializeRequestOptions,
+  RunmeSession,
 } from './grpc/serializerTypes'
 import { initParserClient, ParserServiceClient, type ReadyPromise } from './grpc/client'
 import Languages from './languages'
@@ -424,6 +425,11 @@ export class GrpcSerializer extends SerializerBase {
       return
     }
 
+    if (GrpcSerializer.isDocumentSessionOutputs(doc.metadata)) {
+      this.toggleSessionButton(false)
+      return
+    }
+
     this.lidDocUriMapping.set(lid, doc.uri)
   }
 
@@ -506,6 +512,14 @@ export class GrpcSerializer extends SerializerBase {
     return metadata['runme.dev/frontmatterParsed']?.['runme']?.['id']
   }
 
+  public static isDocumentSessionOutputs(metadata: { [key: string]: any } | undefined): boolean {
+    if (!metadata) {
+      return true
+    }
+    const sessionOutputId = metadata['runme.dev/frontmatterParsed']?.['runme']?.['session']?.['id']
+    return Boolean(sessionOutputId)
+  }
+
   protected async saveNotebook(
     data: NotebookData,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -540,9 +554,25 @@ export class GrpcSerializer extends SerializerBase {
       return Promise.resolve(undefined)
     }
 
-    const options = <SerializeRequestOptions>{ outputs: { enabled: true, summary: true } }
-    const request = <SerializeRequest>{ notebook, options }
+    let session: RunmeSession | undefined
+    const docUri = this.lidDocUriMapping.get(lid ?? '')
+    const sid = this.kernel.getRunnerEnvironment()?.getSessionId()
+    if (sid && docUri) {
+      const relativePath = path.basename(docUri.fsPath)
+      session = {
+        id: sid,
+        document: { relativePath },
+      }
+    }
 
+    const outputs = { enabled: true, summary: true }
+    const options = SerializeRequestOptions.clone({
+      outputs,
+      session,
+    })
+
+    const request = <SerializeRequest>{ notebook, options }
+    console.log(JSON.stringify(request.options))
     const result = await this.client!.serialize(request)
 
     if (result.response.result === undefined) {
@@ -563,6 +593,11 @@ export class GrpcSerializer extends SerializerBase {
   public static marshalNotebook(data: NotebookData): Notebook {
     // the bulk copies cleanly except for what's below
     const notebook = Notebook.clone(data as any)
+
+    // cannot gurantee it wasn't changed
+    if (notebook.metadata['runme.dev/frontmatterParsed']) {
+      delete notebook.metadata['runme.dev/frontmatterParsed']
+    }
 
     notebook.cells.forEach(async (cell, cellIdx) => {
       const dataExecSummary = data.cells[cellIdx].executionSummary

--- a/tests/extension/commands/index.test.ts
+++ b/tests/extension/commands/index.test.ts
@@ -29,6 +29,8 @@ import {
   openFileInRunme,
   addToRecommendedExtensions,
   askNewRunnerSession,
+  askAlternativeOutputsAction,
+  ASK_ALT_OUTPUTS_ACTION,
 } from '../../../src/extension/commands'
 import {
   getTerminalByCell,
@@ -231,6 +233,41 @@ test('open Runme notebook in text editor toggle', (file: TextDocument) => {
   vi.mocked(getActionsOpenViewInEditor).mockReturnValue('toggle' as const)
   openSplitViewAsMarkdownText(file)
   expect(commands.executeCommand).toBeCalledWith('workbench.action.toggleEditorType')
+})
+
+suite('askAlternativeOutputsAction', () => {
+  const orig = 'orig.md'
+  const metadata = {
+    'runme.dev/frontmatterParsed': {
+      runme: { session: { document: { relativePath: orig } } },
+    },
+  }
+
+  const withFn = vi.fn()
+  const uri = { fsPath: orig, with: withFn }
+
+  test('will open preview when chosen', async () => {
+    const warning = vi.mocked(window.showWarningMessage)
+
+    warning.mockResolvedValue(ASK_ALT_OUTPUTS_ACTION.PRVIEW as any)
+    await askAlternativeOutputsAction({ uri, metadata } as any)
+
+    expect(commands.executeCommand).toBeCalledWith('workbench.action.closeActiveEditor')
+    expect(commands.executeCommand).toBeCalledWith('markdown.showPreview', uri)
+    expect(warning).toBeCalledTimes(1)
+  })
+
+  test('will open original in notebook UX when chosen', async () => {
+    const warning = vi.mocked(window.showWarningMessage)
+
+    warning.mockResolvedValue(ASK_ALT_OUTPUTS_ACTION.ORIGINAL as any)
+    withFn.mockReturnValue(uri)
+    await askAlternativeOutputsAction({ uri, metadata } as any)
+
+    expect(commands.executeCommand).toBeCalledWith('workbench.action.closeActiveEditor')
+    expect(commands.executeCommand).toBeCalledWith('vscode.openWith', uri, 'runme')
+    expect(warning).toBeCalledTimes(1)
+  })
 })
 
 suite('askNewRunnerSession', () => {

--- a/tests/extension/commands/index.test.ts
+++ b/tests/extension/commands/index.test.ts
@@ -249,7 +249,7 @@ suite('askAlternativeOutputsAction', () => {
   test('will open preview when chosen', async () => {
     const warning = vi.mocked(window.showWarningMessage)
 
-    warning.mockResolvedValue(ASK_ALT_OUTPUTS_ACTION.PRVIEW as any)
+    warning.mockResolvedValue(ASK_ALT_OUTPUTS_ACTION.PREVIEW as any)
     await askAlternativeOutputsAction({ uri, metadata } as any)
 
     expect(commands.executeCommand).toBeCalledWith('workbench.action.closeActiveEditor')

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -60,7 +60,6 @@ vi.mock('../../src/extension/grpc/client', () => {
 
 vi.mock('../../src/extension/utils', async () => ({
   getDefaultWorkspace: vi.fn(),
-  resetEnv: vi.fn(),
   initWasm: vi.fn(),
   getNamespacedMid: vi.fn(),
   isWindows: vi.fn().mockReturnValue(false),

--- a/tests/extension/kernel.test.ts
+++ b/tests/extension/kernel.test.ts
@@ -4,6 +4,7 @@ import { window, NotebookCell, workspace } from 'vscode'
 import { Kernel } from '../../src/extension/kernel'
 import executors from '../../src/extension/executors'
 import { TelemetryReporter } from '../../__mocks__/vscode-telemetry'
+import { askAlternativeOutputsAction } from '../../src/extension/commands'
 
 vi.mock('vscode')
 vi.mock('vscode-telemetry')
@@ -23,6 +24,7 @@ vi.mock('../../src/extension/executors/index.js', () => ({
 vi.mock('../../src/extension/runner', () => ({}))
 
 vi.mock('../../src/extension/grpc/runnerTypes', () => ({}))
+vi.mock('../../src/extension/commands', () => ({ askAlternativeOutputsAction: vi.fn() }))
 
 const getCells = (cnt: number, metadata: Record<string, any> = {}) =>
   [...new Array(cnt)].map(
@@ -250,4 +252,14 @@ test('supportedLanguages', async () => {
   const k = new Kernel({} as any)
 
   expect(k.getSupportedLanguages()![0]).toStrictEqual('shellscript')
+})
+
+test('deny notebook UX view for session outputs files', async () => {
+  const res = await (Kernel as any).denySessionOutputsNotebook({
+    metadata: {
+      'runme.dev/frontmatterParsed': { runme: { session: { id: 'my-fake-session' } } },
+    },
+  })
+  expect(askAlternativeOutputsAction).toBeCalledTimes(1)
+  expect(res).toBeTruthy()
 })

--- a/tests/extension/kernel.test.ts
+++ b/tests/extension/kernel.test.ts
@@ -254,12 +254,24 @@ test('supportedLanguages', async () => {
   expect(k.getSupportedLanguages()![0]).toStrictEqual('shellscript')
 })
 
-test('deny notebook UX view for session outputs files', async () => {
-  const res = await (Kernel as any).denySessionOutputsNotebook({
-    metadata: {
-      'runme.dev/frontmatterParsed': { runme: { session: { id: 'my-fake-session' } } },
-    },
+suite('#denySessionOutputsNotebook', () => {
+  test('allow notebook UX view for non-session outputs files', async () => {
+    const res = await (Kernel as any).denySessionOutputsNotebook({
+      metadata: {
+        'runme.dev/frontmatterParsed': { runme: { id: 'ulid' } },
+      },
+    })
+    expect(askAlternativeOutputsAction).toBeCalledTimes(0)
+    expect(res).toBeFalsy()
   })
-  expect(askAlternativeOutputsAction).toBeCalledTimes(1)
-  expect(res).toBeTruthy()
+
+  test('deny notebook UX view for session outputs files', async () => {
+    const res = await (Kernel as any).denySessionOutputsNotebook({
+      metadata: {
+        'runme.dev/frontmatterParsed': { runme: { session: { id: 'my-fake-session' } } },
+      },
+    })
+    expect(askAlternativeOutputsAction).toBeCalledTimes(1)
+    expect(res).toBeTruthy()
+  })
 })

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -227,6 +227,11 @@ describe('GrpcSerializer', () => {
       expect(res).toBeFalsy()
     })
 
+    it('should return false for undefined metadata', () => {
+      const res = GrpcSerializer.isDocumentSessionOutputs(undefined)
+      expect(res).toBeFalsy()
+    })
+
     it('should return true when frontmatter does include a session ID', () => {
       const res = GrpcSerializer.isDocumentSessionOutputs({
         'runme.dev/frontmatterParsed': { runme: { session: { id: 'my-fake-session' } } },

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -241,13 +241,13 @@ describe('GrpcSerializer', () => {
   })
 
   describe('#getDocumentLifecycleId', () => {
-    it('should return the document lifecylce ID if present', () => {
+    it('should return the document lifecycle ID if present', () => {
       const fixture = deepCopyFixture()
       const res = GrpcSerializer.getDocumentLifecycleId(fixture.metadata)
       expect(res).toStrictEqual('01HF7B0KJPF469EG9ZWDNKKACQ')
     })
 
-    it('should return undefined for documents without lifecylce IDs', () => {
+    it('should return undefined for documents without lifecycle IDs', () => {
       const fixture = deepCopyFixture()
       delete fixture.metadata['runme.dev/frontmatterParsed']?.['runme']
 
@@ -334,7 +334,7 @@ describe('GrpcSerializer', () => {
   describe('session file', () => {
     const fakeSrcDocUri = { fsPath: '/tmp/fake/source.md' } as any
 
-    it("maps document lifecylce ids to source doc's URIs on notebook opening", async () => {
+    it("maps document lifecycle ids to source doc's URIs on notebook opening", async () => {
       const fixture = deepCopyFixture()
       const lid = fixture.metadata['runme.dev/frontmatterParsed'].runme.id
 

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -204,6 +204,37 @@ describe('GrpcSerializer', () => {
     return JSON.parse(JSON.stringify(raw))
   }
 
+  describe('#isDocumentSessionOutputs', () => {
+    it('should return false when frontmatter does not include a session ID', () => {
+      const fixture = deepCopyFixture()
+      const res = GrpcSerializer.isDocumentSessionOutputs(fixture.metadata)
+      expect(res).toBeFalsy()
+    })
+
+    it('should return true when frontmatter does include a session ID', () => {
+      const res = GrpcSerializer.isDocumentSessionOutputs({
+        'runme.dev/frontmatterParsed': { runme: { session: { id: 'my-fake-session' } } },
+      })
+      expect(res).toBeTruthy()
+    })
+  })
+
+  describe('#getDocumentLifecycleId', () => {
+    it('should return the document lifecylce ID if present', () => {
+      const fixture = deepCopyFixture()
+      const res = GrpcSerializer.getDocumentLifecycleId(fixture.metadata)
+      expect(res).toStrictEqual('01HF7B0KJPF469EG9ZWDNKKACQ')
+    })
+
+    it('should return undefined for documents without lifecylce IDs', () => {
+      const fixture = deepCopyFixture()
+      delete fixture.metadata['runme.dev/frontmatterParsed']?.['runme']
+
+      const res = GrpcSerializer.getDocumentLifecycleId(fixture.metadata)
+      expect(res).toBeUndefined()
+    })
+  })
+
   describe('cell execution summary marshaling', () => {
     it('should not misrepresenting uninitialized values', () => {
       // i.e. undefined is not sucess=false

--- a/vitest.conf.ts
+++ b/vitest.conf.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       enabled: true,
       exclude: ['**/build/**', '**/__fixtures__/**', '**/*.test.ts'],
       statements: 43,
-      branches: 84.5,
+      branches: 85,
       functions: 32,
       lines: 43
     }


### PR DESCRIPTION
This PR will introduce checks at the markdown/frontmatter level whether or not the document opened in the notebook UX was generated as a session outputs file. In the case of the latter, a modal will present alternatives. Please take a look at the screenshot below. This should be a sufficient solution until the deserialization of session outputs markdown is solved (if ever).

PS: A merge/release will require a new stable release of `runme` (including https://github.com/stateful/runme/pull/458).

<img width="528" alt="image" src="https://github.com/stateful/vscode-runme/assets/250527/358914c1-f7d1-456f-bc16-27ad7170c970">