### PR TITLE
Send VS Code theme kind

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -100,6 +100,9 @@ export const window = {
   withProgress: vi.fn(),
   onDidChangeActiveColorTheme: vi.fn().mockReturnValue({ dispose: vi.fn() }),
   showInputBox: vi.fn(),
+  activeColorTheme: {
+    kind: 1,
+  },
 }
 
 export const tasks = {

--- a/src/extension/panels/panel.ts
+++ b/src/extension/panels/panel.ts
@@ -5,6 +5,7 @@ import {
   WebviewView,
   WebviewViewProvider,
   window,
+  ColorThemeKind,
 } from 'vscode'
 import { TelemetryViewProvider } from 'vscode-telemetry'
 import { Subject } from 'rxjs'
@@ -22,6 +23,7 @@ export interface InitPayload {
   panelId: string
   appToken: string | null
   defaultUx: DefaultUx
+  themeKind: ColorThemeKind
 }
 
 class PanelBase extends TelemetryViewProvider implements Disposable {
@@ -98,6 +100,7 @@ export default class Panel extends PanelBase implements WebviewViewProvider {
       panelId: this.identifier,
       appToken: appToken ?? 'EMPTY',
       defaultUx: this.defaultUx,
+      themeKind: window.activeColorTheme.kind,
     })
   }
 

--- a/tests/extension/panels/panel.test.ts
+++ b/tests/extension/panels/panel.test.ts
@@ -55,15 +55,16 @@ suite('Panel', () => {
       ide: 'code',
       panelId: 'main',
       defaultUx: 'panels',
+      themeKind: 1,
     })
 
     expect(hydrated).toContain('<base href="https://app.runme.dev/">')
     expect(hydrated).toContain(
-      '{"appToken":"a.b.c","ide":"code","panelId":"main","defaultUx":"panels"}',
+      '{"appToken":"a.b.c","ide":"code","panelId":"main","defaultUx":"panels","themeKind":1}',
     )
   })
 
-  test('resovles authed', async () => {
+  test('resolves authed', async () => {
     const p = new Panel(contextMock, 'testing')
     p.getAppToken = vi.fn().mockResolvedValue({ token: 'webview.auth.token' })
 
@@ -71,11 +72,11 @@ suite('Panel', () => {
 
     expect(view.webview.html).toContain('<base href="https://app.runme.dev/">')
     expect(view.webview.html).toContain(
-      '{"ide":"code","panelId":"testing","appToken":"webview.auth.token","defaultUx":"panels"}',
+      '{"ide":"code","panelId":"testing","appToken":"webview.auth.token","defaultUx":"panels","themeKind":1}',
     )
   })
 
-  test('resovles unauthed', async () => {
+  test('resolves unauthed', async () => {
     const p = new Panel(contextMock, 'testing')
     p.getAppToken = vi.fn().mockResolvedValue(null)
 
@@ -83,11 +84,11 @@ suite('Panel', () => {
 
     expect(view.webview.html).toContain('<base href="https://app.runme.dev/">')
     expect(view.webview.html).toContain(
-      '{"ide":"code","panelId":"testing","appToken":"EMPTY","defaultUx":"panels"}',
+      '{"ide":"code","panelId":"testing","appToken":"EMPTY","defaultUx":"panels","themeKind":1}',
     )
   })
 
-  test('resovles authed localhost', async () => {
+  test('resolves authed localhost', async () => {
     workspace.getConfiguration().update('baseDomain', 'localhost')
     const p = new Panel(contextMock, 'testing')
     p.getAppToken = vi.fn().mockResolvedValue({ token: 'webview.auth.token' })
@@ -96,11 +97,11 @@ suite('Panel', () => {
 
     expect(view.webview.html).toContain('<base href="http://localhost:4001/">')
     expect(view.webview.html).toContain(
-      '{"ide":"code","panelId":"testing","appToken":"webview.auth.token","defaultUx":"panels"}',
+      '{"ide":"code","panelId":"testing","appToken":"webview.auth.token","defaultUx":"panels","themeKind":1}',
     )
   })
 
-  test('resovles unauthed localhost', async () => {
+  test('resolves unauthed localhost', async () => {
     workspace.getConfiguration().update('baseDomain', 'localhost')
     const p = new Panel(contextMock, 'testing')
     p.getAppToken = vi.fn().mockResolvedValue(null)
@@ -109,7 +110,7 @@ suite('Panel', () => {
 
     expect(view.webview.html).toContain('<base href="http://localhost:4001/">')
     expect(view.webview.html).toContain(
-      '{"ide":"code","panelId":"testing","appToken":"EMPTY","defaultUx":"panels"}',
+      '{"ide":"code","panelId":"testing","appToken":"EMPTY","defaultUx":"panels","themeKind":1}',
     )
   })
 })


### PR DESCRIPTION
Send VS Code `themeKind` as a field during the hydratation of the panels webview app. 