### PR TITLE
Only show Escalate button if Slack is ready

### DIFF
--- a/src/extension/__generated-platform__/gql.ts
+++ b/src/extension/__generated-platform__/gql.ts
@@ -14,8 +14,8 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  */
 const documents = {
     "mutation ArchiveCellExecution($archiveCellExecutionId: String!) {\n  archiveCellExecution(id: $archiveCellExecutionId) {\n    id\n  }\n}": types.ArchiveCellExecutionDocument,
-    "mutation CreateCellExecution($input: CreateCellExecutionInput!) {\n  createCellExecution(input: $input) {\n    id\n    htmlUrl\n    exitCode\n  }\n}": types.CreateCellExecutionDocument,
-    "mutation UpdateCellExecution($id: String!, $input: UpdateCellExecutionInput!) {\n  updateCellExecution(id: $id, input: $input) {\n    id\n    htmlUrl\n    exitCode\n  }\n}": types.UpdateCellExecutionDocument,
+    "mutation CreateCellExecution($input: CreateCellExecutionInput!) {\n  createCellExecution(input: $input) {\n    id\n    htmlUrl\n    exitCode\n    isSlackReady\n  }\n}": types.CreateCellExecutionDocument,
+    "mutation UpdateCellExecution($id: String!, $input: UpdateCellExecutionInput!) {\n  updateCellExecution(id: $id, input: $input) {\n    id\n    htmlUrl\n    exitCode\n    isSlackReady\n  }\n}": types.UpdateCellExecutionDocument,
 };
 
 /**
@@ -39,11 +39,11 @@ export function graphql(source: "mutation ArchiveCellExecution($archiveCellExecu
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "mutation CreateCellExecution($input: CreateCellExecutionInput!) {\n  createCellExecution(input: $input) {\n    id\n    htmlUrl\n    exitCode\n  }\n}"): (typeof documents)["mutation CreateCellExecution($input: CreateCellExecutionInput!) {\n  createCellExecution(input: $input) {\n    id\n    htmlUrl\n    exitCode\n  }\n}"];
+export function graphql(source: "mutation CreateCellExecution($input: CreateCellExecutionInput!) {\n  createCellExecution(input: $input) {\n    id\n    htmlUrl\n    exitCode\n    isSlackReady\n  }\n}"): (typeof documents)["mutation CreateCellExecution($input: CreateCellExecutionInput!) {\n  createCellExecution(input: $input) {\n    id\n    htmlUrl\n    exitCode\n    isSlackReady\n  }\n}"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "mutation UpdateCellExecution($id: String!, $input: UpdateCellExecutionInput!) {\n  updateCellExecution(id: $id, input: $input) {\n    id\n    htmlUrl\n    exitCode\n  }\n}"): (typeof documents)["mutation UpdateCellExecution($id: String!, $input: UpdateCellExecutionInput!) {\n  updateCellExecution(id: $id, input: $input) {\n    id\n    htmlUrl\n    exitCode\n  }\n}"];
+export function graphql(source: "mutation UpdateCellExecution($id: String!, $input: UpdateCellExecutionInput!) {\n  updateCellExecution(id: $id, input: $input) {\n    id\n    htmlUrl\n    exitCode\n    isSlackReady\n  }\n}"): (typeof documents)["mutation UpdateCellExecution($id: String!, $input: UpdateCellExecutionInput!) {\n  updateCellExecution(id: $id, input: $input) {\n    id\n    htmlUrl\n    exitCode\n    isSlackReady\n  }\n}"];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/src/extension/__generated-platform__/graphql.ts
+++ b/src/extension/__generated-platform__/graphql.ts
@@ -31,6 +31,27 @@ export type Scalars = {
   Time: { input: any; output: any; }
 };
 
+export type AccessRequest = {
+  __typename?: 'AccessRequest';
+  cellOutput?: Maybe<CellOutput>;
+  createTime: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  organization?: Maybe<Organization>;
+  organizationId: Scalars['String']['output'];
+  referenceId: Scalars['String']['output'];
+  referenceTable: Scalars['String']['output'];
+  requestedBy?: Maybe<User>;
+  requestedById?: Maybe<Scalars['String']['output']>;
+  status: AccessRequestStatus;
+  updateTime: Scalars['DateTime']['output'];
+};
+
+export enum AccessRequestStatus {
+  Accepted = 'ACCEPTED',
+  Pending = 'PENDING',
+  Rejected = 'REJECTED'
+}
+
 export type AddUserToOrganizationInput = {
   id: Scalars['String']['input'];
   userId: Scalars['String']['input'];
@@ -52,11 +73,41 @@ export type AssistantSearchArgs = {
   input: SearchInput;
 };
 
+export type Cell = {
+  __typename?: 'Cell';
+  cellAttachments: Array<Maybe<CellAttachment>>;
+  cellOutputs: Array<Maybe<CellOutput>>;
+  id: Scalars['String']['output'];
+  mainCellOutput?: Maybe<CellOutput>;
+  notebook: Notebook;
+  notebookId: Scalars['String']['output'];
+  notebookSession?: Maybe<NotebookSession>;
+  notebookSessionId?: Maybe<Scalars['String']['output']>;
+  organization?: Maybe<Organization>;
+  organizationId?: Maybe<Scalars['String']['output']>;
+  totalOutputs?: Maybe<Scalars['Int']['output']>;
+  user: User;
+  userId: Scalars['String']['output'];
+};
+
+export type CellAttachment = {
+  __typename?: 'CellAttachment';
+  cell: Cell;
+  cellId: Scalars['String']['output'];
+  createTime: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  organization?: Maybe<Organization>;
+  organizationId?: Maybe<Scalars['String']['output']>;
+  size: Scalars['Int']['output'];
+  type: Scalars['String']['output'];
+  updateTime: Scalars['DateTime']['output'];
+};
+
 export type CellExecution = {
   __typename?: 'CellExecution';
   archivedTime?: Maybe<Scalars['DateTime']['output']>;
   autoSave: Scalars['Boolean']['output'];
-  cellExecutionShares?: Maybe<Array<Maybe<CellExecutionShare>>>;
   createTime: Scalars['DateTime']['output'];
   exitCode: Scalars['Int']['output'];
   history?: Maybe<Array<Maybe<CellExecution>>>;
@@ -65,6 +116,7 @@ export type CellExecution = {
   input?: Maybe<Scalars['String']['output']>;
   inputData?: Maybe<Scalars['Bytes']['output']>;
   isOwner?: Maybe<Scalars['Boolean']['output']>;
+  isSlackReady?: Maybe<Scalars['Boolean']['output']>;
   languageId?: Maybe<Scalars['String']['output']>;
   lifecycleIdentityId?: Maybe<Scalars['String']['output']>;
   maskedInput?: Maybe<Scalars['String']['output']>;
@@ -93,21 +145,76 @@ export type CellExecutionHistoryArgs = {
   autoSave?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-export type CellExecutionList = {
-  __typename?: 'CellExecutionList';
-  data?: Maybe<Array<Maybe<CellExecution>>>;
-  totalActive?: Maybe<Scalars['Int']['output']>;
-  totalArchived?: Maybe<Scalars['Int']['output']>;
-  totalCount?: Maybe<Scalars['Int']['output']>;
+export type CellOutput = {
+  __typename?: 'CellOutput';
+  archivedTime?: Maybe<Scalars['DateTime']['output']>;
+  autoSave?: Maybe<Scalars['Boolean']['output']>;
+  cell: Cell;
+  cellId: Scalars['String']['output'];
+  cellSharings: Array<Maybe<CellSharing>>;
+  createTime: Scalars['DateTime']['output'];
+  exitCode: Scalars['Int']['output'];
+  fileName?: Maybe<Scalars['String']['output']>;
+  hasMaskedData?: Maybe<Scalars['Boolean']['output']>;
+  htmlUrl?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  input?: Maybe<Scalars['String']['output']>;
+  inputData: Scalars['Byte']['output'];
+  isOwner?: Maybe<Scalars['Boolean']['output']>;
+  languageId?: Maybe<Scalars['String']['output']>;
+  lifecycleIdentityId?: Maybe<Scalars['String']['output']>;
+  maskedInput?: Maybe<Scalars['String']['output']>;
+  maskedStderr?: Maybe<Scalars['Bytes']['output']>;
+  maskedStdout?: Maybe<Scalars['Bytes']['output']>;
+  metadata: Metadata;
+  organization?: Maybe<Organization>;
+  organizationId?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  pid: Scalars['Int']['output'];
+  shareType: ShareType;
+  stderr?: Maybe<Scalars['Bytes']['output']>;
+  stderrData: Scalars['Byte']['output'];
+  stdout?: Maybe<Scalars['Bytes']['output']>;
+  stdoutData: Scalars['Byte']['output'];
+  unmaskable: Scalars['Boolean']['output'];
+  updateTime: Scalars['DateTime']['output'];
+  user?: Maybe<User>;
+  userId: Scalars['String']['output'];
 };
 
-export type CellExecutionShare = {
-  __typename?: 'CellExecutionShare';
-  cellExecution: CellExecution;
-  cellExecutionId: Scalars['String']['output'];
+export type CellOutputFilter = {
+  ownedActive?: InputMaybe<Scalars['Boolean']['input']>;
+  ownedArchived?: InputMaybe<Scalars['Boolean']['input']>;
+  sharedWithMe?: InputMaybe<Scalars['Boolean']['input']>;
+  sharedWithOrg?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type CellOutputMessage = {
+  __typename?: 'CellOutputMessage';
+  cellOutput: CellOutput;
+  cellOutputId: Scalars['String']['output'];
+  cellOutputMessages: Array<Maybe<CellOutputMessage>>;
+  createTime: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
+  organization: Organization;
+  organizationId: Scalars['String']['output'];
+  parentMessage?: Maybe<CellOutputMessage>;
+  parentMessageId?: Maybe<Scalars['String']['output']>;
+  updateTime: Scalars['DateTime']['output'];
+  user: User;
+  userId: Scalars['String']['output'];
+};
+
+export type CellSharing = {
+  __typename?: 'CellSharing';
+  cellOutput: CellOutput;
+  cellOutputId: Scalars['String']['output'];
   group?: Maybe<Group>;
   groupId?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  organization?: Maybe<Organization>;
+  organizationId?: Maybe<Scalars['String']['output']>;
   sharedBy: User;
   sharedById: Scalars['String']['output'];
   user?: Maybe<User>;
@@ -148,6 +255,19 @@ export type ChatSessionInput = {
   id: Scalars['ID']['input'];
 };
 
+export type CreateAccessRequestInput = {
+  referenceId: Scalars['String']['input'];
+  referenceTable: Scalars['String']['input'];
+};
+
+export type CreateCellAttachmentInput = {
+  cellId: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  size: Scalars['Int']['input'];
+  type: Scalars['String']['input'];
+};
+
 export type CreateCellExecutionInput = {
   archivedTime?: InputMaybe<Scalars['DateTime']['input']>;
   autoSave?: InputMaybe<Scalars['Boolean']['input']>;
@@ -165,11 +285,46 @@ export type CreateCellExecutionInput = {
   updateTime?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
-export type CreateCellExecutionShareInput = {
-  cellExecutionId: Scalars['String']['input'];
+export type CreateCellInput = {
+  lifecycleIdentityId: Scalars['String']['input'];
+  notebookId: Scalars['String']['input'];
+  notebookSessionId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type CreateCellOutputInput = {
+  autoSave?: InputMaybe<Scalars['Boolean']['input']>;
+  exitCode: Scalars['Int']['input'];
+  fileName?: InputMaybe<Scalars['String']['input']>;
+  inputData: Scalars['Byte']['input'];
+  languageId?: InputMaybe<Scalars['String']['input']>;
+  lifecycleIdentityId: Scalars['String']['input'];
+  metadata: MetadataInput;
+  notebookLifecycleIdentityId: Scalars['String']['input'];
+  pid: Scalars['Int']['input'];
+  runmeVersion?: InputMaybe<Scalars['String']['input']>;
+  shareType?: InputMaybe<ShareType>;
+  stderrData: Scalars['Byte']['input'];
+  stdoutData: Scalars['Byte']['input'];
+};
+
+export type CreateCellOutputMessageInput = {
+  cellOutputId: Scalars['String']['input'];
+  message: Scalars['String']['input'];
+  parentMessageId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type CreateCellSharingInput = {
+  cellOutputId: Scalars['String']['input'];
   groupId?: InputMaybe<Scalars['String']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
   sharedById: Scalars['String']['input'];
   userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type CreateEnvironmentInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
 };
 
 export type CreateGithubInstallationInput = {
@@ -178,7 +333,6 @@ export type CreateGithubInstallationInput = {
   accountName: Scalars['String']['input'];
   appId: Scalars['Int']['input'];
   appSlug: Scalars['String']['input'];
-  createTime?: InputMaybe<Scalars['DateTime']['input']>;
   installationId: Scalars['Int']['input'];
   permissions: Scalars['JSON']['input'];
   repositorySelection: Scalars['String']['input'];
@@ -186,7 +340,6 @@ export type CreateGithubInstallationInput = {
   suspendedBy?: InputMaybe<Scalars['String']['input']>;
   targetId: Scalars['Int']['input'];
   targetType: GithubTargetType;
-  updateTime: Scalars['DateTime']['input'];
   userId: Scalars['String']['input'];
 };
 
@@ -200,26 +353,48 @@ export type CreateGroupUserInput = {
   userId: Scalars['String']['input'];
 };
 
+export type CreateInvitationInput = {
+  referenceId: Scalars['String']['input'];
+  referenceTable: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
+
+export type CreateLogInput = {
+  data: Scalars['JSON']['input'];
+  type: LogTypeEnum;
+};
+
+export type CreateLogTypeInput = {
+  description: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+};
+
 export type CreateNotebookInput = {
   fileName?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['String']['input'];
-  runmeVersion: Scalars['String']['input'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  runmeVersion?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type CreateNotebookSessionInput = {
+  environmentId?: InputMaybe<Scalars['String']['input']>;
+  notebookId: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+};
+
+export type CreateNotificationInput = {
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  referenceId: Scalars['String']['input'];
+  referenceTable: Scalars['String']['input'];
+  type: NotificationType;
+  userId: Scalars['String']['input'];
 };
 
 export type CreateOrganizationInput = {
-  createTime: Scalars['DateTime']['input'];
   name: Scalars['String']['input'];
-  updateTime: Scalars['DateTime']['input'];
-};
-
-export type CreateOrganizationUserInput = {
-  organizationId: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
 };
 
 export type CreateSlackInstallationInput = {
   appId: Scalars['String']['input'];
-  createTime?: InputMaybe<Scalars['DateTime']['input']>;
   data: Scalars['JSON']['input'];
   defaultChannelId?: InputMaybe<Scalars['String']['input']>;
   defaultChannelName?: InputMaybe<Scalars['String']['input']>;
@@ -228,15 +403,12 @@ export type CreateSlackInstallationInput = {
   teamName: Scalars['String']['input'];
   token: Scalars['Bytes']['input'];
   tokenType?: InputMaybe<SlackTokenType>;
-  updateTime?: InputMaybe<Scalars['DateTime']['input']>;
-  userId: Scalars['String']['input'];
 };
 
 export type CreateUserInput = {
   auth0Id?: InputMaybe<Scalars['String']['input']>;
   bio?: InputMaybe<Scalars['String']['input']>;
   company?: InputMaybe<Scalars['String']['input']>;
-  createTime?: InputMaybe<Scalars['DateTime']['input']>;
   displayName?: InputMaybe<Scalars['String']['input']>;
   email: Scalars['String']['input'];
   emailVerified?: InputMaybe<Scalars['Boolean']['input']>;
@@ -254,14 +426,36 @@ export type CreateUserInput = {
   siteAdmin?: InputMaybe<Scalars['Boolean']['input']>;
   siteUrl?: InputMaybe<Scalars['String']['input']>;
   twitter?: InputMaybe<Scalars['String']['input']>;
-  updateTime?: InputMaybe<Scalars['DateTime']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type CreateWorkflowInput = {
+  fileName: Scalars['String']['input'];
+  githubInstallationId?: InputMaybe<Scalars['String']['input']>;
+  path: Scalars['String']['input'];
+  repository: Scalars['String']['input'];
+};
+
+export type DeleteOrganizationUserInput = {
+  userId: Scalars['String']['input'];
 };
 
 export type DocMetadata = {
   __typename?: 'DocMetadata';
   key: Scalars['String']['output'];
   value: Scalars['String']['output'];
+};
+
+export type Environment = {
+  __typename?: 'Environment';
+  createTime: Scalars['DateTime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  notebookSessions: Array<Maybe<NotebookSession>>;
+  organization: Organization;
+  organizationId: Scalars['String']['output'];
+  updateTime: Scalars['DateTime']['output'];
 };
 
 export type GithubInstallation = {
@@ -272,18 +466,21 @@ export type GithubInstallation = {
   appId: Scalars['Int']['output'];
   appSlug: Scalars['String']['output'];
   createTime: Scalars['DateTime']['output'];
-  documents?: Maybe<Array<Maybe<GithubMarkdown>>>;
   id: Scalars['String']['output'];
   installationId: Scalars['Int']['output'];
+  organization?: Maybe<Organization>;
+  organizationId: Scalars['String']['output'];
   permissions: GithubInstallationPermissions;
   repositorySelection: Scalars['String']['output'];
   suspendedAt?: Maybe<Scalars['DateTime']['output']>;
   suspendedBy?: Maybe<Scalars['String']['output']>;
+  syncingState?: Maybe<SyncingStateEnum>;
   targetId: Scalars['Int']['output'];
   targetType: GithubTargetType;
   updateTime: Scalars['DateTime']['output'];
   user: User;
   userId: Scalars['String']['output'];
+  workflows?: Maybe<Array<Maybe<Workflow>>>;
 };
 
 export type GithubInstallationPermissions = {
@@ -346,6 +543,8 @@ export type GroupUser = {
   group: Group;
   groupId: Scalars['String']['output'];
   id: Scalars['String']['output'];
+  organization: Organization;
+  organizationId: Scalars['String']['output'];
   user: User;
   userId: Scalars['String']['output'];
 };
@@ -361,6 +560,68 @@ export type Hit = {
   document: Scalars['String']['output'];
   metadata: Array<DocMetadata>;
 };
+
+export type Invitation = {
+  __typename?: 'Invitation';
+  createTime: Scalars['DateTime']['output'];
+  createdBy: User;
+  createdById: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  organization?: Maybe<Organization>;
+  organizationId: Scalars['String']['output'];
+  referenceId: Scalars['String']['output'];
+  referenceTable: Scalars['String']['output'];
+  status: InvitationStatus;
+  updateTime: Scalars['DateTime']['output'];
+  user: User;
+  userId: Scalars['String']['output'];
+};
+
+export enum InvitationStatus {
+  Accepted = 'ACCEPTED',
+  Declined = 'DECLINED',
+  Pending = 'PENDING',
+  Revoked = 'REVOKED'
+}
+
+export type InviteUserToOrganizationInput = {
+  displayName?: InputMaybe<Scalars['String']['input']>;
+  email: Scalars['String']['input'];
+};
+
+export type Log = {
+  __typename?: 'Log';
+  cellOutputAccess?: Maybe<LogCellOutput>;
+  createTime: Scalars['DateTime']['output'];
+  data: Scalars['JSON']['output'];
+  id: Scalars['String']['output'];
+  logType: LogType;
+  user: User;
+  userId: Scalars['String']['output'];
+};
+
+export type LogCellOutput = {
+  __typename?: 'LogCellOutput';
+  accessRequested?: Maybe<Scalars['Boolean']['output']>;
+  hasAccess?: Maybe<Scalars['Boolean']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+};
+
+export type LogType = {
+  __typename?: 'LogType';
+  description: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  logs: Array<Maybe<Log>>;
+  name: Scalars['String']['output'];
+};
+
+export enum LogTypeEnum {
+  Crae = 'crae',
+  Cre = 'cre',
+  Crf = 'crf',
+  Crs = 'crs',
+  Crse = 'crse'
+}
 
 export type Metadata = {
   __typename?: 'Metadata';
@@ -383,22 +644,57 @@ export type MetadataInput = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  acceptAccessRequest: AccessRequest;
+  acceptInvitation: Invitation;
   addUserToOrganization: Organization;
   archiveCellExecution?: Maybe<CellExecution>;
+  archiveCellOutput: CellOutput;
+  createAccessRequest: AccessRequest;
+  createCellAttachment: CellAttachment;
   createCellExecution: CellExecution;
+  createCellOutput: CellOutput;
+  createCellOutputMessage: CellOutputMessage;
+  createEnvironment: Environment;
   createGroup: Group;
+  createInvitation: Invitation;
+  createNotebookSession: NotebookSession;
   createOrganization: Organization;
-  deleteCellExecution: CellExecution;
+  declineInvitation: Invitation;
+  deleteCellAttachment: CellAttachment;
+  deleteCellOutput: CellOutput;
+  deleteCellOutputMessage?: Maybe<CellOutputMessage>;
+  deleteEnvironment: Environment;
   deleteGroup: Group;
+  deleteNotebookSession: NotebookSession;
   deleteOrganization: Organization;
+  deleteOrganizationUser: OrganizationUser;
   handleGithubInstallation: GithubInstallation;
+  inviteUserToOrganization: User;
+  rejectAccessRequest: AccessRequest;
   removeUserFromOrganization: Organization;
-  shareCellExecution: CellExecution;
+  revokeInvitation: Invitation;
+  shareCellOutputToSlack: CellOutput;
+  syncGithubInstallation: GithubInstallation;
   unArchiveCellExecution?: Maybe<CellExecution>;
+  unArchiveCellOutput: CellOutput;
+  updateCellAttachment: CellAttachment;
   updateCellExecution: CellExecution;
+  updateCellOutput: CellOutput;
+  updateEnvironment: Environment;
   updateGroup: Group;
+  updateNotebookSession: NotebookSession;
   updateOrganization: Organization;
   updateSlackInstallation: SlackInstallation;
+};
+
+
+export type MutationAcceptAccessRequestArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type MutationAcceptInvitationArgs = {
+  id: Scalars['String']['input'];
 };
 
 
@@ -413,8 +709,39 @@ export type MutationArchiveCellExecutionArgs = {
 };
 
 
+export type MutationArchiveCellOutputArgs = {
+  all?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['String']['input'];
+};
+
+
+export type MutationCreateAccessRequestArgs = {
+  input: CreateAccessRequestInput;
+};
+
+
+export type MutationCreateCellAttachmentArgs = {
+  input: CreateCellAttachmentInput;
+};
+
+
 export type MutationCreateCellExecutionArgs = {
   input: CreateCellExecutionInput;
+};
+
+
+export type MutationCreateCellOutputArgs = {
+  input: CreateCellOutputInput;
+};
+
+
+export type MutationCreateCellOutputMessageArgs = {
+  input: CreateCellOutputMessageInput;
+};
+
+
+export type MutationCreateEnvironmentArgs = {
+  input: CreateEnvironmentInput;
 };
 
 
@@ -423,12 +750,42 @@ export type MutationCreateGroupArgs = {
 };
 
 
+export type MutationCreateInvitationArgs = {
+  input: CreateInvitationInput;
+};
+
+
+export type MutationCreateNotebookSessionArgs = {
+  input: CreateNotebookSessionInput;
+};
+
+
 export type MutationCreateOrganizationArgs = {
   input: CreateOrganizationInput;
 };
 
 
-export type MutationDeleteCellExecutionArgs = {
+export type MutationDeclineInvitationArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type MutationDeleteCellAttachmentArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type MutationDeleteCellOutputArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type MutationDeleteCellOutputMessageArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type MutationDeleteEnvironmentArgs = {
   id: Scalars['String']['input'];
 };
 
@@ -438,8 +795,18 @@ export type MutationDeleteGroupArgs = {
 };
 
 
+export type MutationDeleteNotebookSessionArgs = {
+  id: Scalars['String']['input'];
+};
+
+
 export type MutationDeleteOrganizationArgs = {
   id: Scalars['String']['input'];
+};
+
+
+export type MutationDeleteOrganizationUserArgs = {
+  input: DeleteOrganizationUserInput;
 };
 
 
@@ -448,20 +815,46 @@ export type MutationHandleGithubInstallationArgs = {
 };
 
 
+export type MutationInviteUserToOrganizationArgs = {
+  input: InviteUserToOrganizationInput;
+};
+
+
+export type MutationRejectAccessRequestArgs = {
+  id: Scalars['String']['input'];
+};
+
+
 export type MutationRemoveUserFromOrganizationArgs = {
   input: RemoveUserFromOrganization;
 };
 
 
-export type MutationShareCellExecutionArgs = {
-  id: Scalars['String']['input'];
-  input: ShareCellExecutionInput;
+export type MutationRevokeInvitationArgs = {
+  input: RevokeInvitationInput;
+};
+
+
+export type MutationShareCellOutputToSlackArgs = {
+  input: ShareCellOutputToSlackInput;
 };
 
 
 export type MutationUnArchiveCellExecutionArgs = {
   all?: InputMaybe<Scalars['Boolean']['input']>;
   id: Scalars['String']['input'];
+};
+
+
+export type MutationUnArchiveCellOutputArgs = {
+  all?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars['String']['input'];
+};
+
+
+export type MutationUpdateCellAttachmentArgs = {
+  id: Scalars['String']['input'];
+  input: UpdateCellAttachmentInput;
 };
 
 
@@ -472,9 +865,27 @@ export type MutationUpdateCellExecutionArgs = {
 };
 
 
+export type MutationUpdateCellOutputArgs = {
+  id: Scalars['String']['input'];
+  input: UpdateCellOutputInput;
+};
+
+
+export type MutationUpdateEnvironmentArgs = {
+  id: Scalars['String']['input'];
+  input: UpdateEnvironmentInput;
+};
+
+
 export type MutationUpdateGroupArgs = {
   id: Scalars['String']['input'];
   input: UpdateGroupInput;
+};
+
+
+export type MutationUpdateNotebookSessionArgs = {
+  id: Scalars['String']['input'];
+  input: UpdateNotebookSessionInput;
 };
 
 
@@ -490,7 +901,7 @@ export type MutationUpdateSlackInstallationArgs = {
 
 export type Notebook = {
   __typename?: 'Notebook';
-  cellExecutions?: Maybe<Array<Maybe<CellExecution>>>;
+  cells?: Maybe<Array<Maybe<Cell>>>;
   createTime?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['String']['output'];
   runmeVersion?: Maybe<Scalars['String']['output']>;
@@ -499,12 +910,56 @@ export type Notebook = {
   userId: Scalars['String']['output'];
 };
 
+export type NotebookSession = {
+  __typename?: 'NotebookSession';
+  cells: Array<Maybe<Cell>>;
+  createTime: Scalars['DateTime']['output'];
+  environment?: Maybe<Environment>;
+  environmentId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  notebook: Notebook;
+  notebookId: Scalars['String']['output'];
+  organization: Organization;
+  organizationId: Scalars['String']['output'];
+  updateTime: Scalars['DateTime']['output'];
+};
+
+export type Notification = {
+  __typename?: 'Notification';
+  accessRequest?: Maybe<AccessRequest>;
+  cellOutputMessage?: Maybe<CellOutputMessage>;
+  createTime: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  invitation?: Maybe<Invitation>;
+  isRead: Scalars['Boolean']['output'];
+  organization: Organization;
+  organizationId: Scalars['String']['output'];
+  referenceId: Scalars['String']['output'];
+  referenceTable: Scalars['String']['output'];
+  type: NotificationType;
+  updateTime: Scalars['DateTime']['output'];
+  user: User;
+  userId: Scalars['String']['output'];
+};
+
+export enum NotificationType {
+  CellOutputAccessRequest = 'CELL_OUTPUT_ACCESS_REQUEST',
+  CellOutputAccessRequestAccepted = 'CELL_OUTPUT_ACCESS_REQUEST_ACCEPTED',
+  CellOutputAccessRequestRejected = 'CELL_OUTPUT_ACCESS_REQUEST_REJECTED',
+  CellOutputMessageReply = 'CELL_OUTPUT_MESSAGE_REPLY',
+  OrganizationUserInvitation = 'ORGANIZATION_USER_INVITATION',
+  OrganizationUserInvitationAccepted = 'ORGANIZATION_USER_INVITATION_ACCEPTED',
+  OrganizationUserInvitationDeclined = 'ORGANIZATION_USER_INVITATION_DECLINED'
+}
+
 export type Organization = {
   __typename?: 'Organization';
   createTime: Scalars['DateTime']['output'];
   groups: Array<Maybe<Group>>;
   id: Scalars['String']['output'];
-  name: Scalars['String']['output'];
+  invitations: Array<Maybe<Invitation>>;
+  isDefault: Scalars['Boolean']['output'];
+  name?: Maybe<Scalars['String']['output']>;
   organizationUsers: Array<Maybe<OrganizationUser>>;
   updateTime: Scalars['DateTime']['output'];
 };
@@ -530,34 +985,93 @@ export type Owner = {
   twitter?: Maybe<Scalars['String']['output']>;
 };
 
+export type PaginatedLogs = {
+  __typename?: 'PaginatedLogs';
+  data: Array<Log>;
+  meta: PaginationMeta;
+};
+
+export type PaginatedNotifications = {
+  __typename?: 'PaginatedNotifications';
+  data: Array<Notification>;
+  meta: PaginationMeta;
+};
+
+export type PaginationMeta = {
+  __typename?: 'PaginationMeta';
+  totalPages: Scalars['Int']['output'];
+};
+
 /** About the Redwood queries. */
 export type Query = {
   __typename?: 'Query';
   assistant?: Maybe<Assistant>;
-  cellExecution?: Maybe<CellExecution>;
-  cellExecutions: CellExecutionList;
+  cell?: Maybe<Cell>;
+  cellAttachment?: Maybe<CellAttachment>;
+  cellAttachments: Array<CellAttachment>;
+  cellOutput?: Maybe<CellOutput>;
+  cellOutputMessages: Array<CellOutputMessage>;
+  cells: Array<Cell>;
+  environment?: Maybe<Environment>;
+  environments: Array<Environment>;
   getSlackChannels?: Maybe<Array<Maybe<SlackChannel>>>;
   githubInstallation?: Maybe<GithubInstallation>;
   group?: Maybe<Group>;
+  groupUser?: Maybe<GroupUser>;
+  groupUsers: Array<GroupUser>;
   groups: Array<Group>;
+  invitation: Invitation;
+  log?: Maybe<Log>;
+  logTypes: Array<LogType>;
+  logs: PaginatedLogs;
+  me?: Maybe<User>;
+  notebookSession?: Maybe<NotebookSession>;
+  notebookSessions: Array<NotebookSession>;
+  notifications: PaginatedNotifications;
   organization?: Maybe<Organization>;
   organizations: Array<Organization>;
   /** Fetches the Redwood root schema. */
   redwood?: Maybe<Redwood>;
   slackInstallation?: Maybe<SlackInstallation>;
+  totalCellOutputs: Scalars['Int']['output'];
+  workflows: Array<Workflow>;
 };
 
 
 /** About the Redwood queries. */
