### PR TITLE
Exclude GitHub Action e2e Tests for Dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           RUNME_TEST_TOKEN: ${{ secrets.RUNME_TEST_TOKEN }}
           RUNME_PROJECT: ${{ github.workspace }}
           SHELL: bash
+          GITHUB_ACTOR: ${{ github.actor }}
       - name: 🔼 Upload Artifacts
         uses: actions/upload-artifact@v3
         if: failure()

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -12,7 +12,11 @@ describe('Runme GitHub Workflow Integration', async () => {
   /**
    * Skip GitHub Action tests for local testing due to missing token
    */
-  if ((!token && !process.env.CI) || process.env.NODE_ENV === 'production') {
+  if (
+    (!token && !process.env.CI) ||
+    process.env.NODE_ENV === 'production' ||
+    process.env.GITHUB_ACTOR === 'dependabot[bot]'
+  ) {
     return
   }
 


### PR DESCRIPTION
Excludes the end-to-end test that always fails due to permissions. Additionally, the auto-merge was disabled because we are doing it manually.

Having a CI passing ✅  helps to diagnose potential breaking changes in advance.