### PR TITLE
Rename from "Fork ENV" to "Fork"

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
       },
       {
         "command": "runme.runForkCommand",
-        "title": "Run fork ENV in new terminal"
+        "title": "Run fork session in new terminal"
       },
       {
         "command": "runme.surveyWinDefaultShell",

--- a/src/extension/provider/cellStatusBar/items/fork.ts
+++ b/src/extension/provider/cellStatusBar/items/fork.ts
@@ -5,7 +5,7 @@ import CellStatusBarItem from './cellStatusBarItem'
 export class ForkStatusBarItem extends CellStatusBarItem {
   getStatusBarItem(_cell: NotebookCell): NotebookCellStatusBarItem | undefined {
     const item = new NotebookCellStatusBarItem(
-      '$(github-action) Fork ENV',
+      '$(github-action) Fork',
       NotebookCellStatusBarAlignment.Right,
     )
     item.command = 'runme.runForkCommand'


### PR DESCRIPTION
Shorter is better. While the ENV will be rolled up when exiting the session, we will add more terminal features shortly.