### PR TITLE
Polish AWS and GCP renderers

### DIFF
--- a/src/client/components/aws/ec2InstanceActions.ts
+++ b/src/client/components/aws/ec2InstanceActions.ts
@@ -95,8 +95,10 @@ export class AWSInstanceActions extends LitElement implements Disposable {
     switch (action) {
       case AWSActionType.ConnectViaSSH:
         title = `Do you want to connect via SSH to ${this.instance.name}`
+        break
       case AWSActionType.EC2InstanceDetails:
         title = `Do you want to display the instance details for ${this.instance.name}?`
+        break
     }
     return postClientMessage(ctx, ClientMessages.optionsMessage, {
       title,

--- a/src/client/components/aws/index.ts
+++ b/src/client/components/aws/index.ts
@@ -40,7 +40,8 @@ export class AWSViews extends LitElement {
       case AWSSupportedView.EC2InstanceDetails:
         return html`<ec2-instance-details
           .cellId="${this.state.cellId}"
-          .instance="${this.state.instance}"
+          .instance="${this.state.instanceDetails!.instance || {}}"
+          owner="${this.state.instanceDetails!.owner || '-'}"
           .region="${this.state.region}"
         ></ec2-instance-details>`
     }

--- a/src/client/components/gcp/gke/cluster.ts
+++ b/src/client/components/gcp/gke/cluster.ts
@@ -48,12 +48,12 @@ export class Clusters extends LitElement implements Disposable {
   static styles = css`
     vscode-button {
       color: var(--vscode-button-foreground);
-      background-color: var(--vscode-button-secondaryBackground);
+      background-color: var(--vscode-button-background);
       transform: scale(0.9);
     }
 
     vscode-button:hover {
-      background: var(--vscode-list-hoverBackground);
+      background: var(--vscode-button-secondaryHoverBackground);
     }
 
     table {
@@ -115,9 +115,9 @@ export class Clusters extends LitElement implements Disposable {
     }
 
     .active-tab {
-      color: var(--vscode-tab-activeBorderTop);
+      color: var(--vscode-textLink-activeForeground);
       fill: currentcolor;
-      border-bottom: solid 1px var(--vscode-tab-activeBorderTop);
+      border-bottom: solid 2px var(--vscode-activityBarTop-activeBorder);
     }
 
     .cluster-view {

--- a/src/extension/executors/aws.ts
+++ b/src/extension/executors/aws.ts
@@ -33,7 +33,7 @@ export const aws: IKernelExecutor = async (executor) => {
       }
 
       case AWSSupportedView.EC2InstanceDetails: {
-        const instance = await getEC2InstanceDetail(
+        const instanceDetails = await getEC2InstanceDetail(
           awsResolver.data.region,
           awsResolver.data.instanceId!,
         )
@@ -43,7 +43,7 @@ export const aws: IKernelExecutor = async (executor) => {
             cellId: exec.cell.metadata['runme.dev/id'],
             view: awsResolver.view,
             region: awsResolver.data.region,
-            instance,
+            instanceDetails,
           },
         })
         await outputs.showOutput(OutputType.aws)

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,13 @@ import {
 } from 'vscode'
 import { z } from 'zod'
 import { Bus } from 'tangle'
-import { InstanceStateName, MonitoringState, _InstanceType } from '@aws-sdk/client-ec2'
+import {
+  GroupIdentifier,
+  InstanceLifecycleType,
+  InstanceStateName,
+  MonitoringState,
+  _InstanceType,
+} from '@aws-sdk/client-ec2'
 
 import { OutputType, ClientMessages } from './constants'
 import { SafeCellAnnotationsSchema, SafeNotebookAnnotationsSchema } from './schema'
@@ -234,6 +240,13 @@ export interface AWSEC2Instance extends StringIndexable {
   keyName: string | undefined
   launchTime: Date | undefined
   platform: string | undefined
+  securityGroups?: GroupIdentifier[]
+  lifecycle: InstanceLifecycleType | undefined
+}
+
+export interface AWSEC2InstanceDetails {
+  instance: AWSEC2Instance | undefined
+  owner: string | undefined
 }
 
 export interface AWSEC2InstanceState {
@@ -244,7 +257,7 @@ export interface AWSEC2InstanceState {
 }
 
 export interface AWSEC2InstanceDetailsState {
-  instance: AWSEC2Instance | undefined
+  instanceDetails: AWSEC2InstanceDetails | undefined
   cellId: string
   region: string
   view: AWSSupportedView.EC2InstanceDetails


### PR DESCRIPTION
Add more consistency to cloud renderers, ensure information is accurate and all actions provide links to the original cloud resource when not available directly in the renderer.

This PR also polishes the styles and add more consistency with the current VS Code theme used by the user.

Some screenshots:
The AWS EC2 renderer now include better details:

<img width="1102" alt="Screenshot 2024-04-05 at 12 33 39 AM" src="https://github.com/stateful/vscode-runme/assets/4001529/45517429-b145-4219-ae83-be489ea41d6c">

The GCP styles has been polished:
<img width="1097" alt="Screenshot 2024-04-05 at 12 34 30 AM" src="https://github.com/stateful/vscode-runme/assets/4001529/2176cfcb-7214-492e-b005-7aaf73a48c77">
