### PR TITLE
Keep auto-save user selection across notebooks

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -650,8 +650,13 @@ export function suggestCategories(categories: string[], title: string, placehold
 
 export async function handleNotebookAutosaveSettings() {
   const configAutoSaveSetting = getNotebookAutoSave()
-  const autoSaveIsOn = configAutoSaveSetting === NotebookAutoSaveSetting.Yes ? true : false
-  await ContextState.addKey(NOTEBOOK_AUTOSAVE_ON, autoSaveIsOn)
+  const extensionSettingAutoSaveIsOn =
+    configAutoSaveSetting === NotebookAutoSaveSetting.Yes ? true : false
+  const notebookAutoSaveIsOn = ContextState.getKey(NOTEBOOK_AUTOSAVE_ON)
+  await ContextState.addKey(
+    NOTEBOOK_AUTOSAVE_ON,
+    notebookAutoSaveIsOn !== undefined ? notebookAutoSaveIsOn : extensionSettingAutoSaveIsOn,
+  )
 }
 
 export async function resetNotebookAutosaveSettings() {


### PR DESCRIPTION
Introducing a fix to respect user selection when using auto-save feature.
Currently it uses the extension default when opening a Notebook, overwriting the user selection.

This PR fixes https://github.com/stateful/vscode-runme/issues/1235