### PR TITLE
Going back to the latest stable VS Code version to perform e2e tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,19 +159,19 @@ npm run bundle
 
 The Runme project has several test stages that you can run individually or as a whole:
 
-```sh {"id":"01HF7VQMH8ESX1EFV4PFZ87Q58","name":"test"}
+```sh {"id":"01HF7VQMH8ESX1EFV4PFZ87Q58","name":"test","promptEnv":"no"}
 export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"
 npx runme run test:format test:lint test:unit test:e2e
 ```
 
-```sh {"id":"01J5VPD3TXY1EAZDCXNHN60S77"}
+```sh {"id":"01J5VPD3TXY1EAZDCXNHN60S77","promptEnv":"no"}
 export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"
-npx runme run test:format test:lint test:unit 
+npx runme run test:format test:lint test:unit
 ```
 
 When testing in CI environment, run:
 
-```sh {"id":"01HF7VQMH8ESX1EFV4PGJBDGG0","name":"test:ci"}
+```sh {"id":"01HF7VQMH8ESX1EFV4PGJBDGG0","name":"test:ci","promptEnv":"no"}
 export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"
 npx runme run test:format test:lint test:unit test:e2e:ci
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "@wdio/local-runner": "^8.40.5",
         "@wdio/mocha-framework": "^8.40.3",
         "@wdio/spec-reporter": "^8.40.3",
-        "chromedriver": "^128.0.3",
+        "chromedriver": "^129.0.0",
         "comment-json": "^4.2.5",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.0.0",
@@ -10793,9 +10793,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "128.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-128.0.3.tgz",
-      "integrity": "sha512-Xn/bknOpGlY9tKinwS/hVWeNblSeZvbbJbF8XZ73X1jeWfAFPRXx3fMLdNNz8DqruDbx3cKEJ5wR3mnst6G3iw==",
+      "version": "129.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-129.0.0.tgz",
+      "integrity": "sha512-B1ccqD6hDjNrw94FeqdynIotn1ZV/TnFrkRz2Rync2kzSnq6D6IrSkN1w5Pnuvnc98QhN2xujxDXxkqEqy/PWg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1181,7 +1181,7 @@
     "@wdio/local-runner": "^8.40.5",
     "@wdio/mocha-framework": "^8.40.3",
     "@wdio/spec-reporter": "^8.40.3",
-    "chromedriver": "^128.0.3",
+    "chromedriver": "^129.0.0",
     "comment-json": "^4.2.5",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -346,6 +346,36 @@
         "category": "Runme",
         "title": "Click to select your environment",
         "shortTitle": "Environments"
+      },
+      {
+        "command": "runme.lifecycleIdentityAll",
+        "title": "Lifecycle Identity - All",
+        "category": "Runme",
+        "description": "Turns on Lifecycle Identity"
+      },
+      {
+        "command": "runme.lifecycleIdentityNone",
+        "title": "Lifecycle Identity - None",
+        "category": "Runme",
+        "description": "Lifecycle Identity - None"
+      },
+      {
+        "command": "runme.lifecycleIdentityAll",
+        "title": "Lifecycle Identity - All",
+        "category": "Runme",
+        "description": "Lifecycle Identity - All"
+      },
+      {
+        "command": "runme.lifecycleIdentityDoc",
+        "title": "Lifecycle Identity - Document",
+        "category": "Runme",
+        "description": "Lifecycle Identity - Document"
+      },
+      {
+        "command": "runme.lifecycleIdentityCell",
+        "title": "Lifecycle Identity - Cell",
+        "category": "Runme",
+        "description": "Lifecycle Identity - Cell"
       }
     ],
     "menus": {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -348,6 +348,22 @@ export class RunmeExtension {
         openFileAsRunmeNotebook(outputFilePath)
       }),
 
