### PR TITLE
Start moving away from runme cloud domain/endpoint resolution

### DIFF
--- a/.github/scripts/overwrites/stateful.sh
+++ b/.github/scripts/overwrites/stateful.sh
@@ -12,7 +12,7 @@ npm pkg set contributes.configuration[0].properties[runme.experiments.escalation
 npm pkg set contributes.configuration[0].properties[runme.server.lifecycleIdentity].default=1 --json
 npm pkg set contributes.configuration[0].properties[runme.app.notebookAutoSave].default="yes"
 npm pkg set contributes.configuration[0].properties[runme.app.sessionOutputs].default=false --json
-npm pkg set contributes.configuration[0].properties[runme.app.panel.runme.cloud].default="" --json
+npm pkg set contributes.configuration[0].properties[runme.app.panel.runme.cloud].default="\"\"" --json
 npm pkg set contributes.views.runme[0].name="Platform"
 npm pkg set contributes.viewsContainers.activitybar[0].title="Stateful"
 npm pkg delete galleryBanner

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -30,8 +30,8 @@ export class Uri extends URI {
     /**
      * Allow testing against http endpoints
      */
-    if (uri.authority?.includes('.runme.dev')) {
-      return  `https://testing.runme.dev${path.join(...paths)}`
+    if (uri.authority?.includes('.stateful.com')) {
+      return  `https://testing.stateful.com${path.join(...paths)}`
     }
     return super.file(path.join(uri.fsPath, ...paths))
   })

--- a/src/extension/panels/cloud.ts
+++ b/src/extension/panels/cloud.ts
@@ -72,6 +72,11 @@ export default class CloudPanel extends TanglePanel {
     let staticHtml: string
     try {
       appToken = await this.getAppToken(false).then((appToken) => appToken?.token ?? null)
+    } catch (err: any) {
+      log.error(err?.message || err)
+      appToken = null
+    }
+    try {
       staticHtml = await fetchStaticHtml(this.appUrl).then((r) => r.text())
     } catch (err: any) {
       log.error(err?.message || err)

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -20,9 +20,9 @@ const APP_SECTION_NAME = 'runme.app'
 
 export const OpenViewInEditorAction = z.enum(['split', 'toggle'])
 const DEFAULT_WORKSPACE_FILE_ORDER = ['.env.local', '.env']
-const DEFAULT_RUNME_APP_API_URL = 'https://api.runme.dev'
-const DEFAULT_RUNME_BASE_DOMAIN = 'runme.dev'
-const DEFAULT_RUNME_REMOTE_DEV = 'staging.runme.dev'
+const DEFAULT_RUNME_APP_API_URL = 'https://platform.stateful.com'
+const DEFAULT_RUNME_BASE_DOMAIN = 'platform.stateful.com'
+const DEFAULT_RUNME_REMOTE_DEV = 'staging.platform.stateful.com'
 const APP_LOOPBACKS = ['127.0.0.1', 'localhost']
 const APP_LOOPBACK_MAPPING = new Map<string, string>([
   ['api.', ':4000'],
@@ -363,7 +363,7 @@ const getRunmeAppUrl = (subdomains: string[]): string => {
   }
   const isLoopback = APP_LOOPBACKS.map((host) => base.includes(host)).reduce((p, c) => p || c)
 
-  if (!isLoopback && isPlatformAuthEnabled()) {
+  if (!isLoopback) {
     subdomains = subdomains.map((s) => {
       if (s === 'app') {
         return ''

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -47,6 +47,7 @@ vi.mock('vscode', async () => {
     enableLogger: string | boolean | undefined
     tlsDir: string | undefined
     baseDomain: string | undefined
+    platformAuth: boolean | undefined
     'runme.cloud': string | undefined
   } = {
     port: undefined,
@@ -54,6 +55,7 @@ vi.mock('vscode', async () => {
     enableLogger: undefined,
     tlsDir: undefined,
     baseDomain: undefined,
+    platformAuth: undefined,
     'runme.cloud': undefined,
   }
 
@@ -77,16 +79,16 @@ vi.mock('vscode-telemetry')
 
 suite('Configuration', () => {
   test('should get nullish from font family', () => {
-    expect(getNotebookTerminalConfigurations()).toMatchSnapshot()
+    expect(getNotebookTerminalConfigurations({})).toMatchSnapshot()
     workspace.getConfiguration().update('fontFamily', 'Fira Code')
-    expect(getNotebookTerminalConfigurations().fontFamily).toStrictEqual('Fira Code')
+    expect(getNotebookTerminalConfigurations({}).fontFamily).toStrictEqual('Fira Code')
 
     // example fails because "line" is not valid
     workspace.getConfiguration().update('cursorStyle', 'line')
-    expect(getNotebookTerminalConfigurations().cursorStyle).toStrictEqual(undefined)
+    expect(getNotebookTerminalConfigurations({}).cursorStyle).toStrictEqual(undefined)
 
     workspace.getConfiguration().update('cursorStyle', 'underline')
-    expect(getNotebookTerminalConfigurations().cursorStyle).toStrictEqual('underline')
+    expect(getNotebookTerminalConfigurations({}).cursorStyle).toStrictEqual('underline')
   })
 
   test('should default to a valid port number', () => {
@@ -232,25 +234,24 @@ suite('Configuration', () => {
     })
   })
 
-  suite('app domain resolution', () => {
+  suite.only('app domain resolution', () => {
+    beforeEach(() => {
+      workspace.getConfiguration().update('baseDomain', undefined)
+    })
+
     test('should return URL for api with subdomain', () => {
       const url = getRunmeAppUrl(['api'])
-      expect(url).toStrictEqual('https://api.runme.dev/')
+      expect(url).toStrictEqual('https://api.platform.stateful.com/')
     })
 
     test('should return URL for api with deep subdomain', () => {
       const url = getRunmeAppUrl(['l4', 'l3', 'api'])
-      expect(url).toStrictEqual('https://l4.l3.api.runme.dev/')
+      expect(url).toStrictEqual('https://l4.l3.api.platform.stateful.com/')
     })
 
     test('should return URL without subdomain', () => {
       const url = getRunmeAppUrl([])
-      expect(url).toStrictEqual('https://runme.dev/')
-    })
-
-    test('should return URL without subdomain', () => {
-      const url = getRunmeAppUrl([])
-      expect(url).toStrictEqual('https://runme.dev/')
+      expect(url).toStrictEqual('https://platform.stateful.com/')
     })
 
     test('should allow api URL with http for 127.0.0.1', async () => {
@@ -276,7 +277,24 @@ suite('Configuration', () => {
       const app = getRunmeAppUrl(['app'])
       expect(app).toStrictEqual('http://localhost:4001')
       const api = getRunmeAppUrl(['api'])
-      expect(api).toStrictEqual('https://api.staging.runme.dev/')
+      expect(api).toStrictEqual('https://api.staging.platform.stateful.com/')
+    })
+
+    test('should return URL for api with subdomain for staging', () => {
+      workspace.getConfiguration().update('baseDomain', 'staging.platform.stateful.com')
+      const url = getRunmeAppUrl(['api'])
+      expect(url).toStrictEqual('https://api.staging.platform.stateful.com/')
+    })
+
+    test('should return URL for app with subdomain', () => {
+      const url = getRunmeAppUrl(['app'])
+      expect(url).toStrictEqual('https://platform.stateful.com/')
+    })
+
+    test('should return URL for app with subdomain for staging', () => {
+      workspace.getConfiguration().update('baseDomain', 'staging.platform.stateful.com')
+      const url = getRunmeAppUrl(['app'])
+      expect(url).toStrictEqual('https://staging.platform.stateful.com/')
     })
   })
 

--- a/tests/extension/configuration.test.ts
+++ b/tests/extension/configuration.test.ts
@@ -234,7 +234,7 @@ suite('Configuration', () => {
     })
   })
 
-  suite.only('app domain resolution', () => {
+  suite('app domain resolution', () => {
     beforeEach(() => {
       workspace.getConfiguration().update('baseDomain', undefined)
     })

--- a/tests/extension/panels/panel.test.ts
+++ b/tests/extension/panels/panel.test.ts
@@ -58,7 +58,7 @@ suite('Panel', () => {
       themeKind: 1,
     })
 
-    expect(hydrated).toContain('<base href="https://app.runme.dev/">')
+    expect(hydrated).toContain('<base href="https://platform.stateful.com/">')
     expect(hydrated).toContain(
       '{"appToken":"a.b.c","ide":"code","panelId":"main","defaultUx":"panels","themeKind":1}',
     )
@@ -70,7 +70,7 @@ suite('Panel', () => {
 
     await p.resolveWebviewTelemetryView(view)
 
-    expect(view.webview.html).toContain('<base href="https://app.runme.dev/">')
+    expect(view.webview.html).toContain('<base href="https://platform.stateful.com/">')
     expect(view.webview.html).toContain(
       '{"ide":"code","panelId":"testing","appToken":"webview.auth.token","defaultUx":"panels","themeKind":1}',
     )
@@ -82,7 +82,7 @@ suite('Panel', () => {
 
     await p.resolveWebviewTelemetryView(view)
 
-    expect(view.webview.html).toContain('<base href="https://app.runme.dev/">')
+    expect(view.webview.html).toContain('<base href="https://platform.stateful.com/">')
     expect(view.webview.html).toContain(
       '{"ide":"code","panelId":"testing","appToken":"EMPTY","defaultUx":"panels","themeKind":1}',
     )


### PR DESCRIPTION
This PR moves away from any panels served out of the legacy Runme cloud.

Let's plan for a follow-up effort to remove all non-platform panels/GQL since the backend is considered End Of Life.