### PR TITLE
Disable "Preview Gist" when session outputs are off

### DIFF
--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -373,6 +373,9 @@ export class TerminalView extends LitElement {
   @property({ type: Boolean })
   isAutoSaveEnabled: boolean = false
 
+  @property({ type: Boolean })
+  isSessionOutputsEnabled: boolean = false
+
   constructor() {
     super()
     this.windowSize = {
@@ -833,7 +836,13 @@ export class TerminalView extends LitElement {
             return this.#copy()
           }}"
         ></copy-button>
-        <gist-cell @onGist="${this.#openSessionOutput}"></gist-cell>
+        ${when(
+          this.isSessionOutputsEnabled,
+          () => {
+            return html`<gist-cell @onGist="${this.#openSessionOutput}"></gist-cell>`
+          },
+          () => {},
+        )}
         ${when(
           this.enableShareButton,
           () => {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -117,6 +117,13 @@ export const activate: ActivationFunction = (context: RendererContext<void>) => 
             )
           }
 
+          if (payload.output.isSessionOutputsEnabled) {
+            terminalElement.setAttribute(
+              'isSessionOutputsEnabled',
+              payload.output.isSessionOutputsEnabled.toString(),
+            )
+          }
+
           element.appendChild(terminalElement)
           break
 

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -33,6 +33,7 @@ import {
 import { Mutex } from '../utils/sync'
 import {
   getNotebookTerminalConfigurations,
+  getSessionOutputs,
   isPlatformAuthEnabled,
   isRunmeAppButtonsEnabled,
 } from '../utils/configuration'
@@ -221,6 +222,8 @@ export class NotebookCellOutputManager {
               ? ContextState.getKey(PLATFORM_USER_SIGNED_IN)
               : ContextState.getKey(CLOUD_USER_SIGNED_IN)
 
+            const isSessionOutputsEnabled = getSessionOutputs()
+
             const json: CellOutputPayload<OutputType.terminal> = {
               type: OutputType.terminal,
               output: {
@@ -229,6 +232,7 @@ export class NotebookCellOutputManager {
                 initialRows: terminalRows || terminalConfigurations.rows,
                 enableShareButton: isRunmeAppButtonsEnabled(),
                 isAutoSaveEnabled: isSignedIn ? ContextState.getKey(NOTEBOOK_AUTOSAVE_ON) : false,
+                isSessionOutputsEnabled,
                 ...terminalConfigurations,
               },
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,7 @@ interface Payload {
     initialRows?: number
     enableShareButton: boolean
     isAutoSaveEnabled: boolean
+    isSessionOutputsEnabled: boolean
   }
   [OutputType.github]?: GitHubState
   [OutputType.stdout]: object


### PR DESCRIPTION
Right now, the "Preview Gist" button appears even when session outputs are disabled, so to avoid confusion, this PR disables the button when the session outputs setting is off.

Closes: #1374 