### PR TITLE
Disable coverage for `src/client`

### DIFF
--- a/vitest.conf.ts
+++ b/vitest.conf.ts
@@ -22,6 +22,8 @@ export default defineConfig({
         '**/.wdio-vscode-service/**',
         '**/node_modules/**',
         '**/__generated__/**',
+        // ignore until we bring up coverage
+        'src/client',
         // vendored code
         'src/utils/deno',
         'src/extension/wasm',


### PR DESCRIPTION
Exclude Runme notebook renderers from test coverage until we find time to tackle https://github.com/stateful/vscode-runme/issues/1098.