### PR TITLE
Add an experiments flag to enable ai logging in the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -539,6 +539,12 @@
             "scope": "window",
             "markdownDescription": "Relative path to a file within the workspace to open within a Runme notebook view, when VS Code starts (e.g. `./CONTRIBUTING.md`)."
           },
+          "runme.experiments.aiLogs": {
+            "type": "boolean",
+            "scope": "window",
+            "default": false,
+            "markdownDescription": "If set to `true`, enable logging server logs used for training AIs."
+          },
           "runme.experiments.escalationButton": {
             "type": "boolean",
             "scope": "window",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -84,11 +84,14 @@ export class RunmeExtension {
     const grpcSerializer = kernel.hasExperimentEnabled('grpcSerializer')
     const grpcServer = kernel.hasExperimentEnabled('grpcServer')
     const grpcRunner = kernel.hasExperimentEnabled('grpcRunner')
+    const aiLogs = kernel.hasExperimentEnabled('aiLogs')
+
     const server = new RunmeServer(
       context.extensionUri,
       {
         retryOnFailure: true,
         maxNumberOfIntents: 10,
+        aiLogs: aiLogs,
       },
       !grpcServer,
       grpcRunner,

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -136,6 +136,7 @@ export class Kernel implements Disposable {
     this.#experiments.set('grpcServer', config.get<boolean>('grpcServer', true))
     this.#experiments.set('escalationButton', config.get<boolean>('escalationButton', false))
     this.#experiments.set('smartEnvStore', config.get<boolean>('smartEnvStore', false))
+    this.#experiments.set('aiLogs', config.get<boolean>('aiLogs', false))
 
     this.cellManager = new NotebookCellManager(this.#controller)
     this.#controller.supportsExecutionOrder = getNotebookExecutionOrder()

--- a/src/extension/server/runmeServer.ts
+++ b/src/extension/server/runmeServer.ts
@@ -33,6 +33,7 @@ export interface IServerConfig {
     intents: number
     interval: number
   }
+  aiLogs?: boolean
 }
 
 const log = getLogger('RunmeServer')
@@ -64,6 +65,7 @@ class RunmeServer implements IServer {
   #transport?: GrpcTransport
   #serverDisposables: Disposable[] = []
   #forceExternalServer: boolean
+  #aiLogs: boolean
 
   readonly #onClose = this.register(new EventEmitter<{ code: number | null }>())
   readonly #onTransportReady = this.register(
@@ -94,6 +96,7 @@ class RunmeServer implements IServer {
     this.#acceptsIntents = options.acceptsConnection?.intents || 50
     this.#acceptsInterval = options.acceptsConnection?.interval || 200
     this.#forceExternalServer = externalServer
+    this.#aiLogs = options.aiLogs || false
   }
 
   dispose() {
@@ -230,6 +233,11 @@ class RunmeServer implements IServer {
 
     if (this.enableRunner) {
       args.push('--runner')
+    }
+
+    if (this.#aiLogs) {
+      log.info('AI logs enabled')
+      args.push('--ai-logs=true')
     }
 
     if (getTLSEnabled()) {


### PR DESCRIPTION
* In order to train an AI on feedback we need the server to log executions
* The server added a flag "--ai-logs=true" to enable logging.
* This PR adds an experiments flag to the vscode extension to enable that option.

Related to #574