### PR TITLE
Make RUNME terminal ENV vars transient between restarts/reloads

### DIFF
--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -295,6 +295,7 @@ const registerExtensionEnvVarsMutation = (
   context: ExtensionContext,
   envs: Record<string, string>,
 ): void => {
+  context.environmentVariableCollection.persistent = false
   const binaryBasePath =
     path.dirname(getBinaryPath(context.extensionUri).fsPath) + (isWindows() ? ';' : ':')
   context.environmentVariableCollection.prepend('PATH', binaryBasePath)


### PR DESCRIPTION
Fixes this issue where the kernel server is no longer running on an obsolete port.

```
could not execute command: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp [::1]:7888: connect: connection refused"
```

Documented here: https://github.com/stateful/runme/issues/587#issuecomment-2130344799