### PR TITLE
POC to recover previous dagger state

### DIFF
--- a/dagger/Pipeline.md
+++ b/dagger/Pipeline.md
@@ -11,7 +11,10 @@ One function's output is being used as another function's input. This is a commo
 
 In this notebook, we will explore how to express such pipelines using Dagger inside a literal notebook environment. As an example, we build and bundle this VS Code extension.
 
-> 💡 This demo is using a "slightly" modified version of the dagger binary based on https://github.com/dagger/dagger/pull/7479.
+```sh {"id":"01J4WF41PRJZAMC6DYK4VMKMEE","promptEnv":"no"}
+export PROGRESS="plain"
+echo "Using Dagger's ${PROGRESS} progress logger"
+```
 
 ### Build the Kernel Binary
 

--- a/examples/dagger/Notebook.md
+++ b/examples/dagger/Notebook.md
@@ -29,5 +29,3 @@ dagger --progress=plain \
     container \
         --packages=cowsay
 ```
-
-👉 Let's continue over here with the [pipeline demo](../../dagger/Pipeline.md).

--- a/examples/dagger/Notebook.md
+++ b/examples/dagger/Notebook.md
@@ -9,9 +9,9 @@ Showcase the notebook experience to **author, debug, express, and run** Dagger p
 ### Let's use a Dagger function to build the Runme binary
 
 ```sh {"id":"01HZSMYF33TFKMEVRX5P64BNTB","interactive":"true","name":"RUNME_BINARY"}
-dagger --progress=$PROGRESS \
+dagger --progress=plain \
     call \
-        -m github.com/purpleclay/daggerverse/golang@7e83bccc350fa981e975ac0c8619f92a1b729958 \
+        -m github.com/purpleclay/daggerverse/golang@v0.3.0 \
         --src "https://github.com/stateful/runme#main" \
     build \
         --arch $(go env GOARCH) \
@@ -25,7 +25,7 @@ dagger --progress=$PROGRESS \
 ```sh {"id":"01J022WD7Z6TM1QQ075X09BTK4","interactive":"true","name":"COWSAY"}
 dagger --progress=plain \
     call \
-        -m github.com/shykes/daggerverse/wolfi@v0.1.2 \
+        -m github.com/shykes/daggerverse/wolfi@v0.1.4 \
     container \
         --packages=cowsay
 ```

