### PR TITLE
Infra -> DevOps naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "runme",
   "version": "3.2.2",
   "publisher": "stateful",
-  "displayName": "Runme Infra Notebooks",
+  "displayName": "Runme DevOps Notebooks",
   "description": "Execute your runbooks, docs, and READMEs.",
   "author": "Sebastian Tiedtke <sebastian@stateful.com>",
   "contributors": [

--- a/walkthroughs/0-intro.md
+++ b/walkthroughs/0-intro.md
@@ -21,7 +21,7 @@ Follow these simple steps to set Runme Notebook as your default viewer:
 
 ![for-md](https://github.com/stateful/vscode-runme/assets/36479528/04ef7714-c01e-476b-810c-f31e4b9383ea)
 
-- Lastly, select “Runme Infra Notebooks” as your default markdown viewer.
+- Lastly, select “Runme DevOps Notebooks” as your default markdown viewer.
 
 With these simple steps, you would not have to manually choose Runme Notebook every time you want to view a markdown file; it becomes the automatic and permanent default markdown view.
 


### PR DESCRIPTION
Call them devops notebooks instead of infra to communicate broad utility