+      RunmeExtension.registerCommand('runme.lifecycleIdentityNone', () =>
+        ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.UNSPECIFIED),
+      ),
+
+      RunmeExtension.registerCommand('runme.lifecycleIdentityAll', () =>
+        ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.ALL),
+      ),
+
+      RunmeExtension.registerCommand('runme.lifecycleIdentityDoc', () =>
+        ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.DOCUMENT),
+      ),
+
+      RunmeExtension.registerCommand('runme.lifecycleIdentityCell', () =>
+        ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.CELL),
+      ),
+
       // Register a command to generate completions using foyle
       RunmeExtension.registerCommand(
         'runme.aiGenerate',

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -9,7 +9,7 @@
         "@wdio/local-runner": "^8.40.2",
         "@wdio/mocha-framework": "^8.40.3",
         "@wdio/spec-reporter": "^8.27.2",
-        "chromedriver": "^127.0.3",
+        "chromedriver": "^129.0.0",
         "comment-json": "^4.2.5",
         "expect-webdriverio": "^4.15.4",
         "runme": "^3.0.1",
@@ -2063,9 +2063,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chromedriver": {
-      "version": "127.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-127.0.3.tgz",
-      "integrity": "sha512-trUHkFt0n7jGzNOgkO1srOJfz50kKyAGJ016PyV0hrtyKNIGnOC9r3Jlssz19UoEjSzI/1g2shEiIFtDbBYVaw==",
+      "version": "129.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-129.0.0.tgz",
+      "integrity": "sha512-B1ccqD6hDjNrw94FeqdynIotn1ZV/TnFrkRz2Rync2kzSnq6D6IrSkN1w5Pnuvnc98QhN2xujxDXxkqEqy/PWg==",
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -9,7 +9,7 @@
         "@wdio/local-runner": "^8.40.2",
         "@wdio/mocha-framework": "^8.40.3",
         "@wdio/spec-reporter": "^8.27.2",
-        "chromedriver": "^127.0.2",
+        "chromedriver": "^127.0.3",
         "comment-json": "^4.2.5",
         "expect-webdriverio": "^4.15.4",
         "runme": "^3.0.1",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -7,7 +7,7 @@
     "@wdio/local-runner": "^8.40.2",
     "@wdio/mocha-framework": "^8.40.3",
     "@wdio/spec-reporter": "^8.27.2",
-    "chromedriver": "^127.0.2",
+    "chromedriver": "^127.0.3",
     "comment-json": "^4.2.5",
     "expect-webdriverio": "^4.15.4",
     "runme": "^3.0.1",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -7,7 +7,7 @@
     "@wdio/local-runner": "^8.40.2",
     "@wdio/mocha-framework": "^8.40.3",
     "@wdio/spec-reporter": "^8.27.2",
-    "chromedriver": "^127.0.3",
+    "chromedriver": "^129.0.0",
     "comment-json": "^4.2.5",
     "expect-webdriverio": "^4.15.4",
     "runme": "^3.0.1",

--- a/tests/e2e/specs/identity/identity.empty-file.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.all.e2e.ts
@@ -1,16 +1,6 @@
 import { Key } from 'webdriverio'
 
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -24,6 +14,9 @@ describe('Test suite: Empty file with setting All (1)', async () => {
   })
 
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - All')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/empty-file.md`),
@@ -45,8 +38,6 @@ describe('Test suite: Empty file with setting All (1)', async () => {
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/empty-file.md')
 
-    await updateLifecycleIdentitySetting(1)
-    await reloadWindow()
     await saveFile(browser)
     await assertDocumentContainsSpinner(absDocPath, '')
   })

--- a/tests/e2e/specs/identity/identity.empty-file.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.all.e2e.ts
@@ -8,8 +8,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.empty-file.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.all.e2e.ts
@@ -8,8 +8,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.empty-file.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.cell.e2e.ts
@@ -8,8 +8,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.empty-file.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.cell.e2e.ts
@@ -1,16 +1,6 @@
 import { Key } from 'webdriverio'
 
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -23,6 +13,9 @@ describe('Test suite: Empty file with setting Cell (3)', async () => {
     await removeAllNotifications()
   })
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - Cell')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/empty-file.md`),
@@ -44,8 +37,6 @@ describe('Test suite: Empty file with setting Cell (3)', async () => {
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/empty-file.md')
 
-    await updateLifecycleIdentitySetting(3)
-    await reloadWindow()
     await saveFile(browser)
     await assertDocumentContainsSpinner(absDocPath, '')
   })

--- a/tests/e2e/specs/identity/identity.empty-file.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.cell.e2e.ts
@@ -8,8 +8,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.empty-file.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.document.e2e.ts
@@ -8,8 +8,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.empty-file.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.document.e2e.ts
@@ -1,16 +1,6 @@
 import { Key } from 'webdriverio'
 
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -24,6 +14,9 @@ describe('Test suite: Empty file with setting Document (2)', async () => {
   })
 
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - Doc')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/empty-file.md`),
@@ -45,8 +38,6 @@ describe('Test suite: Empty file with setting Document (2)', async () => {
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/empty-file.md')
 
-    await updateLifecycleIdentitySetting(2)
-    await reloadWindow()
     await saveFile(browser)
     await assertDocumentContainsSpinner(absDocPath, '')
   })

--- a/tests/e2e/specs/identity/identity.empty-file.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.document.e2e.ts
@@ -8,8 +8,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.empty-file.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.none.e2e.ts
@@ -8,8 +8,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.empty-file.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.none.e2e.ts
@@ -1,16 +1,6 @@
 import { Key } from 'webdriverio'
 
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -24,6 +14,9 @@ describe('Test suite: Empty file with setting None (0)', async () => {
   })
 
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - None')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/empty-file.md`),
@@ -45,8 +38,6 @@ describe('Test suite: Empty file with setting None (0)', async () => {
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/empty-file.md')
 
-    await updateLifecycleIdentitySetting(0)
-    await reloadWindow()
     await saveFile(browser)
     await assertDocumentContainsSpinner(absDocPath, '', true)
   })

--- a/tests/e2e/specs/identity/identity.empty-file.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.empty-file.none.e2e.ts
@@ -8,8 +8,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -25,7 +15,11 @@ describe('Test suite: Cell with existent identity and setting All (1)', async ()
   })
 
   const notebook = new RunmeNotebook()
