### PR TITLE
Update wait-on-check-action

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,7 +27,7 @@ jobs:
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
         if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,6 @@ permissions:
 jobs:
   dependencies:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
 
     steps:
       - name: Fetch PR metadata
@@ -26,7 +25,6 @@ jobs:
       - name: Wait for PR CI
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
-        if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -38,7 +36,6 @@ jobs:
       - name: Auto-merge dependabot PRs
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
-        if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   dependencies:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
 
     steps:
       - name: Fetch PR metadata
@@ -25,7 +26,8 @@ jobs:
       - name: Wait for PR CI
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
-        uses: lewagon/wait-on-check-action@v1.3.1
+        if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
+        uses: lewagon/wait-on-check-action@v1.3.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -36,6 +38,7 @@ jobs:
       - name: Auto-merge dependabot PRs
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
+        if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates `lewagon/wait-on-check-action` to version 1.3.3 which aims to fix our Auto-merge action issue with ruby.

Tested in a private repository with version 1.2.0, I see the same error:

![image](https://github.com/stateful/vscode-runme/assets/28850534/5d6819b7-3098-4553-9fb7-512a29816bdc)

While testing in with version 1.3.3. It doesn't break because of ruby anymore:

![image](https://github.com/stateful/vscode-runme/assets/28850534/4e59d521-73a3-4cc5-8495-27c654a024d4)
