### PR TITLE
Simplify and remove deletion of cell ID

### DIFF
--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -203,18 +203,13 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
   public static async addExecInfo(data: NotebookData, kernel: Kernel): Promise<NotebookCellData[]> {
     return Promise.all(
       data.cells.map(async (cell) => {
-        let terminalOutput: NotebookCellOutputWithProcessInfo | undefined
         let id: string = ''
-        for (const out of cell.outputs || []) {
-          Object.entries(out.metadata ?? {}).find(([k, v]) => {
-            if (k === 'runme.dev/id') {
-              terminalOutput = out
-              id = v
-            }
-          })
+        let terminalOutput: NotebookCellOutputWithProcessInfo | undefined
 
-          if (terminalOutput) {
-            delete out.metadata?.['runme.dev/id']
+        for (const cellOutput of cell.outputs || []) {
+          id = cell.metadata?.['runme.dev/id'] || cell.metadata?.['id'] || ''
+          if (id) {
+            terminalOutput = cellOutput
             break
           }
         }

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -141,7 +141,9 @@ function getCellId(cell: vscode.NotebookCell): string {
     throw new Error('Cannot get cell ID for non-code cell!')
   }
 
-  return getAnnotations(cell)['runme.dev/id']!
+  const annotations = getAnnotations(cell)
+
+  return annotations['runme.dev/id'] || annotations['id'] || ''
 }
 
 export function getTerminalByCell(cell: vscode.NotebookCell): RunmeTerminal | undefined {


### PR DESCRIPTION
The deletion of the cell ID causes downstream issues. It also needs to be clarified why it was required in the first place.

I removed the logic to test it for a few days in pre-release.