### PR TITLE
Runme v3 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KK9VT9C160A2WHEHERY
-  version: v2.2
+  version: v3
 ---
 
 # Change Log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7VQMH8ESX1EFV4QCBTXB1Y
-  version: v2.2
+  version: v3
 ---
 
 # Contributing to `vscode-runme`

--- a/examples/CATEGORIES.md
+++ b/examples/CATEGORIES.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KK745EFJMMTRV4WKYVK
-  version: v2.2
+  version: v3
 sidebar_position: 1
 title: Examples
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KK32HBQ9X4AC2GPMZG5
-  version: v2.2
+  version: v3
 sidebar_position: 1
 title: Examples
 ---

--- a/examples/branchGPT.md
+++ b/examples/branchGPT.md
@@ -1,10 +1,12 @@
 ---
 runme:
   id: 01HF7B0KK19BHGNZ0X1W17ZEYB
-  version: v2.2
+  version: v3
 ---
 
 # Enter BranchGPT
+
+🛑 Please note that BranchGPT is deprecated and no longer available in the `runme` CLI.
 
 [![](https://badgen.net/badge/Run%20this%20/Demo/5B3ADF?icon=https://runme.dev/runme_logo.svg)](https://runme.dev/api/runme?repository=https://github.com/stateful/vscode-runme.git&fileToOpen=examples/branchGPT.md)
 

--- a/examples/enhance/README.md
+++ b/examples/enhance/README.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJZGJFJ7P0G9MAQCSM4
-  version: v2.2
+  version: v3
 ---
 
 # Enhance

--- a/examples/fresh/README.md
+++ b/examples/fresh/README.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJX64XJR1HW3PDMFPZ0
-  version: v2.2
+  version: v3
 ---
 
 # Fresh

--- a/examples/frontmatter/skipPrompts/DISABLED.md
+++ b/examples/frontmatter/skipPrompts/DISABLED.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJWYTVQEAZ3GD0P4E91
-  version: v2.2
+  version: v3
 skipPrompts: false
 ---
 

--- a/examples/frontmatter/skipPrompts/ENABLED.md
+++ b/examples/frontmatter/skipPrompts/ENABLED.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJWYTVQEAZ3GA7C3H8H
-  version: v2.2
+  version: v3
 skipPrompts: true
 ---
 

--- a/examples/hardening/server.md
+++ b/examples/hardening/server.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJV2FA10WJP6RHKEJTE
-  version: v2.2
+  version: v3
 ---
 
 [![](https://badgen.net/badge/Open%20with/Runme/5B3ADF?icon=https://runme.dev/img/logo.svg)](https%3A%2F%2Fgithub.com%2Fstateful%2Fhardening-ubuntu-server%2Fblob%2Fmain%2FREADME.md)

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJS30GAG33WMDGDMN4Z
-  version: v2.2
+  version: v3
 ---
 
 # Deploying a Dockerized React App to Kubernetes Cluster

--- a/examples/redis/query.md
+++ b/examples/redis/query.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HFBZHZ5QQQXP99SE2TD4SC6G
-  version: v2.2
+  version: v3
 ---
 
 # Redis Query Runbook for Runme Cloud

--- a/examples/shebang.md
+++ b/examples/shebang.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJQ8625WYMCRVJADMQF
-  version: v2.2
+  version: v3
 ---
 
 # Runme Language Support

--- a/examples/test.md
+++ b/examples/test.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJM3HHFDVSXA6E12JM3
-  version: v2.2
+  version: v3
 ---
 
 # Runme Examples

--- a/examples/vercel/README.md
+++ b/examples/vercel/README.md
@@ -1,7 +1,7 @@
 ---
 runme:
   id: 01HF7B0KJKPC0FGMY181R7Q7GE
-  version: v2.2
+  version: v3
 ---
 
 # Deploy Next.js with Runme

--- a/package.json
+++ b/package.json
@@ -671,7 +671,7 @@
           "runme.app.sessionOutputs": {
             "type": "boolean",
             "scope": "window",
-            "default": false,
+            "default": true,
             "markdownDescription": "If set to `true`, the notebook's outputs are stored inside a full copy of the original file per session."
           },
           "runme.app.loginPrompt": {

--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -435,19 +435,19 @@ export class Annotations extends LitElement {
         <vscode-panel-view id="view-1">
           <div class="grid">
             <div class="box">${this.renderTextFieldTabEntry('name')}</div>
-            <div class="box">${this.renderCheckboxTabEntry('background')}</div>
+            <div class="box">${this.renderCheckboxTabEntry('promptEnv')}</div>
             <div class="box">${this.renderCheckboxTabEntry('interactive')}</div>
-            <div class="box">${this.renderCheckboxTabEntry('closeTerminalOnSuccess')}</div>
+            <div class="box">${this.renderCheckboxTabEntry('background')}</div>
           </div>
         </vscode-panel-view>
         <vscode-panel-view id="view-2">
           <div class="grid">
-            <div class="box">${this.renderCheckboxTabEntry('excludeFromRunAll')}</div>
-            <div class="box">${this.renderCheckboxTabEntry('promptEnv')}</div>
             <div class="box">${this.renderTextFieldTabEntry('mimeType')}</div>
-            <div class="box">${this.renderCategoryTabEntry('category')}</div>
-            <div class="box">${this.renderTextFieldTabEntry('terminalRows')}</div>
             <div class="box">${this.renderTextFieldTabEntry('interpreter')}</div>
+            <div class="box">${this.renderTextFieldTabEntry('terminalRows')}</div>
+            <div class="box">${this.renderCategoryTabEntry('category')}</div>
+            <div class="box">${this.renderCheckboxTabEntry('closeTerminalOnSuccess')}</div>
+            <div class="box">${this.renderCheckboxTabEntry('excludeFromRunAll')}</div>
           </div>
         </vscode-panel-view>
       </vscode-panels>

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -85,7 +85,7 @@ const configurationSchema = {
     notebookAutoSave: z
       .enum([NotebookAutoSaveSetting.Yes, NotebookAutoSaveSetting.No])
       .default(NotebookAutoSaveSetting.No),
-    sessionOutputs: z.boolean().default(false),
+    sessionOutputs: z.boolean().default(true),
     loginPrompt: z.boolean().default(true),
     platformAuth: z.boolean().default(false),
     idpClientId: z.string().default(''),
@@ -388,7 +388,7 @@ const getNotebookAutoSave = (): NotebookAutoSaveSetting => {
 }
 
 const getSessionOutputs = (): boolean => {
-  return getCloudConfigurationValue('sessionOutputs', false)
+  return getCloudConfigurationValue('sessionOutputs', true)
 }
 
 const getLoginPrompt = (): boolean => {

--- a/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
@@ -63,7 +63,7 @@ describe('Test suite: Cell with existent identity and setting All (1)', async ()
       ---
       runme:
         id: 01HEXJ9KWG7BYSFYCNKSRE4JZR
-        version: v2.2
+        version: v3
       ---
 
       ## Existent ID

--- a/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
@@ -63,7 +63,7 @@ describe('Test suite: Cell with existent identity and setting document only (2)'
       ---
       runme:
         id: 01HEXJ9KWG7BYSFYCNKSRE4JZR
-        version: v2.2
+        version: v3
       ---
 
       ## Existent ID

--- a/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
@@ -64,7 +64,7 @@ describe('Test suite: Document with existent identity and setting All (1)', asyn
         bar: baz
       runme:
         id: 01HEJKW175Z0SYY4SJCA86J0TF
-        version: v2.2
+        version: v3
       ---
 
       ## Document with id

--- a/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
@@ -65,7 +65,7 @@ describe('Test suite: Document with existent identity and setting Document only 
         bar: baz
       runme:
         id: 01HEJKW175Z0SYY4SJCA86J0TF
-        version: v2.2
+        version: v3
       ---
 
       ## Document with id

--- a/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
@@ -62,7 +62,7 @@ describe('Test suite: Shebang with setting All (1)', async () => {
       `---
       runme:
         id: 01HEXJ9KWG7BYSFYCNKSRE4JZR
-        version: v2.2
+        version: v3
       ---
 
       ## Shebang

--- a/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
@@ -62,7 +62,7 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
       `---
       runme:
         id: 01HEXJ9KWG7BYSFYCNKSRE4JZR
-        version: v2.2
+        version: v3
       ---
 
       ## Shebang


### PR DESCRIPTION
1. Make SessionOutputs default `on`, note this will still not write them unless one toggles `Auto-Save (on)`.
2. Reformat markdown files to include new major-only version number.
3. Reshuffle annotation options to bring most important ones onto the `General` tab.