+
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - All')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/existent-cell-id.md`),
@@ -47,10 +41,8 @@ describe('Test suite: Cell with existent identity and setting All (1)', async ()
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/existent-cell-id.md')
 
-    await updateLifecycleIdentitySetting(1)
-    await reloadWindow()
-    await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
+    await notebook.focusDocument()
     await workbench.executeCommand('Notebook: Focus First Cell')
     await browser.keys([Key.Enter])
     const cell = await notebook.getCell('console.log("Hello via Shebang")')

--- a/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.all.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-cell.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.cell.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-cell.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.cell.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-cell.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.cell.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Cell with existent identity and setting cell only (3)', as
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - Cell')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/existent-cell-id.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Cell with existent identity and setting cell only (3)', as
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/existent-cell-id.md')
 
-    await updateLifecycleIdentitySetting(3)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.document.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Cell with existent identity and setting document only (2)'
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - Doc')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/existent-cell-id.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Cell with existent identity and setting document only (2)'
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/existent-cell-id.md')
 
-    await updateLifecycleIdentitySetting(2)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Cell with existent identity and setting None (0)', async (
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - None')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/existent-cell-id.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Cell with existent identity and setting None (0)', async (
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/existent-cell-id.md')
 
-    await updateLifecycleIdentitySetting(0)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-cell.none.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Document with existent identity and setting All (1)', asyn
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - All')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/existent-doc-id.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Document with existent identity and setting All (1)', asyn
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/existent-doc-id.md')
 
-    await updateLifecycleIdentitySetting(1)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.all.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.cell.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.cell.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Document with existent identity and setting Cell only (3)'
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - Cell')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/existent-doc-id.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Document with existent identity and setting Cell only (3)'
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/existent-doc-id.md')
 
-    await updateLifecycleIdentitySetting(3)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.existent-doc.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.cell.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
@@ -4,19 +4,9 @@ import path from 'node:path'
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateSettings,
-} from '../../helpers/index.js'
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -31,6 +21,9 @@ describe('Test suite: Document with existent identity and setting Document only 
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - Doc')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/existent-doc-id.md`),
@@ -52,8 +45,6 @@ describe('Test suite: Document with existent identity and setting Document only 
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/existent-doc-id.md')
 
-    await updateSettings({ setting: 'runme.server.lifecycleIdentity', value: 2 })
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
@@ -14,8 +14,8 @@ import {
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.document.e2e.ts
@@ -14,8 +14,8 @@ import {
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.existent-doc.none.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Document with existent identity and setting None (0)', asy
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - None')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/existent-doc-id.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Document with existent identity and setting None (0)', asy
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/existent-doc-id.md')
 
-    await updateLifecycleIdentitySetting(0)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.all.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Shebang with setting All (1)', async () => {
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - All')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/shebang.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Shebang with setting All (1)', async () => {
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/shebang.md')
 
-    await updateLifecycleIdentitySetting(1)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.cell.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Shebang with setting Cell only (3)', async () => {
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - Cell')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/shebang.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Shebang with setting Cell only (3)', async () => {
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/shebang.md')
 
-    await updateLifecycleIdentitySetting(3)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
@@ -1,17 +1,7 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
-
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
@@ -26,6 +16,9 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - Doc')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/shebang.md`),
@@ -47,8 +40,6 @@ describe('Test suite: Shebang with setting Document only (2)', async () => {
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/shebang.md')
 
-    await updateLifecycleIdentitySetting(2)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.document.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 
 async function removeAllNotifications() {

--- a/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
@@ -1,17 +1,8 @@
 import { Key } from 'webdriverio'
 
 import { RunmeNotebook } from '../../pageobjects/notebook.page.js'
-import {
-  assertDocumentContainsSpinner,
-  revertChanges,
-  saveFile,
-  updateLifecycleIdentitySetting,
-} from '../../helpers/index.js'
+import { assertDocumentContainsSpinner, revertChanges, saveFile } from '../../helpers/index.js'
 
-async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
-}
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()
   const notifications = await workbench.getNotifications()
@@ -25,6 +16,9 @@ describe('Test suite: Shebang with setting None (0)', async () => {
 
   const notebook = new RunmeNotebook()
   it('open identity markdown file', async () => {
+    const workbench = await browser.getWorkbench()
+    await workbench.executeCommand('Runme: Lifecycle Identity - None')
+
     await browser.executeWorkbench(async (vscode) => {
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.file(`${vscode.workspace.rootPath}/tests/fixtures/identity/shebang.md`),
@@ -46,8 +40,6 @@ describe('Test suite: Shebang with setting None (0)', async () => {
       return `${vscode.workspace.rootPath}${documentPath}`
     }, '/tests/fixtures/identity/shebang.md')
 
-    await updateLifecycleIdentitySetting(0)
-    await reloadWindow()
     await notebook.focusDocument()
     const workbench = await browser.getWorkbench()
     await workbench.executeCommand('Notebook: Focus First Cell')

--- a/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  // const workbench = await browser.getWorkbench()
-  // await workbench.executeCommand('Developer: Restart Extension Host')
+  const workbench = await browser.getWorkbench()
+  await workbench.executeCommand('Developer: Reload Window')
 }
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()

--- a/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
+++ b/tests/e2e/specs/identity/identity.shebang.none.e2e.ts
@@ -9,8 +9,8 @@ import {
 } from '../../helpers/index.js'
 
 async function reloadWindow() {
-  const workbench = await browser.getWorkbench()
-  await workbench.executeCommand('Developer: Reload Window')
+  // const workbench = await browser.getWorkbench()
+  // await workbench.executeCommand('Developer: Restart Extension Host')
 }
 async function removeAllNotifications() {
   const workbench = await browser.getWorkbench()

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -93,7 +93,7 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: 'vscode',
-      browserVersion: '1.92.2',
+      browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
         workspacePath: extensionPath,

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -163,7 +163,7 @@ export const config: Options.Testrunner = {
   framework: 'mocha',
   //
   // The number of times to retry the entire specfile when it fails as a whole
-  specFileRetries: 0,
+  specFileRetries: 2,
   //
   // Delay in seconds between the spec file retry attempts
   // specFileRetriesDelay: 0,

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -59,9 +59,7 @@ export const config: Options.Testrunner = {
   //
   specs: ['./specs/**/*.e2e.ts'],
   // Patterns to exclude.
-  exclude: [
-    // 'path/to/excluded/files'
-  ],
+  exclude: ['./specs/**/identity/*.e2e.ts'],
   //
   // ======
   // Runner

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -59,7 +59,8 @@ export const config: Options.Testrunner = {
   //
   specs: ['./specs/**/*.e2e.ts'],
   // Patterns to exclude.
-  exclude: ['./specs/**/identity/*.e2e.ts'],
+  // exclude: ['./specs/**/identity/*.e2e.ts'],
+  exclude: [],
   //
   // ======
   // Runner

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -59,8 +59,8 @@ export const config: Options.Testrunner = {
   //
   specs: ['./specs/**/*.e2e.ts'],
   // Patterns to exclude.
-  // exclude: ['./specs/**/identity/*.e2e.ts'],
-  exclude: [],
+  exclude: ['./specs/**/identity/*.e2e.ts'],
+  // exclude: [],
   //
   // ======
   // Runner

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -59,8 +59,8 @@ export const config: Options.Testrunner = {
   //
   specs: ['./specs/**/*.e2e.ts'],
   // Patterns to exclude.
-  exclude: ['./specs/**/identity/*.e2e.ts'],
-  // exclude: [],
+  // exclude: ['./specs/**/identity/*.e2e.ts'],
+  exclude: [],
   //
   // ======
   // Runner
@@ -163,7 +163,7 @@ export const config: Options.Testrunner = {
   framework: 'mocha',
   //
   // The number of times to retry the entire specfile when it fails as a whole
-  specFileRetries: 2,
+  specFileRetries: 0,
   //
   // Delay in seconds between the spec file retry attempts
   // specFileRetriesDelay: 0,

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -120,7 +120,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(5)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(42)
+  expect(commands.registerCommand).toBeCalledTimes(46)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)


### PR DESCRIPTION
It seems that the command `> Developer: Reload Window` is generating a disconnection between the test runner and the chromedriver. This step is required to test Lifecycle Identity e2e Tests using different combinations of settings.

This PR refactors the Lifecycle ID e2e tests to avoid the usage of **Window Reloading** and enabled the latest version again.

Reverts stateful/vscode-runme#1622

Related: https://github.com/webdriverio-community/wdio-vscode-service/issues/136