### PR TITLE
Make ghost cells executable by preserving the runme.dev/id metadata

### DIFF
--- a/src/extension/ai/ghost.ts
+++ b/src/extension/ai/ghost.ts
@@ -335,8 +335,9 @@ export function handleOnDidChangeActiveTextEditor(editor: vscode.TextEditor | un
   if (!isGhostCell(cell)) {
     return
   }
-
-  const update = vscode.NotebookEdit.updateCellMetadata(cell.index, { [ghostKey]: false })
+  // ...cell.metadata creates a shallow copy of the metadata object
+  const updatedMetadata = { ...cell.metadata, [ghostKey]: false }
+  const update = vscode.NotebookEdit.updateCellMetadata(cell.index, updatedMetadata)
   const edit = new vscode.WorkspaceEdit()
   edit.set(editor.document.uri, [update])
   vscode.workspace.applyEdit(edit).then((result: boolean) => {


### PR DESCRIPTION
Fix jlewi/foyle#188

The reason newly added ghost cells aren't executable is because they they lack a runme.dev/id metadata. This field gets set when cells are inserted but it was being removed by the code that updates the cell to set ghost to false. This updateMetadata calls was replacing the entire metadata with a new dictionary and not just updating it. So to fix it we need to pass in a dictionary that contains existing metadata that we want to preserve.