### PR TITLE
Remove option to enable aiLogs in the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -544,12 +544,6 @@
             "scope": "window",
             "markdownDescription": "Relative path to a file within the workspace to open within a Runme notebook view, when VS Code starts (e.g. `./CONTRIBUTING.md`)."
           },
-          "runme.experiments.aiLogs": {
-            "type": "boolean",
-            "scope": "window",
-            "default": false,
-            "markdownDescription": "If set to `true`, enable logging server logs used for training AIs."
-          },
           "runme.experiments.aiAutoCell": {
             "type": "boolean",
             "scope": "window",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -91,14 +91,12 @@ export class RunmeExtension {
     const grpcSerializer = kernel.hasExperimentEnabled('grpcSerializer')
     const grpcServer = kernel.hasExperimentEnabled('grpcServer')
     const grpcRunner = kernel.hasExperimentEnabled('grpcRunner')
-    const aiLogs = kernel.hasExperimentEnabled('aiLogs')
 
     const server = new KernelServer(
       context.extensionUri,
       {
         retryOnFailure: true,
         maxNumberOfIntents: 10,
-        aiLogs: aiLogs,
       },
       !grpcServer,
       grpcRunner,

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -145,7 +145,6 @@ export class Kernel implements Disposable {
     this.#experiments.set('grpcServer', config.get<boolean>('grpcServer', true))
     this.#experiments.set('escalationButton', config.get<boolean>('escalationButton', false))
     this.#experiments.set('smartEnvStore', config.get<boolean>('smartEnvStore', false))
-    this.#experiments.set('aiLogs', config.get<boolean>('aiLogs', false))
     this.#experiments.set('shellWarning', config.get<boolean>('shellWarning', false))
     this.#experiments.set('reporter', config.get<boolean>('reporter', false))
 

--- a/src/extension/server/kernelServer.ts
+++ b/src/extension/server/kernelServer.ts
@@ -33,7 +33,6 @@ export interface IServerConfig {
     intents: number
     interval: number
   }
-  aiLogs?: boolean
 }
 
 const log = getLogger('KernelServer')
@@ -65,7 +64,6 @@ class KernelServer implements IServer {
   #transport?: GrpcTransport
   #serverDisposables: Disposable[] = []
   #forceExternalServer: boolean
-  #aiLogs: boolean
 
   readonly #onClose = this.register(new EventEmitter<{ code: number | null }>())
   readonly #onTransportReady = this.register(
@@ -96,7 +94,6 @@ class KernelServer implements IServer {
     this.#acceptsIntents = options.acceptsConnection?.intents || 50
     this.#acceptsInterval = options.acceptsConnection?.interval || 200
     this.#forceExternalServer = externalServer
-    this.#aiLogs = options.aiLogs || false
   }
 
   dispose() {
@@ -233,11 +230,6 @@ class KernelServer implements IServer {
 
     if (this.enableRunner) {
       args.push('--runner')
-    }
-
-    if (this.#aiLogs) {
-      log.info('AI logs enabled')
-      args.push('--ai-logs=true')
     }
 
     if (getTLSEnabled()) {


### PR DESCRIPTION
* This effectively reverts https://github.com/stateful/vscode-runme/pull/1380
* Per https://github.com/jlewi/foyle/issues/211 we are no longer relying on RunMe logs
* Rather RunMe now uses Foyle APIs to send events to Foyle as necessary.