### PR TITLE
Fix toggling between markdown/text with action buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@octokit/rest": "^19.0.13",
         "@types/node": "^18.19.14",
         "@types/uuid": "^10.0.0",
-        "@types/vscode": "1.72.0",
+        "@types/vscode": "1.78.0",
         "@types/vscode-notebook-renderer": "^1.72.3",
         "@types/webpack-env": "^1.18.1",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -104,7 +104,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "vscode": "^1.72.0"
+        "vscode": "^1.78.0"
       }
     },
     "node_modules/@actions/exec": {
@@ -7213,9 +7213,10 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
-      "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw=="
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.0.tgz",
+      "integrity": "sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==",
+      "dev": true
     },
     "node_modules/@types/vscode-notebook-renderer": {
       "version": "1.72.3",
@@ -23539,6 +23540,11 @@
         "@vscode/extension-telemetry": "^0.8.2",
         "tangle": "^4.0.0"
       }
+    },
+    "node_modules/vscode-telemetry/node_modules/@types/vscode": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
+      "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw=="
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "private": true,
   "engines": {
-    "vscode": "^1.72.0"
+    "vscode": "^1.78.0"
   },
   "galleryBanner": {
     "color": "#0D003D",
@@ -1114,7 +1114,7 @@
     "@octokit/rest": "^19.0.13",
     "@types/node": "^18.19.14",
     "@types/uuid": "^10.0.0",
-    "@types/vscode": "1.72.0",
+    "@types/vscode": "1.78.0",
     "@types/vscode-notebook-renderer": "^1.72.3",
     "@types/webpack-env": "^1.18.1",
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -243,7 +243,7 @@ export function runCLICommand(kernel: Kernel, extensionBaseUri: Uri, grpcRunner:
   }
 }
 
-function openDocumentAs(doc: { text?: TextDocument; notebook?: NotebookDocument }) {
+async function openDocumentAs(doc: { text?: TextDocument; notebook?: NotebookDocument }) {
   const openIn = getActionsOpenViewInEditor()
   switch (openIn) {
     case OpenViewInEditorAction.enum.toggle:
@@ -254,11 +254,11 @@ function openDocumentAs(doc: { text?: TextDocument; notebook?: NotebookDocument 
     default:
       {
         if (doc.notebook) {
-          window.showNotebookDocument(doc.notebook, {
+          await window.showNotebookDocument(doc.notebook, {
             viewColumn: ViewColumn.Active,
           })
         } else if (doc.text) {
-          window.showTextDocument(doc.text, {
+          await window.showTextDocument(doc.text, {
             viewColumn: ViewColumn.Beside,
           })
         }
@@ -267,12 +267,14 @@ function openDocumentAs(doc: { text?: TextDocument; notebook?: NotebookDocument 
   }
 }
 
-export function openAsRunmeNotebook(doc: NotebookDocument) {
-  openDocumentAs({ notebook: doc })
+export async function openAsRunmeNotebook(uri: Uri) {
+  const notebook = await workspace.openNotebookDocument(uri)
+  await openDocumentAs({ notebook })
 }
 
-export function openSplitViewAsMarkdownText(doc: TextDocument) {
-  openDocumentAs({ text: doc })
+export async function openSplitViewAsMarkdownText(uri: Uri) {
+  const text = await workspace.openTextDocument(uri)
+  await openDocumentAs({ text })
 }
 
 export async function askNewRunnerSession(kernel: Kernel) {

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -285,8 +285,7 @@ export class Kernel implements Disposable {
           action,
         )
         if (taken && taken === action) {
-          const doc = await workspace.openTextDocument(notebookDocument.uri)
-          openSplitViewAsMarkdownText(doc)
+          openSplitViewAsMarkdownText(notebookDocument.uri)
         }
       }
     }

--- a/tests/extension/commands/index.test.ts
+++ b/tests/extension/commands/index.test.ts
@@ -200,6 +200,8 @@ suite('runCliCommand', () => {
   beforeEach(() => {
     vi.mocked(getBinaryPath).mockClear()
     vi.mocked(window.showInformationMessage).mockClear()
+    vi.mocked(window.showNotebookDocument).mockClear()
+    vi.mocked(window.showTextDocument).mockClear()
     vi.mocked(getAnnotations).mockClear()
     vi.mocked(terminal.sendText).mockClear()
     vi.mocked(getCLIUseIntegratedRunme).mockClear()
@@ -281,27 +283,29 @@ suite('runCliCommand', () => {
   })
 })
 
-test('open markdown as Runme notebook split', (file: NotebookDocument) => {
+test('open markdown as Runme notebook split', async (file: NotebookDocument) => {
   vi.mocked(getActionsOpenViewInEditor).mockReturnValue('split' as const)
-  openAsRunmeNotebook(file)
+  vi.mocked(workspace.openNotebookDocument).mockResolvedValue(file)
+  await openAsRunmeNotebook(file.uri)
   expect(window.showNotebookDocument).toBeCalledWith(file, { viewColumn: undefined })
 })
 
-test('open Runme notebook in text editor split', (file: TextDocument) => {
+test('open Runme notebook in text editor split', async (file: TextDocument) => {
   vi.mocked(getActionsOpenViewInEditor).mockReturnValue('split' as const)
-  openSplitViewAsMarkdownText(file)
+  vi.mocked(workspace.openTextDocument).mockResolvedValue(file)
+  await openSplitViewAsMarkdownText(file.uri)
   expect(window.showTextDocument).toBeCalledWith(file, { viewColumn: ViewColumn.Beside })
 })
 
-test('open markdown as Runme notebook toggle', (file: NotebookDocument) => {
+test('open markdown as Runme notebook toggle', async (file: NotebookDocument) => {
   vi.mocked(getActionsOpenViewInEditor).mockReturnValue('toggle' as const)
-  openAsRunmeNotebook(file)
+  await openAsRunmeNotebook(file.uri)
   expect(commands.executeCommand).toBeCalledWith('workbench.action.toggleEditorType')
 })
 
-test('open Runme notebook in text editor toggle', (file: TextDocument) => {
+test('open Runme notebook in text editor toggle', async (file: TextDocument) => {
   vi.mocked(getActionsOpenViewInEditor).mockReturnValue('toggle' as const)
-  openSplitViewAsMarkdownText(file)
+  await openSplitViewAsMarkdownText(file.uri)
   expect(commands.executeCommand).toBeCalledWith('workbench.action.toggleEditorType')
 })
 
@@ -345,6 +349,9 @@ suite('askAlternativeOutputsAction', () => {
 })
 
 suite('askNewRunnerSession', () => {
+  beforeEach(() => {
+    vi.mocked(workspace.openNotebookDocument).mockClear()
+  })
   test('asks are you sure first', async () => {
     const newRunnerEnvironment = vi.fn()
     const kernel = { newRunnerEnvironment }
@@ -381,7 +388,7 @@ test('createNewRunmeNotebook', async () => {
   await createNewRunmeNotebook()
   expect(workspace.openNotebookDocument).toBeCalledWith('runme', expect.any(Object))
   expect(NotebookCellData).toBeCalledTimes(3)
-  expect(commands.executeCommand).toBeCalledWith('vscode.openWith', expect.any(String), 'runme')
+  expect(commands.executeCommand).toBeCalledWith('vscode.openWith', undefined, 'runme')
 })
 
 test('welcome command', async () => {


### PR DESCRIPTION
It is likely broken due to the deprecation/changing of APIs. Require a minimum of VS Code v1.78.x now.

<img width="988" alt="image" src="https://github.com/user-attachments/assets/ca82f004-11a9-470e-ad2d-6a90eb423fde">