### PR TITLE
Loads StatefulAuth provider only when it's necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,10 +58,18 @@
   "main": "./out/extension.js",
   "runme": {
     "features": {
+      "RequireStatefulAuth": {
+        "enabled": true,
+        "conditions": {
+          "enabledForExtensions": {
+            "stateful.platform": true,
+            "stateful.runme": false
+          }
+        }
+      },
       "SignedIn": {
         "enabled": true,
         "conditions": {
-          "os": "All",
           "statefulAuthRequired": true,
           "enabledForExtensions": {
             "stateful.platform": true,
@@ -72,7 +80,6 @@
       "ForceLogin": {
         "enabled": true,
         "conditions": {
-          "os": "All",
           "enabledForExtensions": {
             "stateful.platform": true,
             "stateful.runme": false
@@ -82,7 +89,6 @@
       "Escalate": {
         "enabled": true,
         "conditions": {
-          "os": "All",
           "statefulAuthRequired": true,
           "enabledForExtensions": {
             "stateful.platform": true,
@@ -93,7 +99,6 @@
       "Share": {
         "enabled": true,
         "conditions": {
-          "os": "All",
           "enabledForExtensions": {
             "stateful.platform": true,
             "stateful.runme": false
@@ -103,7 +108,6 @@
       "Gist": {
         "enabled": true,
         "conditions": {
-          "os": "All",
           "enabledForExtensions": {
             "stateful.platform": false,
             "stateful.runme": true

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -55,7 +55,6 @@ import {
   getPortNumber,
   getTLSDir,
   getTLSEnabled,
-  isPlatformAuthEnabled,
 } from '../utils/configuration'
 
 import features from './features'
@@ -582,11 +581,15 @@ export async function resolveAuthToken(createIfNone: boolean = true) {
 }
 
 export async function resolveAppToken(createIfNone: boolean = true) {
-  const session = await getPlatformAuthSession(createIfNone)
-  if (!session) {
-    return null
+  if (features.isOnInContextState(FeatureName.RequireStatefulAuth)) {
+    const session = await getPlatformAuthSession(createIfNone)
+    if (!session) {
+      return null
+    }
+    return { token: session.accessToken }
   }
-  return { token: session.accessToken }
+
+  return null
 }
 
 export function fetchStaticHtml(appUrl: string) {
@@ -706,14 +709,6 @@ export function asWorkspaceRelativePath(documentPath: string): {
     return { relativePath: path.basename(documentPath), outside: true }
   }
   return { relativePath, outside: false }
-}
-
-export async function resolveUserSession(
-  createIfNone: boolean,
-): Promise<AuthenticationSession | undefined> {
-  return isPlatformAuthEnabled()
-    ? await getPlatformAuthSession(createIfNone)
-    : await getGithubAuthSession(createIfNone)
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -767,6 +767,7 @@ export enum FeatureName {
   Escalate = 'Escalate',
   ForceLogin = 'ForceLogin',
   SignedIn = 'SignedIn',
+  RequireStatefulAuth = 'RequireStatefulAuth',
 }
 
 export type Feature = {


### PR DESCRIPTION
The Runme extension loads the StatefulAuth provider, which could lead to a poor user experience. Even when the silent flag is passed, there is a listener that may activate the Badge in the User Menu, prompting a login suggestion.

In future PRs, when support for saving cells on the Platform is introduced, this flag can be enabled for Runme.