### PR TITLE
Use setting instead of globalState to disable login prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,11 +223,6 @@
         "title": "Reset Session including Environment Variables",
         "icon": "$(search-refresh)",
         "shortTitle": "Reset Session"
-      },
-      {
-        "command": "runme.resetLoginPrompt",
-        "category": "Runme",
-        "title": "Reset login prompt when asking to Signin with GitHub"
       }
     ],
     "menus": {
@@ -678,6 +673,12 @@
             "scope": "window",
             "default": false,
             "markdownDescription": "If set to `true`, the notebook's outputs are stored inside a full copy of the original file per session."
+          },
+          "runme.app.loginPrompt": {
+            "type": "boolean",
+            "scope": "window",
+            "default": true,
+            "markdownDescription": "If set to `true`, a login prompt will appear anytime Auto-Save is switched on"
           }
         }
       }
@@ -704,7 +705,6 @@
               "markdown": "walkthroughs/1-features.md"
             }
           },
-
           {
             "id": "runme.welcome.learn",
             "title": "Learn more",

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -39,7 +39,7 @@ import IServer from '../server/runmeServer'
 import { NotebookToolbarCommand } from '../../types'
 import getLogger from '../logger'
 import { RecommendExtensionMessage } from '../messaging'
-import { NOTEBOOK_AUTOSAVE_ON, SAVE_CELL_LOGIN_CONSENT_STORAGE_KEY } from '../../constants'
+import { NOTEBOOK_AUTOSAVE_ON } from '../../constants'
 import ContextState from '../contextState'
 
 const log = getLogger('Commands')
@@ -352,13 +352,9 @@ export async function addToRecommendedExtensions(context: ExtensionContext) {
   }).display()
 }
 
-export async function toggleAutosave(context: ExtensionContext, autoSaveIsOn: boolean) {
+export async function toggleAutosave(autoSaveIsOn: boolean) {
   if (autoSaveIsOn) {
-    await promptUserSession(context)
+    await promptUserSession()
   }
   return ContextState.addKey(NOTEBOOK_AUTOSAVE_ON, autoSaveIsOn)
-}
-
-export async function resetLoginPrompt(context: ExtensionContext) {
-  return context.globalState.update(SAVE_CELL_LOGIN_CONSENT_STORAGE_KEY, undefined)
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -50,7 +50,6 @@ import {
   openRunmeSettings,
   toggleAutosave,
   askNewRunnerSession,
-  resetLoginPrompt,
 } from './commands'
 import { WasmSerializer, GrpcSerializer } from './serializer'
 import { RunmeLauncherProvider } from './provider/launcher'
@@ -260,12 +259,8 @@ export class RunmeExtension {
       ),
       createDemoFileRunnerForActiveNotebook(context, kernel),
       createDemoFileRunnerWatcher(context, kernel),
-      RunmeExtension.registerCommand('runme.notebookAutoSaveOn', () =>
-        toggleAutosave(context, false),
-      ),
-      RunmeExtension.registerCommand('runme.notebookAutoSaveOff', () =>
-        toggleAutosave(context, true),
-      ),
+      RunmeExtension.registerCommand('runme.notebookAutoSaveOn', () => toggleAutosave(false)),
+      RunmeExtension.registerCommand('runme.notebookAutoSaveOff', () => toggleAutosave(true)),
       RunmeExtension.registerCommand(
         'runme.notebookSessionOutputs',
         (e: { notebookEditor: { notebookUri: Uri }; ui: boolean }) => {
@@ -279,7 +274,6 @@ export class RunmeExtension {
           commands.executeCommand('markdown.showPreviewToSide', outputFilePath)
         },
       ),
-      RunmeExtension.registerCommand('runme.resetLoginPrompt', () => resetLoginPrompt(context)),
       new CloudAuthProvider(context),
     )
     await bootFile(context)

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -38,12 +38,12 @@ import {
   SERVER_ADDRESS,
   CATEGORY_SEPARATOR,
   NOTEBOOK_AUTOSAVE_ON,
-  SAVE_CELL_LOGIN_CONSENT_STORAGE_KEY,
   CLOUD_USER_SIGNED_IN,
 } from '../constants'
 import {
   getEnvLoadWorkspaceFiles,
   getEnvWorkspaceFileOrder,
+  getLoginPrompt,
   getNotebookAutoSave,
   getPortNumber,
   getTLSDir,
@@ -610,26 +610,23 @@ export function asWorkspaceRelativePath(documentPath: string): {
  * This only happens once. Subsequent saves will not display the prompt.
  * @returns AuthenticationSession
  */
-export async function promptUserSession(
-  context: ExtensionContext,
-): Promise<AuthenticationSession | undefined> {
+export async function promptUserSession(): Promise<AuthenticationSession | undefined> {
   let session = await getAuthSession(false)
-  const displayLoginPrompt = await context.globalState.get(SAVE_CELL_LOGIN_CONSENT_STORAGE_KEY)
+  const displayLoginPrompt = getLoginPrompt()
   if (!session && displayLoginPrompt !== false) {
     const option = await window.showInformationMessage(
       `Securely store your cell output in the Runme Cloud.
       Sign in with GitHub is required, do you want to proceed?`,
       'Yes',
       'No',
-      "Don't ask again",
+      'Open Settings',
     )
     if (!option || option === 'No') {
       return
     }
 
-    if (option === "Don't ask again") {
-      await context.globalState.update(SAVE_CELL_LOGIN_CONSENT_STORAGE_KEY, false)
-      return
+    if (option === 'Open Settings') {
+      return commands.executeCommand('runme.openSettings', 'runme.app.loginPrompt')
     }
 
     session = await getAuthSession(true)

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -84,6 +84,7 @@ const configurationSchema = {
       .enum([NotebookAutoSaveSetting.Yes, NotebookAutoSaveSetting.No])
       .default(NotebookAutoSaveSetting.No),
     sessionOutputs: z.boolean().default(false),
+    loginPrompt: z.boolean().default(true),
   },
 }
 
@@ -372,6 +373,10 @@ const getSessionOutputs = (): boolean => {
   return getCloudConfigurationValue('sessionOutputs', false)
 }
 
+const getLoginPrompt = (): boolean => {
+  return getCloudConfigurationValue('loginPrompt', true)
+}
+
 export {
   getPortNumber,
   getBinaryPath,
@@ -396,4 +401,5 @@ export {
   getForceNewWindowConfig,
   getNotebookAutoSave,
   getSessionOutputs,
+  getLoginPrompt,
 }

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -99,7 +99,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(33)
+  expect(commands.registerCommand).toBeCalledTimes(32)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)


### PR DESCRIPTION
Optionally letting users change the settings here seems a more straightforward way to handle where they don't want to be repeatedly asked to login.