### PR TITLE
Restores functionality for Stateful IDP support on localhost

### DIFF
--- a/src/extension/provider/statefulAuth.ts
+++ b/src/extension/provider/statefulAuth.ts
@@ -96,6 +96,10 @@ export class StatefulAuthProvider implements AuthenticationProvider, Disposable 
     return callbackUrl
   }
 
+  get callbackPageUri() {
+    return `${getRunmeAppUrl(['app'])}ide-callback`
+  }
+
   /**
    * Get the existing sessions
    * @param scopes
@@ -273,7 +277,7 @@ export class StatefulAuthProvider implements AuthenticationProvider, Disposable 
         const searchParams = new URLSearchParams([
           ['response_type', 'code'],
           ['client_id', idpClientId],
-          ['redirect_uri', `${getRunmeAppUrl()}ide-callback`],
+          ['redirect_uri', this.callbackPageUri],
           ['state', encodeURIComponent(callbackUri.toString(true))],
           ['scope', scopes.join(' ')],
           ['prompt', 'login'],
@@ -367,7 +371,7 @@ export class StatefulAuthProvider implements AuthenticationProvider, Disposable 
         client_id: idpClientId,
         code,
         code_verifier: codeVerifier,
-        redirect_uri: `${getRunmeAppUrl()}ide-callback`,
+        redirect_uri: this.callbackPageUri,
       }).toString()
 
       const response = await fetch(`https://${idpDomain}/oauth/token`, {

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -27,8 +27,6 @@ const APP_LOOPBACKS = ['127.0.0.1', 'localhost']
 const APP_LOOPBACK_MAPPING = new Map<string, string>([
   ['api.', ':4000'],
   ['app.', ':4001'],
-  ['api.platform.', ':8911'],
-  ['platform.', ':8910'],
 ])
 
 type NotebookTerminalValue = keyof typeof notebookTerminalSchema
@@ -320,18 +318,9 @@ const getRemoteDev = (baseDomain: string): boolean => {
   return localDev.map((uri) => baseDomain.startsWith(uri)).reduce((p, c) => p || c)
 }
 
-const getRunmeAppUrl = (forSubdomains: string[] = []): string => {
-  let subdomains = forSubdomains
-  if (isPlatformAuthEnabled()) {
-    subdomains = forSubdomains.map((s) => {
-      if (s === 'app') {
-        return ''
-      }
-      return s
-    })
-  }
-
+const getRunmeAppUrl = (subdomains: string[]): string => {
   let base = getRunmeBaseDomain()
+
   const isRemoteDev = getRemoteDev(base)
   if (isRemoteDev) {
     if (subdomains.length === 1 && subdomains?.[0] === 'app') {
@@ -340,8 +329,17 @@ const getRunmeAppUrl = (forSubdomains: string[] = []): string => {
       base = DEFAULT_RUNME_REMOTE_DEV
     }
   }
-
   const isLoopback = APP_LOOPBACKS.map((host) => base.includes(host)).reduce((p, c) => p || c)
+
+  if (!isLoopback && isPlatformAuthEnabled()) {
+    subdomains = subdomains.map((s) => {
+      if (s === 'app') {
+        return ''
+      }
+      return s
+    })
+  }
+
   const scheme = isLoopback ? 'http' : 'https'
 
   let sub = subdomains.join('.')


### PR DESCRIPTION
These adjustments guarantee the correct operation of Stateful IDP on localhost. They involve the removal of mappings associated with specific subdomains linked to previous platform FQDNs.