### PR TITLE
Fix: Preserve identity IDs when IDT is disabled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,8 @@ cat .vscode/extensions.json | grep -v '\/\/' | jq -r ".recommendations[]" | xarg
 
 Then just run the watcher and you're off to the races.
 
-```sh {"background":"true","id":"01HF7VQMH8ESX1EFV4PD922S8P","name":"npm-watch"}
+```sh {"background":"true","id":"01HF7VQMH8ESX1EFV4PD922S8P","name":"npm-watch","promptEnv":"no"}
+export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"
 npm run watch
 ```
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -355,8 +355,8 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
     }
 
     data.cells.forEach((cell) => {
-      if (identity === RunmeIdentity.UNSPECIFIED && cell.metadata?.['runme.dev/stageId']) {
-        cell.metadata['id'] = cell.metadata['runme.dev/stageId']
+      if (identity === RunmeIdentity.UNSPECIFIED && cell.metadata?.['runme.dev/originalId']) {
+        cell.metadata['id'] = cell.metadata['runme.dev/originalId']
         return
       }
 
@@ -609,7 +609,7 @@ export class GrpcSerializer extends SerializerBase {
             return
           }
           if (cell.metadata?.['id']) {
-            cell.metadata['runme.dev/stageId'] = cell.metadata['id']
+            cell.metadata['runme.dev/originalId'] = cell.metadata['id']
           }
         })
         break

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -90,9 +90,9 @@ async function assertDocumentContains(absDocPath: string, matcher: string, exact
   const source = await fs.readFile(absDocPath, 'utf-8')
   const savedContent = sanitizeOutput(source.toString()).split('\n')
   const matcherParts = sanitizeOutput(matcher).split('\n')
-  const maxLength = Math.min(matcherParts.length, savedContent.length)
+  const maxContentLines = Math.min(matcherParts.length, savedContent.length)
 
-  for (let index = 0; index < maxLength; index++) {
+  for (let index = 0; index < maxContentLines; index++) {
     if (exact) {
       await expect(savedContent[index].trim()).toMatch(matcherParts[index].trim())
     }

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -90,8 +90,9 @@ async function assertDocumentContains(absDocPath: string, matcher: string, exact
   const source = await fs.readFile(absDocPath, 'utf-8')
   const savedContent = sanitizeOutput(source.toString()).split('\n')
   const matcherParts = sanitizeOutput(matcher).split('\n')
+  const maxLength = Math.min(matcherParts.length, savedContent.length)
 
-  for (let index = 0; index < savedContent.length; index++) {
+  for (let index = 0; index < maxLength; index++) {
     if (exact) {
       await expect(savedContent[index].trim()).toMatch(matcherParts[index].trim())
     }

--- a/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting All (1)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
+    const cell = await notebook.getCell('console.log("Scenario 1: Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -68,10 +68,10 @@ describe('Test suite: Shebang with setting All (1)', async () => {
       ## Shebang
       Example file used as part of the end to end suite
 
-      ## Scenario
+      ## Scenario 1
 
-      \`\`\`js { name=foo id=01HEXJ9KWG7BYSFYCNKVF0VWR6 }
-      console.log("Run scripts via Shebang!")
+      \`\`\`js {"id":"01HEXJ9KWG7BYSFYCNKVF0VWR6","name":"foo"}
+      console.log("Scenario 1: Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting Cell only (3)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
+    const cell = await notebook.getCell('console.log("Scenario 1: Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -63,10 +63,10 @@ describe('Test suite: Shebang with setting Cell only (3)', async () => {
       ## Shebang
       Example file used as part of the end to end suite
 
-      ## Scenario
+      ## Scenario 1
 
-      \`\`\`js { name=foo id=01HEXJ9KWG7BYSFYCNKVF0VWR6 }
-      console.log("Run scripts via Shebang!")
+      \`\`\`js {"name":"foo","id":"01HEXJ9KWG7BYSFYCNKVF0VWR6"}
+      console.log("Scenario 1: Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
+    const cell = await notebook.getCell('console.log("Scenario 1: Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -68,10 +68,10 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
       ## Shebang
       Example file used as part of the end to end suite
 
-      ## Scenario
+      ## Scenario 1
 
       \`\`\`js {"name":"foo"}
-      console.log("Run scripts via Shebang!")
+      console.log("Scenario 1: Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
@@ -52,7 +52,7 @@ describe('Test suite: Shebang with setting None (0)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
+    const cell = await notebook.getCell('console.log("Scenario 1: Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -62,13 +62,26 @@ describe('Test suite: Shebang with setting None (0)', async () => {
       ## Shebang
       Example file used as part of the end to end suite
 
-      ## Scenario
+      ## Scenario 1
 
       \`\`\`js {"name":"foo"}
-      console.log("Run scripts via Shebang!")
+      console.log("Scenario 1: Run scripts via Shebang!")
 
       \`\`\`
 
+      ## Scenario 2
+
+      \`\`\`js {"id":"01HY444G8B44DF0DSGVRQ299QV"}
+      console.log("Scenario 2: Run scripts via Shebang!")
+
+      \`\`\`
+
+      ## Scenario 3
+
+      \`\`\`js
+      console.log("Scenario 3: Run scripts via Shebang!")
+
+      \`\`\`
       `,
       true,
     )

--- a/tests/fixtures/identity/shebang.md
+++ b/tests/fixtures/identity/shebang.md
@@ -2,9 +2,23 @@
 
 Example file used as part of the end to end suite
 
-## Scenario
+## Scenario 1
 
-```js { name=foo }
-console.log("Run scripts via Shebang!")
+```js {"name":"foo"}
+console.log("Scenario 1: Run scripts via Shebang!")
+
+```
+
+## Scenario 2
+
+```js {"id":"01HY444G8B44DF0DSGVRQ299QV"}
+console.log("Scenario 2: Run scripts via Shebang!")
+
+```
+
+## Scenario 3
+
+```js
+console.log("Scenario 3: Run scripts via Shebang!")
 
 ```


### PR DESCRIPTION
The issue is that when IDT is turned off, identity IDs need to remain unchanged, even if they are included in a notebook.

This includes:

- **runme.dev/stageId**: This is a new metadata field used to transfer the IDT during serialize/deserialize requests only when **RunmeIdentity** is **UNSPECIFIED**.

- Updates to **assertDocumentContains** to only match a portion of the document.

- Test updates

Closes: #1354