### PR TITLE
wdio-vscode-service update to v5.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "unzipper": "^0.10.14",
         "vitest": "^0.34.3",
         "vscode-uri": "^3.0.7",
-        "wdio-vscode-service": "^5.2.1",
+        "wdio-vscode-service": "^5.2.2",
         "webdriverio": "^8.16.5",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4"
@@ -13585,6 +13585,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -20564,9 +20573,9 @@
       }
     },
     "node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
       "dev": true
     },
     "node_modules/wait-on": {
@@ -20703,25 +20712,26 @@
       }
     },
     "node_modules/wdio-vscode-service": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/wdio-vscode-service/-/wdio-vscode-service-5.2.1.tgz",
-      "integrity": "sha512-euDKSEtntuIW2RY9M0aB0or70mDToVjtUEOPwDAz1BFTrmlt9CwcURklRxy2V8RkFM8DnddQCE3oU97fFjzxhw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/wdio-vscode-service/-/wdio-vscode-service-5.2.2.tgz",
+      "integrity": "sha512-FEIVaNZQ9Q/ucHYsUXiA4MhhroNwA7fw62iRWeu503LWYwV7tvBsWjngMuf1SHFywAYaaJcTVofyX9JplhoKrw==",
       "dev": true,
       "dependencies": {
         "@fastify/cors": "^8.3.0",
         "@fastify/static": "^6.10.2",
         "@types/ws": "^8.5.5",
-        "@vscode/test-electron": "^2.3.3",
+        "@vscode/test-electron": "^2.3.4",
         "@wdio/logger": "^8.11.0",
         "clipboardy": "^3.0.0",
         "decamelize": "6.0.0",
         "download": "^8.0.0",
-        "fastify": "^4.19.2",
+        "fastify": "^4.21.0",
         "get-port": "7.0.0",
+        "hpagent": "^1.2.0",
         "slash": "^5.1.0",
         "tmp-promise": "^3.0.3",
-        "undici": "^5.22.1",
-        "vscode-uri": "^3.0.7",
+        "undici": "^5.23.0",
+        "vscode-uri": "^3.0.8",
         "wdio-chromedriver-service": "^8.1.1",
         "ws": "^8.13.0",
         "yargs-parser": "^21.1.1"

--- a/package.json
+++ b/package.json
@@ -934,7 +934,7 @@
     "unzipper": "^0.10.14",
     "vitest": "^0.34.3",
     "vscode-uri": "^3.0.7",
-    "wdio-vscode-service": "^5.2.1",
+    "wdio-vscode-service": "^5.2.2",
     "webdriverio": "^8.16.5",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4"

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -13,7 +13,7 @@
         "expect-webdriverio": "^4.2.7",
         "runme": "^3.0.1",
         "ts-node": "^10.9.1",
-        "wdio-vscode-service": "^5.2.1",
+        "wdio-vscode-service": "^5.2.2",
         "webdriverio": "^8.15.4"
       }
     },
@@ -3977,6 +3977,14 @@
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -7964,9 +7972,9 @@
       }
     },
     "node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
     },
     "node_modules/wait-on": {
       "version": "7.0.1",
@@ -8146,24 +8154,25 @@
       }
     },
     "node_modules/wdio-vscode-service": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/wdio-vscode-service/-/wdio-vscode-service-5.2.1.tgz",
-      "integrity": "sha512-euDKSEtntuIW2RY9M0aB0or70mDToVjtUEOPwDAz1BFTrmlt9CwcURklRxy2V8RkFM8DnddQCE3oU97fFjzxhw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/wdio-vscode-service/-/wdio-vscode-service-5.2.2.tgz",
+      "integrity": "sha512-FEIVaNZQ9Q/ucHYsUXiA4MhhroNwA7fw62iRWeu503LWYwV7tvBsWjngMuf1SHFywAYaaJcTVofyX9JplhoKrw==",
       "dependencies": {
         "@fastify/cors": "^8.3.0",
         "@fastify/static": "^6.10.2",
         "@types/ws": "^8.5.5",
-        "@vscode/test-electron": "^2.3.3",
+        "@vscode/test-electron": "^2.3.4",
         "@wdio/logger": "^8.11.0",
         "clipboardy": "^3.0.0",
         "decamelize": "6.0.0",
         "download": "^8.0.0",
-        "fastify": "^4.19.2",
+        "fastify": "^4.21.0",
         "get-port": "7.0.0",
+        "hpagent": "^1.2.0",
         "slash": "^5.1.0",
         "tmp-promise": "^3.0.3",
-        "undici": "^5.22.1",
-        "vscode-uri": "^3.0.7",
+        "undici": "^5.23.0",
+        "vscode-uri": "^3.0.8",
         "wdio-chromedriver-service": "^8.1.1",
         "ws": "^8.13.0",
         "yargs-parser": "^21.1.1"

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -11,7 +11,7 @@
     "expect-webdriverio": "^4.2.7",
     "runme": "^3.0.1",
     "ts-node": "^10.9.1",
-    "wdio-vscode-service": "^5.2.1",
+    "wdio-vscode-service": "^5.2.2",
     "webdriverio": "^8.15.4"
   }
 }


### PR DESCRIPTION
This PR solves the Dependabot issue related to the **vscode-uri** module.

![image](https://github.com/stateful/vscode-runme/assets/43882/18de5ed8-90fd-4642-92c1-2ec75f0f7eac)


Closes: https://github.com/stateful/vscode-runme/issues/923