### PR TITLE
fetch APIs are part of core since node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "octokit": "^3.1.0",
         "tangle": "^4.0.0",
         "ulidx": "^2.2.1",
-        "undici": "^6.3.0",
         "uuid": "^9.0.1",
         "vscode-telemetry": "^1.0.2",
         "xterm": "^5.3.0",
@@ -2060,6 +2059,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
       "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -19658,17 +19658,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
-    },
-    "node_modules/undici": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.0.tgz",
-      "integrity": "sha512-p8VvLAgnx6g9pydV0GG/kciSx3ZCq5PLeEU4yefjoZCc1HSeiMxbrFzYIZlgSMrX3l0CoTJ37C6edu13acE40A==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -960,7 +960,6 @@
     "octokit": "^3.1.0",
     "tangle": "^4.0.0",
     "ulidx": "^2.2.1",
-    "undici": "^6.3.0",
     "uuid": "^9.0.1",
     "vscode-telemetry": "^1.0.2",
     "xterm": "^5.3.0",

--- a/src/extension/survey.ts
+++ b/src/extension/survey.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import { mkdirSync, readFileSync, unlinkSync } from 'node:fs'
 
-import { fetch } from 'undici'
 import vscode from 'vscode'
 import {
   Disposable,

--- a/src/utils/deno/api.ts
+++ b/src/utils/deno/api.ts
@@ -1,5 +1,3 @@
-import { fetch, Response } from 'undici'
-
 import { Deployment, ManifestEntry, Project } from './api_types'
 
 export interface RequestOptions {


### PR DESCRIPTION
Removing superfluous dependency now that `undici` is part of core.