### PR TITLE
Add more telemetry when adding runme to recommended extensions

### DIFF
--- a/src/extension/messaging.ts
+++ b/src/extension/messaging.ts
@@ -123,9 +123,11 @@ export class RecommendExtensionMessage extends DisplayableMessage implements Dis
       })
     } catch (error) {
       window.showErrorMessage('Failed to add Runme to the recommended extensions')
+      console.error('[command:runme.recommendExtension]', error)
       TelemetryReporter.sendTelemetryEvent(TELEMETRY_EVENTS.RecommendExtension, {
         added: 'false',
         error: 'true',
+        message: (error as any).message,
       })
     }
   }


### PR DESCRIPTION
Logging the error so we can troubleshoot when adding Runme to recommended extensions fails.

<img width="1507" alt="Screenshot 2024-02-29 at 9 47 27 AM" src="https://github.com/stateful/vscode-runme/assets/4001529/4a1c7e7e-963e-4e88-b1c8-da74185611b6">

