### PR TITLE
Fix code-server login

### DIFF
--- a/src/extension/handler/uri.ts
+++ b/src/extension/handler/uri.ts
@@ -57,7 +57,6 @@ export class RunmeUriHandler implements UriHandler, Disposable {
   async handleUri(uri: Uri) {
     log.info(`triggered RunmeUriHandler with ${uri}`)
     const params = new URLSearchParams(uri.query)
-    const windowId = params.get('windowId')
     const state = params.get('state')
     const code = params.get('code')
     const command = params.get('command')
@@ -66,7 +65,7 @@ export class RunmeUriHandler implements UriHandler, Disposable {
       window.showErrorMessage('No query parameter "command" provided')
       return
     }
-    if (command === 'auth' && windowId && state && code) {
+    if (command === 'auth' && state && code) {
       TelemetryReporter.sendTelemetryEvent('extension.uriHandler', {
         command,
         type: AuthenticationProviders.Stateful,
@@ -133,7 +132,7 @@ export class RunmeUriHandler implements UriHandler, Disposable {
       }
     }
 
-    window.showErrorMessage(`Couldn't recognise command "${command}"`)
+    window.showErrorMessage(`Couldn't recognize command "${command}"`)
   }
 
   private async _setupProject(fileToOpen: string, repository?: string | null) {

--- a/tests/extension/handler/uri.test.ts
+++ b/tests/extension/handler/uri.test.ts
@@ -63,7 +63,7 @@ describe('RunmeUriHandler', () => {
     it('should fail if no command was recognised', async () => {
       vi.mocked(Uri.parse).mockReturnValue({ query: { command: 'foobar' } } as any)
       expect(await handler.handleUri(Uri.parse('vscode://stateful.runme?foo=bar'))).toBe(undefined)
-      expect(window.showErrorMessage).toBeCalledWith('Couldn\'t recognise command "foobar"')
+      expect(window.showErrorMessage).toBeCalledWith('Couldn\'t recognize command "foobar"')
     })
 
     it('runs _setupProject if command was "setup"', async () => {


### PR DESCRIPTION
This resolves the issue in code-server where a `Couldn't recognize command` error occurs during authentication against the Platform, because it expects the `windowId` URI parameter, which is missing.

The fix has been successfully tested in both code-server and standard VSCode environments.