### PR TITLE
Named cells UX in notebooks

### DIFF
--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -32,7 +32,6 @@ type Target = {
 
 interface configDetails {
   description: string
-  docs: string
 }
 
 interface DropdownListOption {
@@ -47,47 +46,36 @@ export class Annotations extends LitElement {
   readonly #details: { [id: string]: configDetails } = {
     background: {
       description: 'Run the cell as background process.',
-      docs: 'https://docs.runme.dev/getting-started/vs-code#background-processes',
     },
     interactive: {
       description: 'Run cell inside terminal to allow for interactive input.',
-      docs: 'https://docs.runme.dev/configuration/cell-level#interactive-vs-non-interactive-cells',
     },
     closeTerminalOnSuccess: {
       description: 'Hide terminal after cell successful execution.',
-      docs: 'https://docs.runme.dev/configuration/cell-level#terminal-visibility-post-execution',
     },
     promptEnv: {
       description: 'Prompt user input for exported environment variables.',
-      docs: 'https://docs.runme.dev/configuration/cell-level#set-environment-variables',
     },
     mimeType: {
       description: "Cell's output content MIME type.",
-      docs: 'https://docs.runme.dev/configuration/reference#supported-mime-types',
     },
     name: {
       description: "Cell's canonical name for easy referencing.",
-      docs: 'https://docs.runme.dev/configuration/cell-level#unnamed-vs-named-cells',
     },
     cwd: {
       description: 'Optionally run the cell in different working directory (cwd).',
-      docs: 'https://docs.runme.dev/configuration/cell-level#cells-current-working-directory',
     },
     interpreter: {
       description: 'Inserted into shebang (aka #!) line',
-      docs: 'https://docs.runme.dev/configuration/shebang',
     },
     category: {
       description: 'Execute this code cell within a category. (no comma or spaces allowed)',
-      docs: 'https://docs.runme.dev/configuration/cell-level#run-all-cells-by-category',
     },
     excludeFromRunAll: {
       description: 'Prevent executing this cell during the "Run All" operation.',
-      docs: 'https://docs.runme.dev/configuration/cell-level#exclude-cell-from-run-all',
     },
     terminalRows: {
       description: 'Number of rows to display in the notebook terminal.',
-      docs: 'https://docs.runme.dev/configuration/cell-level#terminal-row',
     },
   }
 
@@ -166,7 +154,7 @@ export class Annotations extends LitElement {
   }
 
   renderCheckbox(id: string, isChecked: boolean, isReadOnly: boolean) {
-    const details = this.#details?.[id] as any
+    const details = this.#details?.[id]
 
     return html`<vscode-checkbox
       id="${id}"
@@ -237,18 +225,16 @@ export class Annotations extends LitElement {
     return html`<p class="error-item current-value-error">Received value: ${value}</p>`
   }
 
-  renderDocsLink(link: string) {
+  renderDocsLink(id: string) {
+    const link = `https://docs.runme.dev/r/extension/${id}`
     return html`<vscode-link href="${link}">(docs ${ExternalLinkIcon})</vscode-link>`
   }
 
   renderCheckboxTabEntry(id: AnnotationsKey) {
     const value = this.annotations?.[id]
-    const details = this.#details?.[id]
 
     return html`<div>
-      <div class="themeText" style="font-weight:600">
-        ${id} ${this.renderDocsLink(details.docs)}
-      </div>
+      <div class="themeText" style="font-weight:600">${id} ${this.renderDocsLink(id)}</div>
       <div style="padding-top:4px">${this.renderCheckbox(id, value as boolean, false)}</div>
     </div> `
   }
@@ -258,9 +244,7 @@ export class Annotations extends LitElement {
     const details = this.#details?.[id]
 
     return html`<div>
-      <div class="themeText" style="font-weight:600">
-        ${id} ${this.renderDocsLink(details.docs)}
-      </div>
+      <div class="themeText" style="font-weight:600">${id} ${this.renderDocsLink(id)}</div>
       <div style="padding-top:4px">
         ${this.renderDropdownList(id, details.description, options, value?.toString())}
       </div>
@@ -270,7 +254,6 @@ export class Annotations extends LitElement {
   renderTextFieldTabEntry(id: AnnotationsKey) {
     let value = this.annotations?.[id]
     let nameGenerated = this.annotations?.['runme.dev/nameGenerated']
-    const details = this.#details?.[id]
 
     const errors: string[] = this.validationErrors?.errors
       ? this.validationErrors.errors[id as keyof CellAnnotations] || []
@@ -286,9 +269,7 @@ export class Annotations extends LitElement {
     }
 
     return html`<div>
-        <div style="font-weight:600" class="themeText">
-          ${id} ${this.renderDocsLink(details.docs)}
-        </div>
+        <div style="font-weight:600" class="themeText">${id} ${this.renderDocsLink(id)}</div>
         <div style="padding-top:4px">${this.renderTextField(id, value as string, placeHolder)}</div>
       </div>
 

--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -69,6 +69,10 @@ export class Annotations extends LitElement {
       description: "Cell's canonical name for easy referencing.",
       docs: 'https://docs.runme.dev/configuration/cell-level#unnamed-vs-named-cells',
     },
+    cwd: {
+      description: 'Optionally run the cell in different working directory (cwd).',
+      docs: 'https://docs.runme.dev/configuration/cell-level#cells-current-working-directory',
+    },
     interpreter: {
       description: 'Inserted into shebang (aka #!) line',
       docs: 'https://docs.runme.dev/configuration/shebang',
@@ -413,17 +417,17 @@ export class Annotations extends LitElement {
                 { text: 'No', value: 'false' },
               ])}
             </div>
+            <div class="box">${this.renderTextFieldTabEntry('cwd')}</div>
             <div class="box">${this.renderCheckboxTabEntry('interactive')}</div>
-            <div class="box">${this.renderCheckboxTabEntry('background')}</div>
           </div>
         </vscode-panel-view>
         <vscode-panel-view id="view-2">
           <div class="grid">
-            <div class="box">${this.renderTextFieldTabEntry('mimeType')}</div>
+            <div class="box">${this.renderCheckboxTabEntry('background')}</div>
             <div class="box">${this.renderTextFieldTabEntry('interpreter')}</div>
+            <div class="box">${this.renderTextFieldTabEntry('mimeType')}</div>
             <div class="box">${this.renderTextFieldTabEntry('terminalRows')}</div>
             <div class="box">${this.renderCategoryTabEntry('category')}</div>
-            <div class="box">${this.renderCheckboxTabEntry('closeTerminalOnSuccess')}</div>
             <div class="box">${this.renderCheckboxTabEntry('excludeFromRunAll')}</div>
           </div>
         </vscode-panel-view>

--- a/src/client/components/configuration/annotations.ts
+++ b/src/client/components/configuration/annotations.ts
@@ -66,7 +66,7 @@ export class Annotations extends LitElement {
       docs: 'https://docs.runme.dev/configuration/reference#supported-mime-types',
     },
     name: {
-      description: "Cell's canonical name for easy referencing in the CLI.",
+      description: "Cell's canonical name for easy referencing.",
       docs: 'https://docs.runme.dev/configuration/cell-level#unnamed-vs-named-cells',
     },
     interpreter: {
@@ -264,7 +264,8 @@ export class Annotations extends LitElement {
   }
 
   renderTextFieldTabEntry(id: AnnotationsKey) {
-    const value = this.annotations?.[id]
+    let value = this.annotations?.[id]
+    let nameGenerated = this.annotations?.['runme.dev/nameGenerated']
     const details = this.#details?.[id]
 
     const errors: string[] = this.validationErrors?.errors
@@ -274,11 +275,17 @@ export class Annotations extends LitElement {
       ? this.validationErrors?.originalAnnotations[id as keyof CellAnnotations]
       : value
 
+    let placeHolder = ''
+    if (id === 'name' && nameGenerated && value === this.annotations?.['runme.dev/name']) {
+      placeHolder = value as string
+      value = ''
+    }
+
     return html`<div>
         <div style="font-weight:600" class="themeText">
           ${id} ${this.renderDocsLink(details.docs)}
         </div>
-        <div style="padding-top:4px">${this.renderTextField(id, value as string)}</div>
+        <div style="padding-top:4px">${this.renderTextField(id, value as string, placeHolder)}</div>
       </div>
 
       ${when(errors.length, () => this.renderErrors(errors))}

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -68,6 +68,7 @@ import Panel from './panels/panel'
 import { createDemoFileRunnerForActiveNotebook, createDemoFileRunnerWatcher } from './handler/utils'
 import { CloudAuthProvider } from './provider/cloudAuth'
 import { StatefulAuthProvider } from './provider/statefulAuth'
+import { NamedProvider } from './provider/named'
 
 export class RunmeExtension {
   async initialize(context: ExtensionContext) {
@@ -205,6 +206,7 @@ export class RunmeExtension {
         Kernel.type,
         new AnnotationsProvider(kernel),
       ),
+      notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new NamedProvider(kernel)),
 
       stopBackgroundTaskProvider,
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -206,7 +206,7 @@ export class RunmeExtension {
         Kernel.type,
         new AnnotationsProvider(kernel),
       ),
-      notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new NamedProvider(kernel)),
+      notebooks.registerNotebookCellStatusBarItemProvider(Kernel.type, new NamedProvider()),
 
       stopBackgroundTaskProvider,
 

--- a/src/extension/provider/named.ts
+++ b/src/extension/provider/named.ts
@@ -1,0 +1,51 @@
+import {
+  NotebookCell,
+  NotebookCellStatusBarItemProvider,
+  NotebookCellStatusBarItem,
+  NotebookCellStatusBarAlignment,
+  NotebookCellKind,
+} from 'vscode'
+
+import { Kernel } from '../kernel'
+import { getAnnotations } from '../utils'
+
+export class NamedProvider implements NotebookCellStatusBarItemProvider {
+  constructor(private readonly kernel: Kernel) {}
+
+  // public async toggleCellAnnotations(cell: NotebookCell): Promise<void> {
+  //   const outputs = await this.kernel.getCellOutputs(cell)
+  //   await outputs.toggleOutput(OutputType.annotations)
+  // }
+
+  async provideCellStatusBarItems(
+    cell: NotebookCell,
+  ): Promise<NotebookCellStatusBarItem | undefined> {
+    if (cell.kind !== NotebookCellKind.Code) {
+      return
+    }
+
+    const annotations = getAnnotations(cell)
+
+    let item: NotebookCellStatusBarItem
+    item = new NotebookCellStatusBarItem(
+      `$(file-symlink-file) ${annotations.name}`,
+      NotebookCellStatusBarAlignment.Left,
+    )
+
+    if (
+      annotations['runme.dev/nameGenerated'] &&
+      annotations.name === annotations['runme.dev/name']
+    ) {
+      item.text = '$(add) Add Name'
+    }
+
+    item.command = {
+      title: 'Configure cell behavior',
+      command: 'runme.toggleCellAnnotations',
+      arguments: [cell],
+    }
+
+    item.tooltip = 'Change name'
+    return item
+  }
+}

--- a/src/extension/provider/named.ts
+++ b/src/extension/provider/named.ts
@@ -6,12 +6,9 @@ import {
   NotebookCellKind,
 } from 'vscode'
 
-import { Kernel } from '../kernel'
 import { getAnnotations } from '../utils'
 
 export class NamedProvider implements NotebookCellStatusBarItemProvider {
-  constructor(private readonly kernel: Kernel) {}
-
   async provideCellStatusBarItems(
     cell: NotebookCell,
   ): Promise<NotebookCellStatusBarItem | undefined> {
@@ -22,18 +19,17 @@ export class NamedProvider implements NotebookCellStatusBarItemProvider {
     const annotations = getAnnotations(cell)
 
     let item: NotebookCellStatusBarItem
-    item = new NotebookCellStatusBarItem(
-      `$(file-symlink-file) ${annotations.name}`,
-      NotebookCellStatusBarAlignment.Left,
-    )
-    item.tooltip = 'Change cell name'
+    const text = '$(add) Add Name'
+    item = new NotebookCellStatusBarItem(text, NotebookCellStatusBarAlignment.Left)
+    item.text = text
+    item.tooltip = 'Add name to important cells'
 
     if (
-      annotations['runme.dev/nameGenerated'] &&
-      annotations.name === annotations['runme.dev/name']
+      annotations['runme.dev/nameGenerated'] !== true ||
+      annotations.name !== annotations['runme.dev/name']
     ) {
-      item.text = '$(add) Add Name'
-      item.tooltip = 'Add name to important cells'
+      item.tooltip = 'Be careful changing the name of an important cell'
+      item.text = `$(file-symlink-file) ${annotations.name}`
     }
 
     item.command = {

--- a/src/extension/provider/named.ts
+++ b/src/extension/provider/named.ts
@@ -12,11 +12,6 @@ import { getAnnotations } from '../utils'
 export class NamedProvider implements NotebookCellStatusBarItemProvider {
   constructor(private readonly kernel: Kernel) {}
 
-  // public async toggleCellAnnotations(cell: NotebookCell): Promise<void> {
-  //   const outputs = await this.kernel.getCellOutputs(cell)
-  //   await outputs.toggleOutput(OutputType.annotations)
-  // }
-
   async provideCellStatusBarItems(
     cell: NotebookCell,
   ): Promise<NotebookCellStatusBarItem | undefined> {
@@ -31,12 +26,14 @@ export class NamedProvider implements NotebookCellStatusBarItemProvider {
       `$(file-symlink-file) ${annotations.name}`,
       NotebookCellStatusBarAlignment.Left,
     )
+    item.tooltip = 'Change cell name'
 
     if (
       annotations['runme.dev/nameGenerated'] &&
       annotations.name === annotations['runme.dev/name']
     ) {
       item.text = '$(add) Add Name'
+      item.tooltip = 'Add name to important cells'
     }
 
     item.command = {
@@ -45,7 +42,6 @@ export class NamedProvider implements NotebookCellStatusBarItemProvider {
       arguments: [cell],
     }
 
-    item.tooltip = 'Change name'
     return item
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -81,7 +81,7 @@ export const AnnotationSchema = {
     }, 'mime type specification invalid format')
     .default('text/plain'),
   interpreter: z.string().optional().default(''),
-  cwd: z.string().nonempty().optional(),
+  cwd: z.string().optional().default(''),
   category: z.string().default(''),
 }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -48,6 +48,8 @@ const boolify = (defaultValue: boolean, invalidTypeError: string = 'expected a b
 
 export const AnnotationSchema = {
   'runme.dev/id': z.string().optional(),
+  'runme.dev/name': z.string().optional(),
+  'runme.dev/nameGenerated': boolify(true).optional(),
   id: z.string().optional(),
   background: boolify(false),
   interactive: boolify(true),

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -97,7 +97,7 @@ test('initializes all providers', async () => {
   }
   const ext = new RunmeExtension()
   await ext.initialize(context)
-  expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(6)
+  expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(7)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
   expect(commands.registerCommand).toBeCalledTimes(32)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)

--- a/tests/extension/provider/named.test.ts
+++ b/tests/extension/provider/named.test.ts
@@ -1,0 +1,56 @@
+import { vi, suite, test, expect, beforeEach } from 'vitest'
+
+import { getAnnotations } from '../../../src/extension/utils'
+import { NamedProvider } from '../../../src/extension/provider/named'
+
+vi.mock('vscode')
+
+vi.mock('../../../src/extension/utils', () => ({
+  getAnnotations: vi.fn(),
+}))
+
+suite('NamedProvider', () => {
+  beforeEach(() => {
+    vi.mocked(getAnnotations).mockClear()
+  })
+
+  test('ignore markdown cells', async () => {
+    const p = new NamedProvider()
+    const item = await p.provideCellStatusBarItems({ kind: 1 } as any)
+    expect(item).toBeUndefined()
+  })
+
+  test('suggest to Add Name if name is generated and unchanged', async () => {
+    vi.mocked(getAnnotations).mockReturnValueOnce({
+      name: 'echo-hello',
+      'runme.dev/name': 'echo-hello',
+      'runme.dev/nameGenerated': true,
+    } as any)
+    const p = new NamedProvider()
+    const item = await p.provideCellStatusBarItems({ kind: 2 } as any)
+    // eslint-disable-next-line quotes
+    expect(item?.text).toMatchInlineSnapshot(`"$(add) Add Name"`)
+    expect(item?.tooltip).toMatchInlineSnapshot(
+      // eslint-disable-next-line quotes
+      `"Add name to important cells"`,
+    )
+    expect(getAnnotations).toBeCalledTimes(1)
+  })
+
+  test('offer changing name if name is not generated', async () => {
+    vi.mocked(getAnnotations).mockReturnValueOnce({
+      name: 'say-hello',
+      'runme.dev/name': 'echo-hello',
+      'runme.dev/nameGenerated': true,
+    } as any)
+    const p = new NamedProvider()
+    const item = await p.provideCellStatusBarItems({ kind: 2 } as any)
+    // eslint-disable-next-line quotes
+    expect(item?.text).toMatchInlineSnapshot(`"$(file-symlink-file) say-hello"`)
+    expect(item?.tooltip).toMatchInlineSnapshot(
+      // eslint-disable-next-line quotes
+      `"Be careful changing the name of an important cell"`,
+    )
+    expect(getAnnotations).toBeCalledTimes(1)
+  })
+})

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -261,6 +261,7 @@ suite('#getAnnotations', () => {
       excludeFromRunAll: false,
       category: '',
       interpreter: '',
+      'runme.dev/name': 'echo-hello',
     })
   })
 })

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -230,6 +230,7 @@ suite('#getAnnotations', () => {
     expect(d).toStrictEqual(<CellAnnotations>{
       background: false,
       closeTerminalOnSuccess: true,
+      cwd: '',
       interactive: true,
       mimeType: 'text/plain',
       name: 'command-123',
@@ -254,6 +255,7 @@ suite('#getAnnotations', () => {
       id: undefined,
       background: false,
       closeTerminalOnSuccess: true,
+      cwd: '',
       interactive: true,
       mimeType: 'text/plain',
       name: 'echo-hello',


### PR DESCRIPTION
Make it more clear that cells can have names: https://docs.runme.dev/configuration/cell-level#unnamed-vs-named-cells

Highlight that named cells are helpful to sift through lots of "cells".

While at it, fix https://github.com/stateful/runme/issues/490 and bring it into foldout.

https://github.com/stateful/vscode-runme/assets/250527/709c0810-22ce-4e80-95e8-d94832c08ae4

