### PR TITLE
Avoid back pressure

### DIFF
--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -22,7 +22,6 @@ import {
   of,
   from,
   map,
-  takeLast,
   firstValueFrom,
   lastValueFrom,
   isObservable,
@@ -89,7 +88,7 @@ export class RunmeTaskProvider implements TaskProvider {
       })
     })
 
-    this.tasks = lastValueFrom(this.loadProjectTasks().pipe(takeLast(1)))
+    this.tasks = lastValueFrom(this.loadProjectTasks())
   }
 
   private async initProjectClient(transport?: GrpcTransport) {

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -21,12 +21,12 @@ import {
   Observable,
   of,
   from,
-  scan,
   map,
   takeLast,
   firstValueFrom,
   lastValueFrom,
   isObservable,
+  toArray,
 } from 'rxjs'
 
 import getLogger from '../logger'
@@ -150,11 +150,8 @@ export class RunmeTaskProvider implements TaskProvider {
     }
 
     return task$.pipe(
-      scan((acc, one) => {
-        acc.push(one)
-        acc.sort((a, b) => dirProx(a) - dirProx(b))
-        return acc
-      }, new Array<ProjectTask>()),
+      toArray(),
+      map((tasks) => tasks.sort((a, b) => dirProx(a) - dirProx(b))),
     )
   }
 


### PR DESCRIPTION
Grab all emissions as a single array, then sort. As opposed to sorting every time a new emission shows up.

This fixes a significant slowdown in the extension host for repos with lots of markdown files.