### PR TITLE
Use native xvfb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           node-version: 18
 
+      - name: Install xvfb
+        run: sudo apt-get update -y && sudo apt-get install xvfb
+
       - name: Install Dependencies
         run: npm ci
         env:
@@ -82,10 +85,7 @@ jobs:
         if: ${{ github.event.inputs.releaseChannel == 'stable' }}
 
       - name: Run Tests
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: npm test
-          options: "-screen 0 1600x1200x24"
+        run: xvfb-run --server-args="-screen 0 1600x1200x24" npm test
         env:
           NODE_ENV: production
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install xvfb
+        run: sudo apt-get update -y && sudo apt-get install xvfb
       - name: 👷 Install Dependencies
         run: npm ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🧪 Setup and Test with Runme
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: npx runme run configureNPM setup build test:ci
+        run: xvfb-run npx runme run configureNPM setup build test:ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNME_TEST_TOKEN: ${{ secrets.RUNME_TEST_TOKEN }}


### PR DESCRIPTION
Use native xvfb instead of `coactions/setup-xvfb@v1` because it's failing for GH pipelines. See  https://github.com/coactions/setup-xvfb/issues/19 