### PR TITLE
Await reporter after running the cell

### DIFF
--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -761,7 +761,7 @@ export class Kernel implements Disposable {
 
     TelemetryReporter.sendTelemetryEvent('cell.startExecute')
     // todo(sebastian): rewrite to use non-blocking impl
-    await getEventReporter().reportExecution(cell)
+    const execCellReport = getEventReporter().reportExecution(cell)
     runmeExec.start(Date.now())
 
     const annotations = getAnnotations(cell)
@@ -808,6 +808,8 @@ export class Kernel implements Disposable {
       successfulCellExecution = false
       log.error('Error executing cell', e.message)
       window.showErrorMessage(e.message)
+    } finally {
+      await execCellReport
     }
 
     TelemetryReporter.sendTelemetryEvent('cell.endExecute', {


### PR DESCRIPTION
This won't detach producer from consumer/reporter yet. However, it makes reporting more asynchronous, which is desirable.