### PR TITLE
Remove throw if there is not a Stateful session

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -550,7 +550,7 @@ export async function resolveAppToken(createIfNone: boolean = true) {
   if (isPlatformAuthEnabled()) {
     const session = await getPlatformAuthSession(createIfNone)
     if (!session) {
-      throw new Error('You must authenticate with your Stateful account')
+      return null
     }
     return { token: session.accessToken }
   }


### PR DESCRIPTION
Remove the error throw if there is no a Stateful session. This way the "EMPTY" string will be sent as a token to the webview panels app, so it can handle unauthenticated users.