### PR TITLE
Optionally new line when pasting from editor codelens

### DIFF
--- a/src/extension/provider/codelens.ts
+++ b/src/extension/provider/codelens.ts
@@ -26,7 +26,7 @@ import { IRunner } from '../runner'
 import { Kernel } from '../kernel'
 import { getAnnotations } from '../utils'
 import { Serializer } from '../../types'
-import { getCodeLensEnabled } from '../../utils/configuration'
+import { getCodeLensEnabled, getCodeLensPasteIntoTerminalNewline } from '../../utils/configuration'
 import { RunmeExtension } from '../extension'
 import type { SurveyWinCodeLensRun } from '../survey'
 import IServer from '../server/runmeServer'
@@ -238,7 +238,7 @@ export class RunmeCodeLensProvider implements CodeLensProvider, Disposable {
           }
 
           activeTerminal.show(false)
-          activeTerminal.sendText(value, false)
+          activeTerminal.sendText(value, getCodeLensPasteIntoTerminalNewline())
         }
         break
     }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -64,6 +64,7 @@ const configurationSchema = {
   },
   codelens: {
     enable: z.boolean().default(true),
+    pasteNewline: z.boolean().default(false),
   },
   notebook: {
     executionOrder: z.boolean().default(true),
@@ -277,6 +278,10 @@ const getCodeLensEnabled = (): boolean => {
   return getCodeLensConfigurationValue<boolean>('enable', true)
 }
 
+const getCodeLensPasteIntoTerminalNewline = (): boolean => {
+  return getCodeLensConfigurationValue<boolean>('pasteNewline', false)
+}
+
 const getNotebookExecutionOrder = (): boolean => {
   return getNotebookConfigurationValue<boolean>('executionOrder', true)
 }
@@ -407,6 +412,7 @@ export {
   getBinaryPath,
   getCLIUseIntegratedRunme,
   getCodeLensEnabled,
+  getCodeLensPasteIntoTerminalNewline,
   getNotebookExecutionOrder,
   getCustomServerAddress,
   getEnvLoadWorkspaceFiles,

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -13,6 +13,7 @@ import {
   getTLSDir,
   getNotebookTerminalConfigurations,
   getCodeLensEnabled,
+  getCodeLensPasteIntoTerminalNewline,
   getCLIUseIntegratedRunme,
   getNotebookExecutionOrder,
 } from '../../src/utils/configuration'
@@ -143,6 +144,10 @@ suite('Configuration', () => {
 
   test('getCodeLensEnabled should return true by default', () => {
     expect(getCodeLensEnabled()).toStrictEqual(true)
+  })
+
+  test('getCodeLensPasteIntoTerminalNewline should return false by default', () => {
+    expect(getCodeLensPasteIntoTerminalNewline()).toStrictEqual(false)
   })
 
   test('getNotebookExecutionOrder should return true by default', () => {


### PR DESCRIPTION
Optionally add a new line when pasting from editor codelens into terminal.

This will skip an implicit "confirmation step" and run pasted command directly.