### PR TITLE
Open Stateful site from panels.

### DIFF
--- a/src/extension/panels/cloud.ts
+++ b/src/extension/panels/cloud.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, WebviewView, window, ColorThemeKind } from 'vscode'
+import { ExtensionContext, WebviewView, window, ColorThemeKind, Uri, env } from 'vscode'
 
 import { fetchStaticHtml, resolveAppToken } from '../utils'
 import { IAppToken } from '../services/runme'
@@ -131,6 +131,12 @@ export default class CloudPanel extends TanglePanel {
         } catch (error) {
           await window.showErrorMessage(`Failed to restore cell: ${(error as any).message}`)
         }
+      }),
+      bus.on('onSiteOpen', async (cmdEvent) => {
+        if (!cmdEvent?.url) {
+          return
+        }
+        env.openExternal(Uri.parse(cmdEvent?.url))
       }),
     ]
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,9 @@ export interface SyncSchema {
   onCellUnArchived?: {
     cellId: string
   }
+  onSiteOpen?: {
+    url: string
+  }
 }
 
 export type SyncSchemaBus = Bus<SyncSchema>


### PR DESCRIPTION
Handle a new `onSiteOpen` event that the Cloud Panel app sends when a button should open Platform's site.