### PR TITLE
Refactor platform API message handling in kernel.ts

### DIFF
--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -38,6 +38,8 @@ const LISTEN_TO_EVENTS = [
   'theme:',
   ClientMessages.cloudApiRequest,
   ClientMessages.cloudApiResponse,
+  ClientMessages.platformApiRequest,
+  ClientMessages.platformApiResponse,
   ClientMessages.onOptionsMessage,
   ClientMessages.optionsMessage,
   ClientMessages.onCopyTextToClipboard,
@@ -448,6 +450,7 @@ export class TerminalView extends LitElement {
             }
             break
           case ClientMessages.cloudApiResponse:
+          case ClientMessages.platformApiResponse:
             {
               if (e.output.id !== this.id) {
                 return

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -95,17 +95,13 @@ export default async function saveCellExecution(
       },
     })
     TelemetryReporter.sendTelemetryEvent('app.save')
-    // TODO(cpda): Preserve consistent messaging format similar to CloudAPI to prevent unnecessary
-    // modifications across components for now.
-    return postClientMessage(messaging, ClientMessages.cloudApiResponse, {
+    return postClientMessage(messaging, ClientMessages.platformApiResponse, {
       data: result,
       id: message.output.id,
     })
   } catch (error) {
     TelemetryReporter.sendTelemetryEvent('app.error')
-    // TODO(cpda): Preserve consistent messaging format similar to CloudAPI to prevent unnecessary
-    // modifications across components for now.
-    return postClientMessage(messaging, ClientMessages.cloudApiResponse, {
+    return postClientMessage(messaging, ClientMessages.platformApiResponse, {
       data: (error as any).message,
       id: message.output.id,
       hasErrors: true,

--- a/src/extension/messages/platformRequest/updateCellExecution.ts
+++ b/src/extension/messages/platformRequest/updateCellExecution.ts
@@ -45,17 +45,13 @@ export default async function updateCellExecution(
       },
     })
     TelemetryReporter.sendTelemetryEvent('app.update')
-    // TODO(cpda): Preserve consistent messaging format similar to CloudAPI to prevent unnecessary
-    // modifications across components for now.
-    return postClientMessage(messaging, ClientMessages.cloudApiResponse, {
+    return postClientMessage(messaging, ClientMessages.platformApiResponse, {
       data: result,
       id: message.output.id,
     })
   } catch (error) {
     TelemetryReporter.sendTelemetryEvent('app.update.error')
-    // TODO(cpda): Preserve consistent messaging format similar to CloudAPI to prevent unnecessary
-    // modifications across components for now.
-    return postClientMessage(messaging, ClientMessages.cloudApiResponse, {
+    return postClientMessage(messaging, ClientMessages.platformApiResponse, {
       data: (error as any).message,
       id: message.output.id,
       hasErrors: true,

--- a/tests/extension/kernel.test.ts
+++ b/tests/extension/kernel.test.ts
@@ -87,7 +87,6 @@ suite('#handleRendererMessage', () => {
   } as any
 
   beforeEach(() => {
-    vi
     vi.mocked(notebooks.createRendererMessaging).mockImplementation((_name: string) => {
       return {
         postMessage: vi.fn(),

--- a/tests/extension/messages/platformApiRequest/saveCellExecution.test.ts
+++ b/tests/extension/messages/platformApiRequest/saveCellExecution.test.ts
@@ -1,0 +1,189 @@
+import { AuthenticationSession, authentication, notebooks } from 'vscode'
+import { suite, vi, it, beforeAll, afterAll, afterEach, expect } from 'vitest'
+import { HttpResponse, graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+import saveCellExecution, {
+  type APIRequestMessage,
+} from '../../../../src/extension/messages/platformRequest/saveCellExecution'
+import { Kernel } from '../../../../src/extension/kernel'
+import { ClientMessages } from '../../../../src/constants'
+import { APIMethod } from '../../../../src/types'
+import { getCellById } from '../../../../src/extension/cell'
+
+vi.mock('vscode-telemetry')
+vi.mock('../../../src/extension/runner', () => ({}))
+vi.mock('../../../src/extension/grpc/runnerTypes', () => ({}))
+
+vi.mock('vscode', async () => {
+  const mocked = (await vi.importActual('../../../../__mocks__/vscode')) as any
+  return {
+    ...mocked,
+    default: {
+      NotebookCellKind: {
+        Markup: 1,
+        Code: 2,
+      },
+    },
+  }
+})
+
+vi.mock('../../../../src/extension/cell', async () => {
+  const actual = await import('../../../../src/extension/cell')
+  return {
+    ...actual,
+    getCellById: vi.fn(),
+  }
+})
+
+const graphqlHandlers = [
+  graphql.mutation('CreateCellExecution', () => {
+    return HttpResponse.json({
+      data: {
+        id: 'cell-id',
+        htmlUrl: 'https://app.runme.dev/cell/gotyou!',
+      },
+    })
+  }),
+]
+
+const server = setupServer(...graphqlHandlers)
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' })
+})
+
+afterAll(() => {
+  server.close()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+suite('Save cell execution', () => {
+  const kernel = new Kernel({} as any)
+  kernel.getTerminal = vi.fn().mockReturnValue({
+    processId: 100,
+    runnerSession: {
+      hasExited: vi.fn(),
+    },
+  })
+
+  it('Should save the output for authenticated user', async () => {
+    const cell: any = {
+      metadata: { name: 'foobar', id: 'cell-id', ['runme.dev/id']: 'cell-id' },
+      document: {
+        uri: { fsPath: '/foo/bar/README.md' },
+        getText: () => 'hello world',
+        languageId: 'sh',
+      },
+      kind: 2,
+    }
+
+    cell.notebook = {
+      getCells: () => [cell],
+      isDirty: false,
+    }
+    vi.mocked(getCellById).mockResolvedValue(cell)
+    const messaging = notebooks.createRendererMessaging('runme-renderer')
+    const authenticationSession: AuthenticationSession = {
+      accessToken: '',
+      id: '',
+      scopes: ['repo'],
+      account: {
+        id: '',
+        label: '',
+      },
+    }
+    const message = {
+      type: ClientMessages.platformApiRequest,
+      output: {
+        id: 'cell-id',
+        method: APIMethod.CreateCellExecution,
+        data: {
+          stdout: 'hello world',
+        },
+      },
+    } as any
+    const requestMessage: APIRequestMessage = {
+      messaging,
+      message,
+      editor: {
+        notebook: {
+          metadata: {
+            ['runme.dev/frontmatterParsed']: { runme: { id: 'ulid' } },
+          },
+        },
+      } as any,
+    }
+    vi.mocked(authentication.getSession).mockResolvedValue(authenticationSession)
+
+    await saveCellExecution(requestMessage, kernel)
+
+    expect(messaging.postMessage).toBeCalledWith({
+      output: {
+        data: {
+          data: {
+            id: 'cell-id',
+            htmlUrl: 'https://app.runme.dev/cell/gotyou!',
+          },
+        },
+        id: 'cell-id',
+      },
+      type: 'common:platformApiResponse',
+    })
+  })
+
+  it('Should not save cell output when user is not authenticated', async () => {
+    const cell: any = {
+      metadata: { name: 'foobar', id: 'cell-id', ['runme.dev/id']: 'cell-id' },
+      document: {
+        uri: { fsPath: '/foo/bar/README.md' },
+        getText: () => 'hello world',
+        languageId: 'sh',
+      },
+      kind: 2,
+    }
+    cell.notebook = {
+      getCells: () => [cell],
+      isDirty: false,
+    }
+    vi.mocked(getCellById).mockResolvedValue(cell)
+    const messaging = notebooks.createRendererMessaging('runme-renderer')
+    const message = {
+      type: ClientMessages.platformApiRequest,
+      output: {
+        id: 'cell-id',
+        method: APIMethod.CreateCellExecution,
+        data: {
+          stdout: 'hello world',
+        },
+      },
+    } as any
+    const requestMessage: APIRequestMessage = {
+      messaging,
+      message,
+      editor: {
+        notebook: {
+          metadata: {
+            ['runme.dev/frontmatterParsed']: { runme: { id: 'ulid' } },
+          },
+        },
+      } as any,
+    }
+    vi.mocked(authentication.getSession).mockResolvedValue(undefined)
+
+    await saveCellExecution(requestMessage, kernel)
+
+    expect(messaging.postMessage).toBeCalledWith({
+      output: {
+        data: {
+          displayShare: false,
+        },
+        id: 'cell-id',
+      },
+      type: 'common:platformApiResponse',
+    })
+  })
+})


### PR DESCRIPTION
- Remapped cloud API requests to platform API requests when platform authentication is enabled.
- Updated the response messages for saving cell executions to use platform API response messages.
- Added tests for platform API request handling and saving cell executions.