### PR TITLE
Running e2e tests using VSCode v1.92.2

### DIFF
--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -93,7 +93,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: 'stable',
+      browserVersion: '1.92.2',
       'wdio:vscodeOptions': {
         extensionPath,
         workspacePath: extensionPath,


### PR DESCRIPTION
Tests are not working using the latest VS Code v1.93.0

```
connect ECONNREFUSED 127.0.0.1:61195
[0-5] RequestError in "Test suite: Empty file with setting All (1).should not remove the front matter with the identity"
RequestError: socket hang up
    at ClientRequest.<anonymous> (file:///Users/cristian/Code/vscode-runme/tests/e2e/node_modules/got/dist/source/core/index.js:790:107)
    at Object.onceWrapper (node:events:632:26)
    at ClientRequest.emit (node:events:529:35)
    at ClientRequest.emit (node:domain:489:12)
    at Socket.socketOnEnd (node:_http_client:525:9)
    at Socket.emit (node:events:529:35)
    at Socket.emit (node:domain:489:12)
    at endReadableNT (node:internal/streams/readable:1400:12)
    at connResetException (node:internal/errors:720:14)
    at Socket.socketOnEnd (node:_http_client:525:23)
    at Socket.emit (node:events:529:35)
    at Socket.emit (node:domain:489:12)
    at endReadableNT (node:internal/streams/readable:1400:12)
```    