### PR TITLE
Only require cell lifecycle identity by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -608,7 +608,7 @@
           "runme.server.lifecycleIdentity": {
             "type": "number",
             "scope": "window",
-            "default": 1,
+            "default": 3,
             "enum": [
               0,
               1,

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -60,7 +60,7 @@ const configurationSchema = {
     enableTLS: z.boolean().default(true),
     tlsDir: z.string().optional(),
     transportType: z.enum(['TCP', 'UDS']).default('TCP'),
-    lifecycleIdentity: z.nativeEnum(RunmeIdentity).default(RunmeIdentity.ALL),
+    lifecycleIdentity: z.nativeEnum(RunmeIdentity).default(RunmeIdentity.CELL),
   },
   codelens: {
     enable: z.boolean().default(true),

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -138,7 +138,7 @@ suite('Configuration', () => {
   test('getServerConfigurationValue should give default persist identity', () => {
     expect(
       getServerConfigurationValue<number>('lifecycleIdentity', RunmeIdentity.UNSPECIFIED),
-    ).toStrictEqual(RunmeIdentity.ALL)
+    ).toStrictEqual(RunmeIdentity.CELL)
   })
 
   test('getCodeLensEnabled should return true by default', () => {


### PR DESCRIPTION
The group of users who require this is much smaller than what makes sense for default now.