### PR TITLE
Bug fix: AIManager doesn't properly get the configuration for baseURL

### DIFF
--- a/src/extension/ai/manager.ts
+++ b/src/extension/ai/manager.ts
@@ -17,12 +17,11 @@ export class AIManager {
   client: PromiseClient<typeof AIService>
   completionGenerator: generate.CompletionGenerator
   constructor() {
-    const config = vscode.workspace.getConfiguration('runme.experiments')
-    const autoComplete = config.get<boolean>('aiAutoCell', false)
-
-    this.client = this.createAIClient()
     this.log = getLogger('AIManager')
     this.log.info('AI: Initializing AI Manager')
+    const config = vscode.workspace.getConfiguration('runme.experiments')
+    const autoComplete = config.get<boolean>('aiAutoCell', false)
+    this.client = this.createAIClient()
     this.completionGenerator = new generate.CompletionGenerator(this.client)
     if (autoComplete) {
       this.registerGhostCellEvents()
@@ -33,17 +32,7 @@ export class AIManager {
   createAIClient = (): PromiseClient<typeof AIService> => {
     const config = vscode.workspace.getConfiguration('runme')
     const baseURL = config.get<string>('aiBaseURL', 'http://localhost:8877/api')
-    // TODO(jeremy): The log.info statements prevents the extension from loading at least in debug
-    // mode. My suspicion
-    // is that createAIClient is invoked from the constructor which is invoked at extension
-    // loading time. In logger.ts there is a call to outputChannel = window.createOutputChannel('Runme')
-    // to setup the outputChannel. I wonder if that creates a race condition.
-    // The problem seemed to happen if I call console.log as well. It seemed somewhat intermittent
-    // Which would be consistent with a race condition. I wonder if the problem is specific to
-    // running in debug mode?
-    // this.log.info('AI: Using AI service at: ' + baseURL)
-    // this.log.info(`AI: Using AI service at: ${baseURL}`)
-    // console.log(`AI: Using AI service at ${baseURL}`)
+    this.log.info(`AI: Using AI service at: ${baseURL}`)
     return createPromiseClient(AIService, createDefaultTransport(baseURL))
   }
 

--- a/src/extension/ai/manager.ts
+++ b/src/extension/ai/manager.ts
@@ -22,16 +22,28 @@ export class AIManager {
 
     this.client = this.createAIClient()
     this.log = getLogger('AIManager')
-
+    this.log.info('AI: Initializing AI Manager')
     this.completionGenerator = new generate.CompletionGenerator(this.client)
     if (autoComplete) {
       this.registerGhostCellEvents()
     }
   }
 
-  createAIClient(): PromiseClient<typeof AIService> {
+  // N.B. We use arrow notation to ensure this is bound to the AIManager instance.
+  createAIClient = (): PromiseClient<typeof AIService> => {
     const config = vscode.workspace.getConfiguration('runme')
-    const baseURL = config.get<string>('runme.aiBaseURL', 'http://localhost:8877/api')
+    const baseURL = config.get<string>('aiBaseURL', 'http://localhost:8877/api')
+    // TODO(jeremy): The log.info statements prevents the extension from loading at least in debug
+    // mode. My suspicion
+    // is that createAIClient is invoked from the constructor which is invoked at extension
+    // loading time. In logger.ts there is a call to outputChannel = window.createOutputChannel('Runme')
+    // to setup the outputChannel. I wonder if that creates a race condition.
+    // The problem seemed to happen if I call console.log as well. It seemed somewhat intermittent
+    // Which would be consistent with a race condition. I wonder if the problem is specific to
+    // running in debug mode?
+    // this.log.info('AI: Using AI service at: ' + baseURL)
+    // this.log.info(`AI: Using AI service at: ${baseURL}`)
+    // console.log(`AI: Using AI service at ${baseURL}`)
     return createPromiseClient(AIService, createDefaultTransport(baseURL))
   }
 

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -75,7 +75,7 @@ test('initializes all providers', async () => {
   const configValues = {
     binaryPath: 'bin',
     // This is needed for the AIManager to initialize.
-    'runme.aiBaseURL': 'http://localhost:8877/api',
+    aiBaseURL: 'http://localhost:8877/api',
   }
   vi.mocked(workspace.getConfiguration).mockReturnValue({
     get: vi.fn((config: string) => configValues[config]),


### PR DESCRIPTION
* We weren't actually reading the baseURL from the config because the key should be "aiBaseURL" not "runme.aiBaseURL"

* I tried to add logging to ensure we know what the actual value of the endpoint is but that seemed to prevent the extension from loading.