### PR TITLE
Fix lifecycle ID for cells at deserialization time

### DIFF
--- a/src/extension/ai/generate.ts
+++ b/src/extension/ai/generate.ts
@@ -6,7 +6,8 @@ import { Serializer } from '../../types'
 import getLogger from '../logger'
 import { initAIServiceClient } from '../grpc/aiClient'
 import { AIServiceClient } from '../grpc/aiTypes'
-import { CellKind } from '../grpc/serializerTypes'
+import { CellKind, RunmeIdentity } from '../grpc/serializerTypes'
+import { ServerLifecycleIdentity, getServerConfigurationValue } from '../../utils/configuration'
 
 import * as converters from './converters'
 const log = getLogger('AIGenerate')
@@ -100,7 +101,11 @@ function addAIGeneratedCells(index: number, response: GenerateCellsResponse): vs
     notebook.cells.push(newCell)
   }
 
-  let newCellData = serializer.SerializerBase.revive(notebook)
+  const identity: ServerLifecycleIdentity = getServerConfigurationValue<ServerLifecycleIdentity>(
+    'lifecycleIdentity',
+    RunmeIdentity.ALL,
+  )
+  let newCellData = serializer.SerializerBase.revive(notebook, identity)
   // Now insert the new cells at the end of the notebook
   return vscode.NotebookEdit.insertCells(index, newCellData)
 }

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -90,8 +90,9 @@ async function assertDocumentContains(absDocPath: string, matcher: string, exact
   const source = await fs.readFile(absDocPath, 'utf-8')
   const savedContent = sanitizeOutput(source.toString()).split('\n')
   const matcherParts = sanitizeOutput(matcher).split('\n')
+  const maxContentLines = Math.min(matcherParts.length, savedContent.length)
 
-  for (let index = 0; index < savedContent.length; index++) {
+  for (let index = 0; index < maxContentLines; index++) {
     if (exact) {
       await expect(savedContent[index].trim()).toMatch(matcherParts[index].trim())
     }

--- a/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting All (1)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
+    const cell = await notebook.getCell('console.log("Scenario 1: Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -68,10 +68,10 @@ describe('Test suite: Shebang with setting All (1)', async () => {
       ## Shebang
       Example file used as part of the end to end suite
 
-      ## Scenario
+      ## Scenario 1
 
-      \`\`\`js { name=foo id=01HEXJ9KWG7BYSFYCNKVF0VWR6 }
-      console.log("Run scripts via Shebang!")
+      \`\`\`js {"id":"01HEXJ9KWG7BYSFYCNKVF0VWR6","name":"foo"}
+      console.log("Scenario 1: Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting Cell only (3)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
+    const cell = await notebook.getCell('console.log("Scenario 1: Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -63,10 +63,10 @@ describe('Test suite: Shebang with setting Cell only (3)', async () => {
       ## Shebang
       Example file used as part of the end to end suite
 
-      ## Scenario
+      ## Scenario 1
 
-      \`\`\`js { name=foo id=01HEXJ9KWG7BYSFYCNKVF0VWR6 }
-      console.log("Run scripts via Shebang!")
+      \`\`\`js {"name":"foo","id":"01HEXJ9KWG7BYSFYCNKVF0VWR6"}
+      console.log("Scenario 1: Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
@@ -53,7 +53,7 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
+    const cell = await notebook.getCell('console.log("Scenario 1: Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -68,10 +68,10 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
       ## Shebang
       Example file used as part of the end to end suite
 
-      ## Scenario
+      ## Scenario 1
 
       \`\`\`js {"name":"foo"}
-      console.log("Run scripts via Shebang!")
+      console.log("Scenario 1: Run scripts via Shebang!")
 
       \`\`\`
 

--- a/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
@@ -52,7 +52,7 @@ describe('Test suite: Shebang with setting None (0)', async () => {
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
-    const cell = await notebook.getCell('console.log("Run scripts via Shebang!")')
+    const cell = await notebook.getCell('console.log("Scenario 1: Run scripts via Shebang!")')
     await cell.focus()
     await saveFile(browser)
 
@@ -62,13 +62,26 @@ describe('Test suite: Shebang with setting None (0)', async () => {
       ## Shebang
       Example file used as part of the end to end suite
 
-      ## Scenario
+      ## Scenario 1
 
       \`\`\`js {"name":"foo"}
-      console.log("Run scripts via Shebang!")
+      console.log("Scenario 1: Run scripts via Shebang!")
 
       \`\`\`
 
+      ## Scenario 2
+
+      \`\`\`js {"id":"01HY444G8B44DF0DSGVRQ299QV"}
+      console.log("Scenario 2: Run scripts via Shebang!")
+
+      \`\`\`
+
+      ## Scenario 3
+
+      \`\`\`js
+      console.log("Scenario 3: Run scripts via Shebang!")
+
+      \`\`\`
       `,
       true,
     )

--- a/tests/fixtures/identity/shebang.md
+++ b/tests/fixtures/identity/shebang.md
@@ -2,9 +2,23 @@
 
 Example file used as part of the end to end suite
 
-## Scenario
+## Scenario 1
 
-```js { name=foo }
-console.log("Run scripts via Shebang!")
+```js {"name":"foo"}
+console.log("Scenario 1: Run scripts via Shebang!")
+
+```
+
+## Scenario 2
+
+```js {"id":"01HY444G8B44DF0DSGVRQ299QV"}
+console.log("Scenario 2: Run scripts via Shebang!")
+
+```
+
+## Scenario 3
+
+```js
+console.log("Scenario 3: Run scripts via Shebang!")
 
 ```


### PR DESCRIPTION
Includes the following:
- Ports test suite updates (2a42f575fb3a4ff49ff670a81773b331182ee4be) from https://github.com/stateful/vscode-runme/pull/1359
- Removes reconcileCellIdentity (ran at serialization time; was a bandaid)
- Properly fixes the underlying issue by shifting it to deserialization time

Supersedes the bugfix in https://github.com/stateful/vscode-runme/pull/1359 and fixes https://github.com/stateful/vscode-runme/issues/1354 properly.