### PR TITLE
Add a warning to avoid conflicts across Stateful extensions

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,4 +1,4 @@
-import { extensions, type ExtensionContext } from 'vscode'
+import { window, extensions, type ExtensionContext, env, Uri } from 'vscode'
 import { TelemetryReporter } from 'vscode-telemetry'
 
 import { RunmeExtension } from './extension'
@@ -16,6 +16,16 @@ export async function activate(context: ExtensionContext) {
 
   if (extensionIdentifier === 'stateful.runme' && pfound) {
     log.warn('Skipping extension activation to avoid conflicts')
+    const message =
+      'For optimal performance, we recommend using only one Stateful extension at a time. ' +
+      'Consider uninstalling Stateful Runme to continue using Stateful Platform.'
+
+    const actionText = 'Go to Stateful Runme'
+    const response = await window.showWarningMessage(message, actionText)
+    if (response === actionText) {
+      await env.openExternal(Uri.parse('vscode:extension/stateful.runme'))
+    }
+
     return
   }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -17,10 +17,10 @@ export async function activate(context: ExtensionContext) {
   if (extensionIdentifier === 'stateful.runme' && pfound) {
     log.warn('Skipping extension activation to avoid conflicts')
     const message =
-      'For optimal performance, we recommend using only one Stateful extension at a time. ' +
-      'Consider uninstalling Stateful Runme to continue using Stateful Platform.'
+      "The Stateful extension is a superset of Runme. Both extension can't be enabled at the same time." +
+      'Please deactivate Runme and restart VS Code to avoid conflicts.'
 
-    const actionText = 'Go to Stateful Runme'
+    const actionText = 'Open Runme Extension'
     const response = await window.showWarningMessage(message, actionText)
     if (response === actionText) {
       await env.openExternal(Uri.parse('vscode:extension/stateful.runme'))


### PR DESCRIPTION
Stateful Platform is a Superset of the Runme extension, so it is necessary to add a warning to avoid strange behaviour. 