### PR TITLE
Fix Foyle language id on cells

### DIFF
--- a/src/extension/ai/generate.ts
+++ b/src/extension/ai/generate.ts
@@ -93,6 +93,7 @@ function addAIGeneratedCells(index: number, response: GenerateCellsResponse): vs
       value: cell.value,
       metadata: cell.metadata,
       kind: kind,
+      languageId: cell.languageId,
       // TODO(jeremy): Should we include outputs? The generate response should never contain outputs so we shouldn't
       // have to worry about them.
     }


### PR DESCRIPTION
* See jlewi/foyle#125 the language id isn't being set on cells inserted from Foyle
* As a result the language gets set to `text` and they aren't runnable.