### PR TITLE
Rewire overwrites to use Runme GHA

### DIFF
--- a/.github/scripts/overwrites/runme.md
+++ b/.github/scripts/overwrites/runme.md
@@ -10,17 +10,26 @@ Remove panels mostly relevant for development.
 npm pkg delete "contributes.views.runme[id='runme.chat']"
 npm pkg delete "contributes.views.runme[id='runme.search']"
 npm pkg delete "contributes.terminal"
-npm pkg set "contributes.configuration[0].properties[runme.experiments.smartEnvStore].default=false" --json
 git diff package.json
 ```
 
-Remove smart env store panels.
+Deactivate smart env store and remove panels.
 
 ```sh {"id":"01J7EZQJX1843SKQCRC7P8BHYV","interactive":"false","name":"deactivate-smartenv"}
 npm pkg delete "contributes.views[runme-notebook]"
 npm pkg delete "contributes.viewsContainers.panel"
+npm pkg set "contributes.configuration[0].properties[runme.experiments.smartEnvStore].default=false" --json
 git diff package.json
 ```
+
+Enable smart env store for edge/pre-release.
+
+```sh {"id":"01J7F152F569Z9QXZZEV0CW1Z6","interactive":"false","name":"activate-smartenv"}
+npm pkg set "contributes.configuration[0].properties[runme.experiments.smartEnvStore].default=true" --json
+git diff package.json
+```
+
+### Reset
 
 ```sh {"excludeFromRunAll":"true","id":"01J7EZQSG262FMGJAYG1W6Z3EQ"}
 git checkout -f package.json

--- a/.github/scripts/overwrites/runme.md
+++ b/.github/scripts/overwrites/runme.md
@@ -7,8 +7,8 @@ cwd: ../../..
 Remove panels mostly relevant for development.
 
 ```sh {"id":"01J7EZNXTG43WAYRWPFX7MHN7F","interactive":"false","name":"deactivate-panels"}
-npm pkg delete "contributes.views.runme[id='runme.chat']"
-npm pkg delete "contributes.views.runme[id='runme.search']"
+npm pkg delete "contributes.views.runme[1]" # remove chat
+npm pkg delete "contributes.views.runme[1]" # remove search
 npm pkg delete "contributes.terminal"
 git diff package.json
 ```

--- a/.github/scripts/overwrites/runme.md
+++ b/.github/scripts/overwrites/runme.md
@@ -1,0 +1,28 @@
+---
+cwd: ../../..
+---
+
+# Settings Overwrites
+
+Remove panels mostly relevant for development.
+
+```sh {"id":"01J7EZNXTG43WAYRWPFX7MHN7F","interactive":"false","name":"deactivate-panels"}
+npm pkg delete "contributes.views.runme[id='runme.chat']"
+npm pkg delete "contributes.views.runme[id='runme.search']"
+npm pkg delete "contributes.terminal"
+npm pkg set "contributes.configuration[0].properties[runme.experiments.smartEnvStore].default=false" --json
+git diff package.json
+```
+
+Remove smart env store panels.
+
+```sh {"id":"01J7EZQJX1843SKQCRC7P8BHYV","interactive":"false","name":"deactivate-smartenv"}
+npm pkg delete "contributes.views[runme-notebook]"
+npm pkg delete "contributes.viewsContainers.panel"
+git diff package.json
+```
+
+```sh {"excludeFromRunAll":"true","id":"01J7EZQSG262FMGJAYG1W6Z3EQ"}
+git checkout -f package.json
+git diff package.json
+```

--- a/.github/scripts/overwrites/stateful.md
+++ b/.github/scripts/overwrites/stateful.md
@@ -6,7 +6,7 @@ cwd: ../../..
 
 To overwrite Runme's defaults to match Stateful's run following commands:
 
-```sh {"id":"01J1N29F9C3BCHS56FWF55DA0E","name":"overwrite-stateful"}
+```sh {"id":"01J1N29F9C3BCHS56FWF55DA0E","name":"overwrite-stateful","promptEnv":"no"}
 export EXTENSION_NAME="platform"
 bash .github/scripts/overwrites/stateful.sh
 ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,12 @@ jobs:
           workflows: deactivate-smartenv
         if: ${{ github.event.inputs.releaseChannel == 'stable' }}
 
+      - name: Activate smart env store for edge
+        uses: stateful/runme-action@v2
+        with:
+          workflows: activate-smartenv
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+
       # Linux X86
       - name: Package Extension Linux x86_64 (Edge)
         if: ${{ github.event.inputs.releaseChannel == 'edge' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,10 @@ jobs:
           echo "EXTENSION_NAME=${EXTENSION_NAME}" >> $GITHUB_ENV
 
       - name: Overwrite Extension Definition
+        uses: stateful/runme-action@v2
+        with:
+          workflows: overwrite-stateful
         if: env.EXTENSION_NAME != 'runme'
-        run: |
-          .github/scripts/overwrites/stateful.sh
 
       - name: Get Stable Releases
         uses: actions/github-script@v6
@@ -167,13 +168,16 @@ jobs:
         if: ${{ github.event.inputs.releaseChannel == 'edge' || env.EXTENSION_NAME != 'runme' }}
         run: node .github/scripts/updateEdgeVersion.js
 
-      - name: Deactivate additional panel
-        run: |
-          jq 'del( .contributes.views.runme[1], .contributes.views.runme[2] )' package.json > _package.json
-          jq 'del( .contributes.views["runme-notebook"], .contributes.viewsContainers.panel, .contributes.terminal )' _package.json > __package.json
-          mv -f __package.json package.json
-          rm -f _package.json
-        # if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+      - name: Deactivate additional panel & terminal
+        uses: stateful/runme-action@v2
+        with:
+          workflows: deactivate-panels
+
+      - name: Deactivate smart env store for stable
+        uses: stateful/runme-action@v2
+        with:
+          workflows: deactivate-smartenv
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
 
       # Linux X86
       - name: Package Extension Linux x86_64 (Edge)


### PR DESCRIPTION
- [x] Leverage Runme tasks to execute overwrites at build time
- [x] Use Runme GHA to execute tasks
- [x] Allow smart env store for edge versions