--- a/src/client/components/dagger.ts
+++ b/src/client/components/dagger.ts
@@ -189,6 +189,15 @@ export class DaggerCli extends LitElement {
   connectedCallback(): void {
     super.connectedCallback()
     const ctx = getContext()
+
+    if (this.state.json) {
+      this.#applyState({
+        id: this.cellId,
+        cellId: this.cellId,
+        json: this.state.json,
+      })
+    }
+
     this.disposables.push(
       onClientMessage(ctx, async (e) => {
         switch (e.type) {

--- a/src/client/components/dagger.ts
+++ b/src/client/components/dagger.ts
@@ -190,11 +190,11 @@ export class DaggerCli extends LitElement {
     super.connectedCallback()
     const ctx = getContext()
 
-    if (this.state.json) {
+    if (this.state.jsonOutput) {
       this.#applyState({
         id: this.cellId,
         cellId: this.cellId,
-        json: this.state.json,
+        json: this.state.jsonOutput,
       })
     }
 

--- a/src/client/components/dagger.ts
+++ b/src/client/components/dagger.ts
@@ -190,11 +190,17 @@ export class DaggerCli extends LitElement {
     super.connectedCallback()
     const ctx = getContext()
 
-    if (this.state.jsonOutput) {
+    if (this.state.output?.json) {
       this.#applyState({
         id: this.cellId,
         cellId: this.cellId,
-        json: this.state.jsonOutput,
+        json: JSON.parse(this.state.output?.json),
+      })
+    } else if (this.state.output?.text) {
+      this.#applyState({
+        id: this.cellId,
+        cellId: this.cellId,
+        text: this.state.output?.text,
       })
     }
 

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -179,17 +179,18 @@ export class NotebookCellOutputManager {
       }
 
       case OutputType.dagger: {
+        const cellId = cell.metadata['runme.dev/id']
         const payload: CellOutputPayload<OutputType.dagger> = {
           type: OutputType.dagger,
-          output: { cellId: cell.metadata['runme.dev/id'] },
+          output: { cellId },
         }
 
-        const state = this.daggerState[cell.metadata['runme.dev/id']]
+        const jsonOutput = this.daggerState[cellId]
 
-        if (state) {
+        if (jsonOutput) {
           payload.output = {
             ...payload.output,
-            json: state,
+            jsonOutput: jsonOutput,
           }
         }
 
@@ -329,6 +330,10 @@ export class NotebookCellOutputManager {
 
   saveDaggerState(cellId: string, value: any) {
     this.daggerState[cellId] = value
+  }
+
+  cleanDaggerState(cellId: string) {
+    delete this.daggerState[cellId]
   }
 
   registerCellTerminalState(type: NotebookTerminalType): ITerminalState {

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -185,13 +185,11 @@ export class NotebookCellOutputManager {
           output: { cellId },
         }
 
-        const jsonOutput = this.outputsState?.get?.(type)?.get?.(cellId)
+        const output = this.outputsState?.get?.(type)?.get?.(cellId)
 
-        if (jsonOutput) {
-          payload.output = {
-            ...payload.output,
-            jsonOutput: jsonOutput,
-          }
+        payload.output = {
+          ...payload.output,
+          output: { json: output?.json, text: output?.text },
         }
 
         return new NotebookCellOutput([NotebookCellOutputItem.json(payload, OutputType.dagger)], {

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -150,6 +150,7 @@ export class NotebookCellOutputManager {
 
   protected terminalState?: ITerminalState
   protected terminalEnabled = false
+  protected daggerState: Record<string, any> = {}
 
   constructor(
     protected cell: NotebookCell,
@@ -181,6 +182,15 @@ export class NotebookCellOutputManager {
         const payload: CellOutputPayload<OutputType.dagger> = {
           type: OutputType.dagger,
           output: { cellId: cell.metadata['runme.dev/id'] },
+        }
+
+        const state = this.daggerState[cell.metadata['runme.dev/id']]
+
+        if (state) {
+          payload.output = {
+            ...payload.output,
+            json: state,
+          }
         }
 
         return new NotebookCellOutput([NotebookCellOutputItem.json(payload, OutputType.dagger)], {
@@ -315,6 +325,10 @@ export class NotebookCellOutputManager {
         return undefined
       }
     }
+  }
+
+  saveDaggerState(cellId: string, value: any) {
+    this.daggerState[cellId] = value
   }
 
   registerCellTerminalState(type: NotebookTerminalType): ITerminalState {

--- a/src/extension/executors/dagger.ts
+++ b/src/extension/executors/dagger.ts
@@ -14,7 +14,7 @@ export const dagger: IKernelExecutor = async (executor) => {
     updateCellMetadata(exec.cell, {
       'runme.dev/daggerState': {},
     })
-    outputs.showOutput(OutputType.vercel)
+    outputs.showOutput(OutputType.dagger)
 
     return false
   }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -211,6 +211,11 @@ export class Kernel implements Disposable {
     outputs.saveDaggerState(cell.metadata?.['runme.dev/id'], value)
   }
 
+  async cleanDaggerState(cell: NotebookCell) {
+    const outputs = await this.getCellOutputs(cell)
+    outputs.cleanDaggerState(cell.metadata?.['runme.dev/id'])
+  }
+
   async registerCellTerminalState(
     cell: NotebookCell,
     type: NotebookTerminalType,
@@ -834,6 +839,7 @@ export class Kernel implements Disposable {
       const runSecondary = () => {
         return runUriResource({ ...runnerOpts, runScript: notify })
       }
+      this.cleanDaggerState(runnerOpts.exec.cell)
       return this.executeRunnerSafe({ ...runnerOpts, runScript: runSecondary })
     }
 

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -206,6 +206,11 @@ export class Kernel implements Disposable {
     return (await this.getCellOutputs(cell)).getCellTerminalState()
   }
 
+  async saveDaggerState(cell: NotebookCell, value: any) {
+    const outputs = await this.getCellOutputs(cell)
+    outputs.saveDaggerState(cell.metadata?.['runme.dev/id'], value)
+  }
+
   async registerCellTerminalState(
     cell: NotebookCell,
     type: NotebookTerminalType,
@@ -788,47 +793,49 @@ export class Kernel implements Disposable {
       return runUriResource(opts)
     }
 
-    // if (execKey === 'dagger' && supportsGrpcRunner) {
-    //   const notify = (res?: string): Promise<boolean> => {
-    //     try {
-    //       const daggerJsonParsed = JSON.parse(res || '{}')
-    //       daggerJsonParsed.runme = { cellText: runnerOpts.runningCell.getText() }
-    //       return new Promise<boolean>((resolve) => {
-    //         this.messaging
-    //           .postMessage(<ClientMessage<ClientMessages.daggerSyncState>>{
-    //             type: ClientMessages.daggerSyncState,
-    //             output: {
-    //               id: runnerOpts.cellId,
-    //               cellId: runnerOpts.cellId,
-    //               json: daggerJsonParsed,
-    //             },
-    //           })
-    //           .then(() => resolve(true))
-    //       })
-    //     } catch (e) {
-    //       // not a fatal error
-    //       if (e instanceof Error) {
-    //         console.error(e.message)
-    //       }
-    //       return new Promise<boolean>((resolve) => {
-    //         this.messaging
-    //           .postMessage(<ClientMessage<ClientMessages.daggerSyncState>>{
-    //             type: ClientMessages.daggerSyncState,
-    //             output: {
-    //               id: runnerOpts.cellId,
-    //               cellId: runnerOpts.cellId,
-    //               text: res,
-    //             },
-    //           })
-    //           .then(() => resolve(true))
-    //       })
-    //     }
-    //   }
-    //   const runSecondary = () => {
-    //     return runUriResource({ ...runnerOpts, runScript: notify })
-    //   }
-    //   return this.executeRunnerSafe({ ...runnerOpts, runScript: runSecondary })
-    // }
+    if (execKey === 'dagger' && supportsGrpcRunner) {
+      const notify = async (res?: string): Promise<boolean> => {
+        try {
+          const daggerJsonParsed = JSON.parse(res || '{}')
+          daggerJsonParsed.runme = { cellText: runnerOpts.runningCell.getText() }
+          await this.saveDaggerState(runnerOpts.exec.cell, daggerJsonParsed)
+
+          return new Promise<boolean>((resolve) => {
+            this.messaging
+              .postMessage(<ClientMessage<ClientMessages.daggerSyncState>>{
+                type: ClientMessages.daggerSyncState,
+                output: {
+                  id: runnerOpts.cellId,
+                  cellId: runnerOpts.cellId,
+                  json: daggerJsonParsed,
+                },
+              })
+              .then(() => resolve(true))
+          })
+        } catch (e) {
+          // not a fatal error
+          if (e instanceof Error) {
+            console.error(e.message)
+          }
+          return new Promise<boolean>((resolve) => {
+            this.messaging
+              .postMessage(<ClientMessage<ClientMessages.daggerSyncState>>{
+                type: ClientMessages.daggerSyncState,
+                output: {
+                  id: runnerOpts.cellId,
+                  cellId: runnerOpts.cellId,
+                  text: res,
+                },
+              })
+              .then(() => resolve(true))
+          })
+        }
+      }
+      const runSecondary = () => {
+        return runUriResource({ ...runnerOpts, runScript: notify })
+      }
+      return this.executeRunnerSafe({ ...runnerOpts, runScript: runSecondary })
+    }
 
     return executorByKey(executorOpts)
   }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -806,7 +806,9 @@ export class Kernel implements Disposable {
         try {
           const daggerJsonParsed = JSON.parse(res || '{}')
           daggerJsonParsed.runme = { cellText: runnerOpts.runningCell.getText() }
-          await this.saveOutputState(runnerOpts.exec.cell, OutputType.dagger, daggerJsonParsed)
+          await this.saveOutputState(runnerOpts.exec.cell, OutputType.dagger, {
+            json: JSON.stringify(daggerJsonParsed),
+          })
 
           return new Promise<boolean>((resolve) => {
             this.messaging
@@ -825,6 +827,11 @@ export class Kernel implements Disposable {
           if (e instanceof Error) {
             console.error(e.message)
           }
+
+          await this.saveOutputState(runnerOpts.exec.cell, OutputType.dagger, {
+            text: res,
+          })
+
           return new Promise<boolean>((resolve) => {
             this.messaging
               .postMessage(<ClientMessage<ClientMessages.daggerSyncState>>{

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,7 +155,7 @@ export type DaggerStateAction = {
 
 export interface DaggerState {
   cellId?: string
-  json?: string
+  jsonOutput?: string
   cli?: {
     status: string
     actions: [DaggerStateAction]

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,7 @@ export type DaggerStateAction = {
 
 export interface DaggerState {
   cellId?: string
+  json?: string
   cli?: {
     status: string
     actions: [DaggerStateAction]

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,7 +155,10 @@ export type DaggerStateAction = {
 
 export interface DaggerState {
   cellId?: string
-  jsonOutput?: string
+  output?: {
+    json?: string
+    text?: string
+  }
   cli?: {
     status: string
     actions: [DaggerStateAction]


### PR DESCRIPTION
This update introduces support for persisting the latest Dagger output. This ensures that the Dagger component’s state remains intact when interacting with cell outputs, such as adjusting settings, and preventing any potential loss of data or state during such interactions.

Closes: #1490 
