### PR TITLE
Platform auth secrets per stage

### DIFF
--- a/src/extension/provider/statefulAuth.ts
+++ b/src/extension/provider/statefulAuth.ts
@@ -54,7 +54,8 @@ const passthrough = (value: any, resolve: (value?: any) => void) => resolve(valu
 
 export class StatefulAuthProvider implements AuthenticationProvider, Disposable {
   #disposables: Disposable[] = []
-  #hashedApiUrl: string = crypto
+  // used as compound key in a hash-table; does not contain sensitive data
+  #insensitiveHashedApiUrl: string = crypto
     .createHash('sha1')
     .update(getRunmeAppUrl(['api']))
     .digest('hex')
@@ -462,7 +463,7 @@ export class StatefulAuthProvider implements AuthenticationProvider, Disposable 
   }
 
   private get sessionSecretKey() {
-    return `${SESSIONS_SECRET_KEY}.${this.#hashedApiUrl}`
+    return `${SESSIONS_SECRET_KEY}.${this.#insensitiveHashedApiUrl}`
   }
 
   private async getAllSessions(): Promise<StatefulAuthSession[]> {

--- a/tests/extension/provider/statefulAuth.test.ts
+++ b/tests/extension/provider/statefulAuth.test.ts
@@ -1,23 +1,33 @@
+import * as crypto from 'node:crypto'
+
 import { expect, vi, beforeEach, describe, it } from 'vitest'
 import { Uri, ExtensionContext } from 'vscode'
 
 import { StatefulAuthProvider } from '../../../src/extension/provider/statefulAuth'
 import { RunmeUriHandler } from '../../../src/extension/handler/uri'
+import { getRunmeAppUrl } from '../../../src/utils/configuration'
 
 vi.mock('vscode')
 vi.mock('vscode-telemetry')
+
+vi.mock('../../../src/utils/configuration', () => {
+  return {
+    getRunmeAppUrl: vi.fn(),
+  }
+})
+
+const contextFake: ExtensionContext = {
+  extensionUri: Uri.parse('file:///Users/fakeUser/projects/vscode-runme'),
+} as any
+
+const uriHandlerFake: RunmeUriHandler = {} as any
 
 describe('StatefulAuthProvider', () => {
   let provider: StatefulAuthProvider
 
   beforeEach(() => {
-    const contextMock: ExtensionContext = {
-      extensionUri: Uri.parse('file:///Users/fakeUser/projects/vscode-runme'),
-    } as any
-
-    const uriHandler: RunmeUriHandler = {} as any
-
-    provider = new StatefulAuthProvider(contextMock, uriHandler)
+    vi.mocked(getRunmeAppUrl).mockReturnValue('https://api.for.platform')
+    provider = new StatefulAuthProvider(contextFake, uriHandlerFake)
   })
 
   it('gets sessions', async () => {
@@ -28,5 +38,32 @@ describe('StatefulAuthProvider', () => {
   it('gets sessions with specific scopes', async () => {
     const sessions = await provider.getSessions(['profile'])
     expect(sessions).toEqual([])
+  })
+})
+
+describe('StatefulAuthProvider#sessionSecretKey', () => {
+  let provider: StatefulAuthProvider
+
+  it('returns a secret key for production', () => {
+    provider = new StatefulAuthProvider(contextFake, uriHandlerFake)
+
+    // access private prop
+    expect((provider as any).sessionSecretKey).toEqual(
+      'stateful.sessions.8e0b4f45d990c8b235d4036020299d4af5c8c4a0',
+    )
+  })
+
+  it('includes a hashed URL of the stage into the secret key', () => {
+    const fakeStagingUrl = 'https://api.staging.for.platform'
+    vi.mocked(getRunmeAppUrl).mockReturnValue(fakeStagingUrl)
+
+    provider = new StatefulAuthProvider(contextFake, uriHandlerFake)
+    const hashed = crypto.createHash('sha1').update(fakeStagingUrl).digest('hex')
+
+    // access private prop
+    const sessionSecretKey = (provider as any).sessionSecretKey
+
+    expect(sessionSecretKey).toContain(hashed)
+    expect(sessionSecretKey).toEqual('stateful.sessions.5d458b91cb755f8e839839dd3d1b4d597bba2c11')
   })
 })


### PR DESCRIPTION
I believe the reason why we see "false positive" errors when switching stages is that auth tokens aren't valid across stages (staging, prod, etc). The solution is fairly simple by stashing the token into the secrets store under keys that are unique to the stages.