### PR TITLE
Separate dependabot rules for /examples/k8s

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,11 @@ updates:
           - "chromedriver"
           - "wdio-vscode-service"
           - "webdriverio"
+  - package-ecosystem: npm
+    directory: "/examples/k8s"
+    schedule:
+      interval: monthly
+      time: "09:00"
+      day: "wednesday"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Dependabot updates inside /examples/k8s are not significant, so these can have a separate scheduling.