### PR TITLE
Set execution order according to session

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,12 @@ export NODE_OPTIONS="--experimental-specifier-resolution=node"
 npx vitest -c ./vitest.conf.ts --run
 ```
 
+The test coverage report is easy to access at:
+
+```sh {"id":"01HJVVP86RWEMH7QM80EPK266B","name":"test:report"}
+open coverage/lcov-report/index.html
+```
+
 #### E2E Testing
 
 We use WebdriverIO to run e2e tests on the VS Code extension:

--- a/package.json
+++ b/package.json
@@ -614,6 +614,11 @@
             ],
             "markdownDescription": "Default behavior of Open In Editor action button"
           },
+          "runme.notebook.executionOrder": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable execution order counter per cell in notebook UX"
+          },
           "runme.codelens.enable": {
             "type": "boolean",
             "default": true,

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -526,8 +526,6 @@ export class Kernel implements Disposable {
     const environmentManager = this.getEnvironmentManager()
     const outputs = await this.getCellOutputs(cell)
 
-    // exec.executionOrder = this.incrementOrderCounter()
-
     if (
       this.runner &&
       // hard disable gRPC runner on windows

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -28,6 +28,7 @@ import {
 } from '../constants'
 import { API } from '../utils/deno/api'
 import { postClientMessage } from '../utils/messaging'
+import { getNotebookExecutionOrder } from '../utils/configuration'
 
 import * as survey from './survey'
 import getLogger from './logger'
@@ -111,7 +112,7 @@ export class Kernel implements Disposable {
       this.#controller,
       this.hasExperimentEnabled('outputPersistence') ?? false,
     )
-    this.#controller.supportsExecutionOrder = true
+    this.#controller.supportsExecutionOrder = getNotebookExecutionOrder()
     this.#controller.description = 'Run your Markdown'
     this.#controller.executeHandler = this._executeAll.bind(this)
 

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -111,7 +111,7 @@ export class Kernel implements Disposable {
       this.#controller,
       this.hasExperimentEnabled('outputPersistence') ?? false,
     )
-    this.#controller.supportsExecutionOrder = false
+    this.#controller.supportsExecutionOrder = true
     this.#controller.description = 'Run your Markdown'
     this.#controller.executeHandler = this._executeAll.bind(this)
 
@@ -526,6 +526,8 @@ export class Kernel implements Disposable {
     const environmentManager = this.getEnvironmentManager()
     const outputs = await this.getCellOutputs(cell)
 
+    // exec.executionOrder = this.incrementOrderCounter()
+
     if (
       this.runner &&
       // hard disable gRPC runner on windows
@@ -652,11 +654,13 @@ export class Kernel implements Disposable {
 
       const runnerEnv = await this.runner.createEnvironment(
         // copy env from process naively for now
-        // later we might want a more sophisticated approach/to bring this serverside
+        // later we might want a more sophisticated approach/to bring this server-side
         processEnviron(),
       )
 
       this.runnerEnv = runnerEnv
+
+      this.cellManager.setRunnerEnv(runnerEnv)
 
       // runs this last to not overwrite previous outputs
       await commands.executeCommand('notebook.clearAllCellsOutputs')

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -13,6 +13,7 @@ const ACTIONS_SECTION_NAME = 'runme.actions'
 const SERVER_SECTION_NAME = 'runme.server'
 const TERMINAL_SECTION_NAME = 'runme.terminal'
 const CODELENS_SECTION_NAME = 'runme.codelens'
+const NOTEBOOK_SECTION_NAME = 'runme.notebook'
 const ENV_SECTION_NAME = 'runme.env'
 const CLI_SECTION_NAME = 'runme.cli'
 const APP_SECTION_NAME = 'runme.app'
@@ -63,6 +64,9 @@ const configurationSchema = {
   },
   codelens: {
     enable: z.boolean().default(true),
+  },
+  notebook: {
+    executionOrder: z.boolean().default(true),
   },
   env: {
     workspaceFileOrder: z.array(z.string()).default(DEFAULT_WORKSPACE_FILE_ORDER),
@@ -135,6 +139,19 @@ const getCodeLensConfigurationValue = <T>(
   const configurationSection = workspace.getConfiguration(CODELENS_SECTION_NAME)
   const configurationValue = configurationSection.get<T>(configName)!
   const parseResult = configurationSchema.codelens[configName].safeParse(configurationValue)
+  if (parseResult.success) {
+    return parseResult.data as T
+  }
+  return defaultValue
+}
+
+const getNotebookConfigurationValue = <T>(
+  configName: keyof typeof configurationSchema.notebook,
+  defaultValue: T,
+) => {
+  const configurationSection = workspace.getConfiguration(NOTEBOOK_SECTION_NAME)
+  const configurationValue = configurationSection.get<T>(configName)!
+  const parseResult = configurationSchema.notebook[configName].safeParse(configurationValue)
   if (parseResult.success) {
     return parseResult.data as T
   }
@@ -257,6 +274,10 @@ const getCodeLensEnabled = (): boolean => {
   return getCodeLensConfigurationValue<boolean>('enable', true)
 }
 
+const getNotebookExecutionOrder = (): boolean => {
+  return getNotebookConfigurationValue<boolean>('executionOrder', true)
+}
+
 const registerExtensionEnvironmentVariables = (context: ExtensionContext): void => {
   context.environmentVariableCollection.prepend(
     'PATH',
@@ -357,6 +378,7 @@ export {
   getTLSDir,
   getNotebookTerminalConfigurations,
   getCodeLensEnabled,
+  getNotebookExecutionOrder,
   registerExtensionEnvironmentVariables,
   getCustomServerAddress,
   getActionsOpenViewInEditor,

--- a/tests/extension/cell.test.ts
+++ b/tests/extension/cell.test.ts
@@ -42,11 +42,21 @@ describe('NotebookCellManager', () => {
     expect(errorMock.mock.calls[0][0]).toMatch('has not been registered')
   })
 
+  it('returns existing outputs on cell re-register', async () => {
+    const manager = new NotebookCellManager({} as any, false)
+    const cell = {} as any
+
+    const outputs1 = manager.registerCell(cell)
+    expect(outputs1).toBeTruthy()
+    const outputs2 = manager.registerCell(cell)
+    expect(outputs2).toBeTruthy()
+
+    expect(outputs1).toStrictEqual(outputs2)
+  })
+
   it('set mru session id on outputs whenever they are being used', async () => {
     const manager = new NotebookCellManager({} as any, false)
-    manager.setRunnerEnv(<IRunnerEnvironment>{
-      getSessionId: () => 'session-id1',
-    })
+    manager.setRunnerEnv(<IRunnerEnvironment>{ getSessionId: () => 'session-id1' })
     const cell = {} as any
 
     manager.registerCell(cell)
@@ -54,13 +64,30 @@ describe('NotebookCellManager', () => {
     expect((outputs as any).mruSessionId).toStrictEqual('session-id1')
     expect(outputs).toBeTruthy()
 
-    manager.setRunnerEnv(<IRunnerEnvironment>{
-      getSessionId: () => 'session-id2',
-    })
+    manager.setRunnerEnv(<IRunnerEnvironment>{ getSessionId: () => 'session-id2' })
 
     const outputsP = manager.getNotebookOutputs(cell)
     expect(outputsP).resolves.toBeInstanceOf(NotebookCellOutputManager)
     expect(((await outputsP) as any).mruSessionId).toStrictEqual('session-id2')
+  })
+
+  it('increment order for session id when an execution is created', async () => {
+    const createNotebookCellExecution = vi.fn()
+    const manager = new NotebookCellManager({ createNotebookCellExecution } as any, false)
+    manager.setRunnerEnv(<IRunnerEnvironment>{ getSessionId: () => 'session-id1' })
+    const cell = {} as any
+
+    manager.registerCell(cell)
+    const outputs = await manager.getNotebookOutputs(cell)
+    expect((outputs as any).mruSessionId).toStrictEqual('session-id1')
+    expect(outputs).toBeTruthy()
+
+    await manager.createNotebookCellExecution(cell)
+    await manager.createNotebookCellExecution(cell)
+    await manager.createNotebookCellExecution(cell)
+
+    expect((outputs as any).currentExecutionOrder()).toStrictEqual(3)
+    expect(createNotebookCellExecution).toBeCalledTimes(3)
   })
 })
 
@@ -384,6 +411,59 @@ describe('NotebookCellOutputManager', () => {
 
     await outputs.refreshOutput(OutputType.annotations)
     expect(replaceOutput).toHaveBeenCalledTimes(1)
+  })
+
+  describe('exec and order', () => {
+    const cell = mockCell()
+
+    const { controller, createExecution } = mockNotebookController(cell)
+
+    const outputs = new NotebookCellOutputManager(cell, controller, false)
+
+    it('sets mru session ID and order', () => {
+      outputs.setSessionExecutionOrder('session-id1', 3641)
+      expect((outputs as any).currentExecutionOrder()).toStrictEqual(3641)
+    })
+
+    it('resets order when mru session ID changes', () => {
+      outputs.setMruSessionId('session-id2')
+      expect((outputs as any).currentExecutionOrder()).toStrictEqual(undefined)
+    })
+
+    it('applies current session order to execution', async () => {
+      outputs.setSessionExecutionOrder('session-id1', 1337)
+      const exec1 = mockCellExecution(cell)
+      createExecution.mockReturnValue(exec1)
+
+      const runmeExec = await outputs.createNotebookCellExecution()
+      expect(runmeExec).toBeTruthy()
+
+      expect(runmeExec!.underlyingExecution.executionOrder).toStrictEqual(1337)
+    })
+  })
+
+  describe('outputs and order', () => {
+    it('retains session order for outputs', async () => {
+      const cell = mockCell()
+
+      const { controller, createExecution } = mockNotebookController(cell)
+
+      const outputs = new NotebookCellOutputManager(cell, controller, false)
+      outputs.setSessionExecutionOrder('session-id', 1337)
+
+      const exec1 = mockCellExecution(cell)
+      createExecution.mockReturnValue(exec1)
+
+      const runmeExec = await outputs.createNotebookCellExecution()
+      expect(runmeExec).toBeTruthy()
+
+      runmeExec!.start()
+
+      await outputs.toggleOutput(OutputType.annotations)
+      expect(exec1.executionOrder).toStrictEqual(1337)
+
+      runmeExec!.end(undefined)
+    })
   })
 })
 

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -14,6 +14,7 @@ import {
   getNotebookTerminalConfigurations,
   getCodeLensEnabled,
   getCLIUseIntegratedRunme,
+  getNotebookExecutionOrder,
 } from '../../src/utils/configuration'
 import { SERVER_PORT } from '../../src/constants'
 import { RunmeIdentity } from '../../src/extension/grpc/serializerTypes'
@@ -140,6 +141,10 @@ suite('Configuration', () => {
 
   test('getCodeLensEnabled should return true by default', () => {
     expect(getCodeLensEnabled()).toStrictEqual(true)
+  })
+
+  test('getNotebookExecutionOrder should return true by default', () => {
+    expect(getNotebookExecutionOrder()).toStrictEqual(true)
   })
 
   test('getCLIUseIntegratedRunme should return false by default', () => {


### PR DESCRIPTION
Will count execution continuously across notebooks per session ID (starting new sessions will become available with Session Outputs currently opt-in). Skips "Configure" and non-cell executions.

<img width="915" alt="Screenshot 2023-12-29 at 3 15 58 PM" src="https://github.com/stateful/vscode-runme/assets/250527/a131d96d-f9cc-4578-85ec-9d5b4c5c709a">