### PR TITLE
Don't write cell IDs when turned off

### DIFF
--- a/examples/identity/existent-cell-id.md
+++ b/examples/identity/existent-cell-id.md
@@ -5,5 +5,5 @@ Example file used as part of the end to end suite
 ## Scenario
 
 ```js { id=01HER3GA0RQKJETKK5X5PPRTB4 }
-console.log("Hello from JS")
+console.log("Hello via Shebang")
 ```

--- a/examples/identity/existent-doc-id.md
+++ b/examples/identity/existent-doc-id.md
@@ -12,5 +12,5 @@ Example file used as part of the end to end suite
 ## Scenario
 
 ```js { name=foo }
-console.log("Always bet on JS!")
+console.log("Run scripts via Shebang!")
 ```

--- a/examples/identity/shebang.md
+++ b/examples/identity/shebang.md
@@ -5,6 +5,6 @@ Example file used as part of the end to end suite
 ## Scenario
 
 ```js { name=foo }
-console.log("Always bet on JS!")
+console.log("Run scripts via Shebang!")
 
 ```

--- a/examples/shebang.md
+++ b/examples/shebang.md
@@ -35,7 +35,7 @@ puts "Reversed words: #{sentence.reverse_words}"
 ## or JavaScript:
 
 ```js {"id":"01HF7B0KJQ8625WYMCRNP9C0RE"}
-console.log("Always bet on JS!")
+console.log("Run scripts via Shebang!")
 ```
 
 ## even TypeScript:

