### PR TITLE
Refactor Stateful IDP to use Platform endpoints

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -4,8 +4,11 @@ import { join } from 'node:path'
 
 import { vi } from 'vitest'
 import { URI } from 'vscode-uri'
-import type { Command, Disposable } from 'vscode'
+import { Command, Disposable as DisposableOriginal } from 'vscode'
 
+export const Disposable = {
+  from: vi.fn()
+}
 
 export const notebooks = {
   createNotebookController: vi.fn().mockReturnValue({
@@ -214,7 +217,7 @@ export const ProgressLocation = {
 }
 
 type MessageCallback<T> = (message: T) => void
-type Event<T> = (listener: MessageCallback<T>) => Disposable
+type Event<T> = (listener: MessageCallback<T>) => DisposableOriginal
 
 export class EventEmitter<T> {
   listeners: MessageCallback<T>[] = []
@@ -291,7 +294,8 @@ export const ShellExecution = vi.fn()
 export const Task = vi.fn()
 export const authentication = {
   getSession: vi.fn(),
-  onDidChangeSessions: vi.fn()
+  onDidChangeSessions: vi.fn(),
+  registerAuthenticationProvider: vi.fn()
 }
 
 export class WorkspaceEdit {

--- a/package.json
+++ b/package.json
@@ -692,24 +692,6 @@
             "scope": "window",
             "default": false,
             "markdownDescription": "If set to `true` enables Stateful Authentication Provider"
-          },
-          "runme.app.idpClientId": {
-            "type": "string",
-            "scope": "window",
-            "default": "",
-            "markdownDescription": "Stateful Identity Client Id"
-          },
-          "runme.app.idpDomain": {
-            "type": "string",
-            "scope": "window",
-            "default": "",
-            "markdownDescription": "Stateful Identity Domain"
-          },
-          "runme.app.idpAudience": {
-            "type": "string",
-            "scope": "window",
-            "default": "",
-            "markdownDescription": "Stateful Identity Audicence"
           }
         }
       }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -86,9 +86,6 @@ const configurationSchema = {
     sessionOutputs: z.boolean().default(true),
     loginPrompt: z.boolean().default(true),
     platformAuth: z.boolean().default(false),
-    idpClientId: z.string().default(''),
-    idpDomain: z.string().default(''),
-    idpAudience: z.string().default(''),
   },
 }
 
@@ -394,13 +391,6 @@ const getLoginPrompt = (): boolean => {
 const isPlatformAuthEnabled = (): boolean => {
   return getCloudConfigurationValue('platformAuth', false)
 }
-const getIdpConfig = () => {
-  return {
-    idpClientId: getCloudConfigurationValue('idpClientId', ''),
-    idpDomain: getCloudConfigurationValue('idpDomain', ''),
-    idpAudience: getCloudConfigurationValue('idpAudience', ''),
-  }
-}
 
 export {
   enableServerLogs,
@@ -428,5 +418,4 @@ export {
   registerExtensionEnvironmentVariables,
   getSessionOutputs,
   getLoginPrompt,
-  getIdpConfig,
 }

--- a/tests/extension/provider/statefulAuth.test.ts
+++ b/tests/extension/provider/statefulAuth.test.ts
@@ -1,0 +1,32 @@
+import { expect, vi, beforeEach, describe, it } from 'vitest'
+import { Uri, ExtensionContext } from 'vscode'
+
+import { StatefulAuthProvider } from '../../../src/extension/provider/statefulAuth'
+import { RunmeUriHandler } from '../../../src/extension/handler/uri'
+
+vi.mock('vscode')
+vi.mock('vscode-telemetry')
+
+describe('StatefulAuthProvider', () => {
+  let provider: StatefulAuthProvider
+
+  beforeEach(() => {
+    const contextMock: ExtensionContext = {
+      extensionUri: Uri.parse('file:///Users/fakeUser/projects/vscode-runme'),
+    } as any
+
+    const uriHandler: RunmeUriHandler = {} as any
+
+    provider = new StatefulAuthProvider(contextMock, uriHandler)
+  })
+
+  it('gets sessions', async () => {
+    const sessions = await provider.getSessions()
+    expect(sessions).toEqual([])
+  })
+
+  it('gets sessions with specific scopes', async () => {
+    const sessions = await provider.getSessions(['profile'])
+    expect(sessions).toEqual([])
+  })
+})


### PR DESCRIPTION
Refactor the Stateful Identity Provider to remove the settings from the extension and delegate it to the API.

Things to do in the next iterations:

- Enhance the security between the extension and the Platform API,TLS Auth maybe...
- Increase the test coverage