### PR TITLE
Updates NODE_OPTIONS to avoid deployment issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         run: npm run build:prod
         env:
           NODE_ENV: production
-          NODE_OPTIONS: --max-old-space-size=8192
+          NODE_OPTIONS: "--max-old-space-size=8192 --experimental-specifier-resolution=node"
           INSTRUMENTATION_KEY: ${{ secrets.INSTRUMENTATION_KEY }}
         if: ${{ github.event.inputs.releaseChannel == 'edge' }}
 
@@ -77,7 +77,7 @@ jobs:
         run: npm run build:prod
         env:
           NODE_ENV: production
-          NODE_OPTIONS: --max-old-space-size=8192
+          NODE_OPTIONS: "--max-old-space-size=8192 --experimental-specifier-resolution=node"
           INSTRUMENTATION_KEY: ${{ secrets.INSTRUMENTATION_KEY }}
         if: ${{ github.event.inputs.releaseChannel == 'stable' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           run: npx runme run configureNPM setup build test:ci
         env:
+          NODE_OPTIONS: "--max-old-space-size=8192 --experimental-specifier-resolution=node"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNME_TEST_TOKEN: ${{ secrets.RUNME_TEST_TOKEN }}
           RUNME_PROJECT: ${{ github.workspace }}


### PR DESCRIPTION
When the **NODE_OPTIONS** is already set in the GitHub actions file **runme** omits prompting, and it's resolved from the GitHub Action workflow.