-export type QueryCellExecutionArgs = {
+export type QueryCellArgs = {
+  filters?: InputMaybe<CellOutputFilter>;
   id: Scalars['String']['input'];
 };
 
 
 /** About the Redwood queries. */
-export type QueryCellExecutionsArgs = {
-  archived?: InputMaybe<Scalars['Boolean']['input']>;
-  autoSave?: InputMaybe<Scalars['Boolean']['input']>;
+export type QueryCellAttachmentArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryCellOutputArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryCellOutputMessagesArgs = {
+  cellOutputId: Scalars['String']['input'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryCellsArgs = {
+  filters?: InputMaybe<CellOutputFilter>;
+};
+
+
+/** About the Redwood queries. */
+export type QueryEnvironmentArgs = {
+  id: Scalars['String']['input'];
 };
 
 
@@ -568,8 +1082,54 @@ export type QueryGroupArgs = {
 
 
 /** About the Redwood queries. */
+export type QueryGroupUserArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryInvitationArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryLogArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryLogsArgs = {
+  filters?: InputMaybe<Scalars['JSON']['input']>;
+  page: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** About the Redwood queries. */
+export type QueryNotebookSessionArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryNotificationsArgs = {
+  filters?: InputMaybe<Scalars['JSON']['input']>;
+  page: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** About the Redwood queries. */
 export type QueryOrganizationArgs = {
   id: Scalars['String']['input'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryTotalCellOutputsArgs = {
+  filters?: InputMaybe<CellOutputFilter>;
 };
 
 /**
@@ -592,6 +1152,11 @@ export type RemoveUserFromOrganization = {
   userId: Scalars['String']['input'];
 };
 
+export type RevokeInvitationInput = {
+  referenceTable: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
+
 export type Search = {
   __typename?: 'Search';
   hits: Array<Hit>;
@@ -607,12 +1172,9 @@ export type SearchInput = {
   query: Scalars['String']['input'];
 };
 
-export type ShareCellExecutionInput = {
-  groupIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  notify?: InputMaybe<Scalars['Boolean']['input']>;
-  shareType: ShareType;
-  unmaskable: Scalars['Boolean']['input'];
-  userEmails?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+export type ShareCellOutputToSlackInput = {
+  cellOutputId?: InputMaybe<Scalars['String']['input']>;
+  channelId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export enum ShareType {
@@ -643,14 +1205,13 @@ export type SlackInstallation = {
   defaultChannelId?: Maybe<Scalars['String']['output']>;
   defaultChannelName?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  organization?: Maybe<Organization>;
   scopes: Scalars['String']['output'];
   teamId: Scalars['String']['output'];
   teamName: Scalars['String']['output'];
   token: Scalars['Bytes']['output'];
   tokenType?: Maybe<SlackTokenType>;
   updateTime: Scalars['DateTime']['output'];
-  user: User;
-  userId: Scalars['String']['output'];
 };
 
 export enum SlackTokenType {
@@ -663,15 +1224,65 @@ export type Subscription = {
   chat?: Maybe<ChatMessage>;
 };
 
+export enum SyncingStateEnum {
+  Error = 'ERROR',
+  Synced = 'SYNCED',
+  Syncing = 'SYNCING'
+}
+
+export type UpdateAccessRequestInput = {
+  createTime?: InputMaybe<Scalars['DateTime']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  referenceId?: InputMaybe<Scalars['String']['input']>;
+  referenceTable?: InputMaybe<Scalars['String']['input']>;
+  requestedById?: InputMaybe<Scalars['String']['input']>;
+  updateTime?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type UpdateCellAttachmentInput = {
+  cellId?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
+  type?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type UpdateCellExecutionInput = {
   isPrivate?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-export type UpdateCellExecutionShareInput = {
-  cellExecutionId?: InputMaybe<Scalars['String']['input']>;
+export type UpdateCellInput = {
+  lifecycleIdentityId?: InputMaybe<Scalars['String']['input']>;
+  notebookId?: InputMaybe<Scalars['String']['input']>;
+  notebookSessionId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateCellOutputInput = {
+  groupIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  notify?: InputMaybe<Scalars['Boolean']['input']>;
+  shareType: ShareType;
+  unmaskable?: InputMaybe<Scalars['Boolean']['input']>;
+  userIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type UpdateCellOutputMessageInput = {
+  cellOutputId?: InputMaybe<Scalars['String']['input']>;
+  message?: InputMaybe<Scalars['String']['input']>;
+  parentMessageId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateCellSharingInput = {
+  cellOutputId?: InputMaybe<Scalars['String']['input']>;
   groupId?: InputMaybe<Scalars['String']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
   sharedById?: InputMaybe<Scalars['String']['input']>;
   userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateEnvironmentInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateGithubInstallationInput = {
@@ -680,7 +1291,6 @@ export type UpdateGithubInstallationInput = {
   accountName?: InputMaybe<Scalars['String']['input']>;
   appId?: InputMaybe<Scalars['Int']['input']>;
   appSlug?: InputMaybe<Scalars['String']['input']>;
-  createTime?: InputMaybe<Scalars['DateTime']['input']>;
   installationId?: InputMaybe<Scalars['Int']['input']>;
   permissions?: InputMaybe<Scalars['JSON']['input']>;
   repositorySelection?: InputMaybe<Scalars['String']['input']>;
@@ -688,7 +1298,6 @@ export type UpdateGithubInstallationInput = {
   suspendedBy?: InputMaybe<Scalars['String']['input']>;
   targetId?: InputMaybe<Scalars['Int']['input']>;
   targetType?: InputMaybe<GithubTargetType>;
-  updateTime?: InputMaybe<Scalars['DateTime']['input']>;
   userId?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -699,20 +1308,53 @@ export type UpdateGroupInput = {
 
 export type UpdateGroupUserInput = {
   groupId?: InputMaybe<Scalars['String']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
   userId?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdateNotebookInput = {
+export type UpdateInvitationInput = {
   createTime?: InputMaybe<Scalars['DateTime']['input']>;
-  runmeVersion?: InputMaybe<Scalars['String']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  referenceId?: InputMaybe<Scalars['String']['input']>;
+  referenceTable?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<InvitationStatus>;
+  updateTime?: InputMaybe<Scalars['DateTime']['input']>;
+  userId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateLogInput = {
+  data?: InputMaybe<Scalars['JSON']['input']>;
+  type?: InputMaybe<LogTypeEnum>;
+};
+
+export type UpdateLogTypeInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateNotebookInput = {
+  id: Scalars['String']['input'];
+  lifecycleIdentityId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateNotebookSessionInput = {
+  environmentId?: InputMaybe<Scalars['String']['input']>;
+  notebookId?: InputMaybe<Scalars['String']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateNotificationInput = {
+  createTime?: InputMaybe<Scalars['DateTime']['input']>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  referenceId?: InputMaybe<Scalars['String']['input']>;
+  referenceTable?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<NotificationType>;
   updateTime?: InputMaybe<Scalars['DateTime']['input']>;
   userId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateOrganizationInput = {
-  createTime?: InputMaybe<Scalars['DateTime']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
-  updateTime?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
 export type UpdateOrganizationUserInput = {
@@ -729,7 +1371,6 @@ export type UpdateUserInput = {
   auth0Id?: InputMaybe<Scalars['String']['input']>;
   bio?: InputMaybe<Scalars['String']['input']>;
   company?: InputMaybe<Scalars['String']['input']>;
-  createTime?: InputMaybe<Scalars['DateTime']['input']>;
   displayName?: InputMaybe<Scalars['String']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
   emailVerified?: InputMaybe<Scalars['Boolean']['input']>;
@@ -747,8 +1388,14 @@ export type UpdateUserInput = {
   siteAdmin?: InputMaybe<Scalars['Boolean']['input']>;
   siteUrl?: InputMaybe<Scalars['String']['input']>;
   twitter?: InputMaybe<Scalars['String']['input']>;
-  updateTime?: InputMaybe<Scalars['DateTime']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateWorkflowInput = {
+  fileName?: InputMaybe<Scalars['String']['input']>;
+  githubInstallationId?: InputMaybe<Scalars['String']['input']>;
+  path?: InputMaybe<Scalars['String']['input']>;
+  repository?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type User = {
@@ -757,7 +1404,7 @@ export type User = {
   SlackInstallations: Array<Maybe<SlackInstallation>>;
   auth0Id?: Maybe<Scalars['String']['output']>;
   bio?: Maybe<Scalars['String']['output']>;
-  cellExecutions: Array<Maybe<CellExecution>>;
+  cells: Array<Maybe<Cell>>;
   company?: Maybe<Scalars['String']['output']>;
   createTime?: Maybe<Scalars['DateTime']['output']>;
   displayName?: Maybe<Scalars['String']['output']>;
@@ -765,7 +1412,6 @@ export type User = {
   emailVerified?: Maybe<Scalars['Boolean']['output']>;
   firebaseRefreshTime?: Maybe<Scalars['DateTime']['output']>;
   githubId?: Maybe<Scalars['String']['output']>;
-  githubInstallations: Array<Maybe<GithubInstallation>>;
   githubRefreshTime?: Maybe<Scalars['DateTime']['output']>;
   githubUsername?: Maybe<Scalars['String']['output']>;
   googleId?: Maybe<Scalars['String']['output']>;
@@ -775,6 +1421,7 @@ export type User = {
   linkedin?: Maybe<Scalars['String']['output']>;
   microsoftId?: Maybe<Scalars['String']['output']>;
   microsoftRefreshTime?: Maybe<Scalars['DateTime']['output']>;
+  organizationUsers?: Maybe<Array<Maybe<OrganizationUser>>>;
   photoUrl?: Maybe<Scalars['String']['output']>;
   signupOrigin?: Maybe<SignupOrigin>;
   siteAdmin?: Maybe<Scalars['Boolean']['output']>;
@@ -782,6 +1429,20 @@ export type User = {
   twitter?: Maybe<Scalars['String']['output']>;
   updateTime?: Maybe<Scalars['DateTime']['output']>;
   username?: Maybe<Scalars['String']['output']>;
+};
+
+export type Workflow = {
+  __typename?: 'Workflow';
+  fileName: Scalars['String']['output'];
+  githubInstallation?: Maybe<GithubInstallation>;
+  githubInstallationId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  path: Scalars['String']['output'];
+  repository: Scalars['String']['output'];
+};
+
+export type _CreateNotebookInput = {
+  lifecycleIdentityId: Scalars['String']['input'];
 };
 
 export type ArchiveCellExecutionMutationVariables = Exact<{
@@ -796,7 +1457,7 @@ export type CreateCellExecutionMutationVariables = Exact<{
 }>;
 
 
-export type CreateCellExecutionMutation = { __typename?: 'Mutation', createCellExecution: { __typename?: 'CellExecution', id: string, htmlUrl?: string | null, exitCode: number } };
+export type CreateCellExecutionMutation = { __typename?: 'Mutation', createCellExecution: { __typename?: 'CellExecution', id: string, htmlUrl?: string | null, exitCode: number, isSlackReady?: boolean | null } };
 
 export type UpdateCellExecutionMutationVariables = Exact<{
   id: Scalars['String']['input'];
@@ -804,9 +1465,9 @@ export type UpdateCellExecutionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateCellExecutionMutation = { __typename?: 'Mutation', updateCellExecution: { __typename?: 'CellExecution', id: string, htmlUrl?: string | null, exitCode: number } };
+export type UpdateCellExecutionMutation = { __typename?: 'Mutation', updateCellExecution: { __typename?: 'CellExecution', id: string, htmlUrl?: string | null, exitCode: number, isSlackReady?: boolean | null } };
 
 
 export const ArchiveCellExecutionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ArchiveCellExecution"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"archiveCellExecutionId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"archiveCellExecution"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"archiveCellExecutionId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<ArchiveCellExecutionMutation, ArchiveCellExecutionMutationVariables>;
-export const CreateCellExecutionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateCellExecution"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateCellExecutionInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createCellExecution"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"htmlUrl"}},{"kind":"Field","name":{"kind":"Name","value":"exitCode"}}]}}]}}]} as unknown as DocumentNode<CreateCellExecutionMutation, CreateCellExecutionMutationVariables>;
-export const UpdateCellExecutionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateCellExecution"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateCellExecutionInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateCellExecution"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"htmlUrl"}},{"kind":"Field","name":{"kind":"Name","value":"exitCode"}}]}}]}}]} as unknown as DocumentNode<UpdateCellExecutionMutation, UpdateCellExecutionMutationVariables>;
+export const CreateCellExecutionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateCellExecution"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateCellExecutionInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createCellExecution"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"htmlUrl"}},{"kind":"Field","name":{"kind":"Name","value":"exitCode"}},{"kind":"Field","name":{"kind":"Name","value":"isSlackReady"}}]}}]}}]} as unknown as DocumentNode<CreateCellExecutionMutation, CreateCellExecutionMutationVariables>;
+export const UpdateCellExecutionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateCellExecution"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateCellExecutionInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateCellExecution"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"htmlUrl"}},{"kind":"Field","name":{"kind":"Name","value":"exitCode"}},{"kind":"Field","name":{"kind":"Name","value":"isSlackReady"}}]}}]}}]} as unknown as DocumentNode<UpdateCellExecutionMutation, UpdateCellExecutionMutationVariables>;

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -101,7 +101,7 @@ export default async function saveCellExecution(
       },
     })
 
-    const showEscalationButton = !!result.data?.createCellExecution.isSlackReady
+    const showEscalationButton = !!result.data?.createCellExecution?.isSlackReady
 
     TelemetryReporter.sendTelemetryEvent('app.save')
     return postClientMessage(messaging, ClientMessages.platformApiResponse, {

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -100,11 +100,14 @@ export default async function saveCellExecution(
         },
       },
     })
+
+    const showEscalationButton = !!result.data?.createCellExecution.isSlackReady
+
     TelemetryReporter.sendTelemetryEvent('app.save')
     return postClientMessage(messaging, ClientMessages.platformApiResponse, {
       data: result,
       id: message.output.id,
-      escalationButton,
+      escalationButton: showEscalationButton,
     })
   } catch (error) {
     TelemetryReporter.sendTelemetryEvent('app.error')

--- a/src/extension/messages/platformRequest/updateCellExecution.ts
+++ b/src/extension/messages/platformRequest/updateCellExecution.ts
@@ -46,7 +46,8 @@ export default async function updateCellExecution(
         },
       },
     })
-    const showEscalationButton = !!result.data?.updateCellExecution.isSlackReady
+
+    const showEscalationButton = !!result.data?.updateCellExecution?.isSlackReady
 
     TelemetryReporter.sendTelemetryEvent('app.update')
     return postClientMessage(messaging, ClientMessages.platformApiResponse, {

--- a/src/extension/messages/platformRequest/updateCellExecution.ts
+++ b/src/extension/messages/platformRequest/updateCellExecution.ts
@@ -46,11 +46,13 @@ export default async function updateCellExecution(
         },
       },
     })
+    const showEscalationButton = !!result.data?.updateCellExecution.isSlackReady
+
     TelemetryReporter.sendTelemetryEvent('app.update')
     return postClientMessage(messaging, ClientMessages.platformApiResponse, {
       data: result,
       id: message.output.id,
-      escalationButton,
+      escalationButton: showEscalationButton,
     })
   } catch (error) {
     TelemetryReporter.sendTelemetryEvent('app.update.error')

--- a/src/gql-platform/createCellExecution.graphql
+++ b/src/gql-platform/createCellExecution.graphql
@@ -3,5 +3,6 @@ mutation CreateCellExecution($input: CreateCellExecutionInput!) {
    id
    htmlUrl
    exitCode
+   isSlackReady
   }
 }

--- a/src/gql-platform/updateCellExecution.graphql
+++ b/src/gql-platform/updateCellExecution.graphql
@@ -3,5 +3,6 @@ mutation UpdateCellExecution($id: String!, $input: UpdateCellExecutionInput!) {
    id
    htmlUrl
    exitCode
+   isSlackReady
   }
 }


### PR DESCRIPTION
Integrate the new field `isSlackReady` from the Platform API, so the Escalate button only shows up if the Slack's organization is already set up.