### PR TITLE
Prevent notebook UX from being rendered unusable

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -168,20 +168,27 @@ export function isGitHubLink(runningCell: vscode.TextDocument) {
 }
 
 export function getKey(runningCell: vscode.TextDocument): string {
-  if (isDenoScript(runningCell)) {
-    return 'deno'
-  }
+  try {
+    if (isDenoScript(runningCell)) {
+      return 'deno'
+    }
 
-  if (isGitHubLink(runningCell)) {
-    return 'github'
-  }
+    if (isGitHubLink(runningCell)) {
+      return 'github'
+    }
 
-  if (new GCPResolver(runningCell.getText()).match()) {
-    return 'gcp'
-  }
+    if (new GCPResolver(runningCell.getText()).match()) {
+      return 'gcp'
+    }
 
-  if (new AWSResolver(runningCell.getText()).match()) {
-    return 'aws'
+    if (new AWSResolver(runningCell.getText()).match()) {
+      return 'aws'
+    }
+  } catch (err: any) {
+    if (err?.code !== 'ERR_INVALID_URL') {
+      throw err
+    }
+    console.error(err)
   }
 
   const { languageId } = runningCell

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -146,6 +146,19 @@ test('getKey', () => {
       languageId: 'shellscript',
     } as any),
   ).toBe('sh')
+
+  expect(
+    getKey({
+      getText: vi
+        .fn()
+        .mockReturnValue(
+          'export EC2_INSTANCE_ID=123\n' +
+            'https://us-east-1.console.aws.amazon.com/ec2/home' +
+            '?region=us-east-1#InstanceDetails:instanceId=$EC2_INSTANCE_ID',
+        ),
+      languageId: 'sh',
+    } as any),
+  ).toBe('sh')
 })
 
 suite('normalizeLanguage', () => {


### PR DESCRIPTION
Catch the exception and stop cell execution as unsuccessful to prevent "runaway" execution as shown here:

https://github.com/stateful/vscode-runme/assets/250527/6e3dad27-bd40-4140-bade-22d98a866fc4

At some future point, I'd like to do a more substantial refactor of how Cloud Renderers are "embedded" in bash. However, we need to collect more feedback from usage first.