### PR TITLE
Tasks relative display paths

### DIFF
--- a/src/extension/provider/launcher.ts
+++ b/src/extension/provider/launcher.ts
@@ -58,7 +58,7 @@ export class RunmeFile extends TreeItem {
 export class RunmeLauncherProvider implements TreeDataProvider<RunmeFile>, Disposable {
   #disposables: Disposable[] = []
 
-  private _includeUnnamedTasks = false
+  private _includeAllTasks = false
 
   private filesTree: Map<string, TreeFile> = new Map()
   private defaultItemState: TreeItemCollapsibleState = TreeItemCollapsibleState.Collapsed
@@ -71,8 +71,8 @@ export class RunmeLauncherProvider implements TreeDataProvider<RunmeFile>, Dispo
     )
   }
 
-  public get includeUnnamedTasks(): boolean {
-    return this._includeUnnamedTasks
+  public get includeAllTasks(): boolean {
+    return this._includeAllTasks
   }
 
   private _onDidChangeTreeData: EventEmitter<RunmeFile | undefined> = new EventEmitter<
@@ -163,20 +163,20 @@ export class RunmeLauncherProvider implements TreeDataProvider<RunmeFile>, Dispo
   }
 
   async includeUnnamed() {
-    this._includeUnnamedTasks = true
+    this._includeAllTasks = true
     await commands.executeCommand(
       'setContext',
       'runme.launcher.includeUnnamed',
-      this._includeUnnamedTasks,
+      this._includeAllTasks,
     )
   }
 
   async excludeUnnamed() {
-    this._includeUnnamedTasks = false
+    this._includeAllTasks = false
     await commands.executeCommand(
       'setContext',
       'runme.launcher.includeUnnamed',
-      this._includeUnnamedTasks,
+      this._includeAllTasks,
     )
   }
 

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -131,7 +131,7 @@ export class RunmeTaskProvider implements TaskProvider {
       if (outside) {
         // penalty for being outside of base path
         // todo(sebastian): perhaps skip?
-        return 10 * len
+        return 100 * len
       }
       return len
     }

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -22,7 +22,7 @@ import { GrpcTransport } from '@protobuf-ts/grpc-transport'
 import { Observable, of, scan, takeLast, lastValueFrom } from 'rxjs'
 
 import getLogger from '../logger'
-import { getAnnotations, getWorkspaceEnvs } from '../utils'
+import { asWorkspaceRelativePath, getAnnotations, getWorkspaceEnvs } from '../utils'
 import { Serializer, RunmeTaskDefinition } from '../../types'
 import { SerializerBase } from '../serializer'
 import type { IRunner, IRunnerEnvironment, RunProgramOptions } from '../runner'
@@ -126,7 +126,7 @@ export class RunmeTaskProvider implements TaskProvider {
     })
 
     const dirProx = (pt: ProjectTask) => {
-      const { relativePath, outside } = RunmeTaskProvider.asRelativePath(pt.documentPath)
+      const { relativePath, outside } = asWorkspaceRelativePath(pt.documentPath)
       const len = relativePath.split(separator).length
       if (outside) {
         // penalty for being outside of base path
@@ -187,14 +187,6 @@ export class RunmeTaskProvider implements TaskProvider {
     return task
   }
 
-  static asRelativePath(documentPath: string): { relativePath: string; outside: boolean } {
-    const relativePath = workspace.asRelativePath(documentPath)
-    if (relativePath === documentPath) {
-      return { relativePath: path.basename(documentPath), outside: true }
-    }
-    return { relativePath, outside: false }
-  }
-
   static async newRunmeProjectTask(
     projectTask: ProjectTask,
     options: TaskOptions = {},
@@ -204,7 +196,7 @@ export class RunmeTaskProvider implements TaskProvider {
     runnerEnv?: IRunnerEnvironment,
   ): Promise<Task> {
     const { name, documentPath } = projectTask
-    const { relativePath: source } = RunmeTaskProvider.asRelativePath(documentPath)
+    const { relativePath: source } = asWorkspaceRelativePath(documentPath)
 
     const task = new Task(
       { type: 'runme', name, command: name },

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -129,8 +129,6 @@ export class RunmeTaskProvider implements TaskProvider {
       const { relativePath, outside } = asWorkspaceRelativePath(pt.documentPath)
       const len = relativePath.split(separator).length
       if (outside) {
-        // penalty for being outside of base path
-        // todo(sebastian): perhaps skip?
         return 100 * len
       }
       return len
@@ -153,10 +151,16 @@ export class RunmeTaskProvider implements TaskProvider {
 
     const runnerEnv = this.kernel?.getRunnerEnvironment()
     const all = await this.tasks
-    const includeGenerated = this.treeView.includeUnnamedTasks
+    const includeAllTasks = this.treeView.includeAllTasks
 
     try {
-      const filtered = all.filter((prjTask) => prjTask.isNameGenerated === includeGenerated)
+      const filtered = all.filter((prjTask) => {
+        if (includeAllTasks) {
+          return true
+        }
+        const { outside } = asWorkspaceRelativePath(prjTask.documentPath)
+        return !prjTask.isNameGenerated && !outside
+      })
       // show all if there isn't a single named task
       const listed = filtered.length > 0 ? filtered : all
       const runmeTasks = listed.map(

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -584,3 +584,14 @@ export async function handleNotebookAutosaveSettings() {
   ContextState.addKey(NOTEBOOK_AUTOSAVE_ON, autoSaveIsOn)
   await commands.executeCommand('setContext', NOTEBOOK_AUTOSAVE_ON, autoSaveIsOn)
 }
+
+export function asWorkspaceRelativePath(documentPath: string): {
+  relativePath: string
+  outside: boolean
+} {
+  const relativePath = workspace.asRelativePath(documentPath)
+  if (relativePath === documentPath) {
+    return { relativePath: path.basename(documentPath), outside: true }
+  }
+  return { relativePath, outside: false }
+}


### PR DESCRIPTION
The project service will return absolute paths exclusively. However, in the UI we want them to be displayed relative to the workspace root(s) wherever possible. This PR introduces the baseline logic to do exactly that.