--- a/src/extension/panels/notebook.ts
+++ b/src/extension/panels/notebook.ts
@@ -99,7 +99,6 @@ export class NotebookPanel extends TanglePanel {
   }
 
   private updateWebview(vars: SnapshotEnv[]) {
-    // console.log('updating webview', this.#webviewView, this.#webviewView?.webview)
     this.#webviewView!.webview.html = this.getHtml(
       this.#webviewView!.webview,
       this.context.extensionUri,

--- a/src/extension/panels/notebook.ts
+++ b/src/extension/panels/notebook.ts
@@ -99,7 +99,7 @@ export class NotebookPanel extends TanglePanel {
   }
 
   private updateWebview(vars: SnapshotEnv[]) {
-    console.log('updating webview', this.#webviewView, this.#webviewView?.webview)
+    // console.log('updating webview', this.#webviewView, this.#webviewView?.webview)
     this.#webviewView!.webview.html = this.getHtml(
       this.#webviewView!.webview,
       this.context.extensionUri,

--- a/tests/e2e/specs/identity/identity.empty-file.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.none.e2e.ts
@@ -48,7 +48,7 @@ describe('Test suite: Empty file with setting None (0)', async () => {
     await updateLifecycleIdentitySetting(0)
     await reloadWindow()
     await saveFile(browser)
-    await assertDocumentContainsSpinner(absDocPath, '')
+    await assertDocumentContainsSpinner(absDocPath, '', true)
   })
 
   after(() => {

--- a/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Cell with existent identity and setting All (1)', async ()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Hello from JS")')
+    const cell = await notebook.getCell('console.log("Hello via Shebang")')
     await cell.focus()
     await saveFile(browser)
 
@@ -72,7 +72,7 @@ describe('Test suite: Cell with existent identity and setting All (1)', async ()
       ## Scenario
 
       \`\`\`js {"id":"01HER3GA0RQKJETKK5X5PPRTB4"}
-      console.log("Hello from JS")
+      console.log("Hello via Shebang")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.existent-cell.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.cell.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Cell with existent identity and setting cell only (3)', as
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Hello from JS")')
+    const cell = await notebook.getCell('console.log("Hello via Shebang")')
     await cell.focus()
     await saveFile(browser)
 
@@ -66,7 +66,7 @@ describe('Test suite: Cell with existent identity and setting cell only (3)', as
       ## Scenario
 
       \`\`\`js {"id":"01HER3GA0RQKJETKK5X5PPRTB4"}
-      console.log("Hello from JS")
+      console.log("Hello via Shebang")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
@@ -71,9 +71,8 @@ describe('Test suite: Cell with existent identity and setting document only (2)'
 
       ## Scenario
 
-      \`\`\`js {"id":"01HER3GA0RQKJETKK5X5PPRTB4"}
+      \`\`\`js
       console.log("Hello from JS")
-
       \`\`\`
 
       `,

--- a/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Cell with existent identity and setting document only (2)'
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Hello from JS")')
+    const cell = await notebook.getCell('console.log("Hello via Shebang")')
     await cell.focus()
     await saveFile(browser)
 
@@ -72,7 +72,7 @@ describe('Test suite: Cell with existent identity and setting document only (2)'
       ## Scenario
 
       \`\`\`js
-      console.log("Hello from JS")
+      console.log("Hello via Shebang")
       \`\`\`
 
       `,

--- a/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
@@ -71,6 +71,7 @@ describe('Test suite: Cell with existent identity and setting None (0)', async (
       \`\`\`
 
       `,
+      true,
     )
   })
 

--- a/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
@@ -65,7 +65,7 @@ describe('Test suite: Cell with existent identity and setting None (0)', async (
 
       ## Scenario
 
-      \`\`\`js {"id":"01HER3GA0RQKJETKK5X5PPRTB4"}
+      \`\`\`js
       console.log("Hello via Shebang")
 
       \`\`\`

--- a/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Cell with existent identity and setting None (0)', async (
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Hello from JS")')
+    const cell = await notebook.getCell('console.log("Hello via Shebang")')
     await cell.focus()
     await saveFile(browser)
 
@@ -66,7 +66,7 @@ describe('Test suite: Cell with existent identity and setting None (0)', async (
       ## Scenario
 
       \`\`\`js {"id":"01HER3GA0RQKJETKK5X5PPRTB4"}
-      console.log("Hello from JS")
+      console.log("Hello via Shebang")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Document with existent identity and setting All (1)', asyn
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Always bet on JS!")')
+    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -74,7 +74,7 @@ describe('Test suite: Document with existent identity and setting All (1)', asyn
       ## Scenario
 
       \`\`\`js {"id":"01HFA08N6F66WSG09RR9XEP0T6","name":"foo"}
-      console.log("Always bet on JS!")
+      console.log("Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.existent-doc.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.cell.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Document with existent identity and setting Cell only (3)'
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Always bet on JS!")')
+    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -73,7 +73,7 @@ describe('Test suite: Document with existent identity and setting Cell only (3)'
       ## Scenario
 
       \`\`\`js {"name":"foo"}
-      console.log("Always bet on JS!")
+      console.log("Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
@@ -54,7 +54,7 @@ describe('Test suite: Document with existent identity and setting Document only 
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Always bet on JS!")')
+    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -75,7 +75,7 @@ describe('Test suite: Document with existent identity and setting Document only 
       ## Scenario
 
       \`\`\`js {"name":"foo"}
-      console.log("Always bet on JS!")
+      console.log("Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Document with existent identity and setting None (0)', asy
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Always bet on JS!")')
+    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -73,7 +73,7 @@ describe('Test suite: Document with existent identity and setting None (0)', asy
       ## Scenario
 
       \`\`\`js {"name":"foo"}
-      console.log("Always bet on JS!")
+      console.log("Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
@@ -79,6 +79,7 @@ describe('Test suite: Document with existent identity and setting None (0)', asy
 
 
       `,
+      true,
     )
   })
 

--- a/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting All (1)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Always bet on JS!")')
+    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -71,7 +71,7 @@ describe('Test suite: Shebang with setting All (1)', async () => {
       ## Scenario
 
       \`\`\`js { name=foo id=01HEXJ9KWG7BYSFYCNKVF0VWR6 }
-      console.log("Always bet on JS!")
+      console.log("Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting Cell only (3)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Always bet on JS!")')
+    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -66,7 +66,7 @@ describe('Test suite: Shebang with setting Cell only (3)', async () => {
       ## Scenario
 
       \`\`\`js { name=foo id=01HEXJ9KWG7BYSFYCNKVF0VWR6 }
-      console.log("Always bet on JS!")
+      console.log("Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Always bet on JS!")')
+    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -71,7 +71,7 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
       ## Scenario
 
       \`\`\`js {"name":"foo"}
-      console.log("Always bet on JS!")
+      console.log("Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
@@ -52,7 +52,7 @@ describe('Test suite: Shebang with setting None (0)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Always bet on JS!")')
+    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -65,7 +65,7 @@ describe('Test suite: Shebang with setting None (0)', async () => {
       ## Scenario
 
       \`\`\`js {"name":"foo"}
-      console.log("Always bet on JS!")
+      console.log("Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
@@ -70,6 +70,7 @@ describe('Test suite: Shebang with setting None (0)', async () => {
       \`\`\`
 
       `,
+      true,
     )
   })
 


### PR DESCRIPTION
The integration tests were to lenient to catch this bug (intro'd with refactor) since they only check for lifecycle identity presence.

Fixes #1251.