### PR TITLE
Enables Cells Saving in Runme

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "conditions": {
           "enabledForExtensions": {
             "stateful.platform": true,
-            "stateful.runme": false
+            "stateful.runme": true
           }
         }
       },
@@ -101,7 +101,7 @@
         "conditions": {
           "enabledForExtensions": {
             "stateful.platform": true,
-            "stateful.runme": false
+            "stateful.runme": true
           }
         }
       },

--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -379,6 +379,9 @@ export class TerminalView extends LitElement {
   @property({ type: Boolean })
   isPlatformAuthEnabled: boolean = false
 
+  @property({ type: Boolean })
+  isDaggerOutput: boolean = false
+
   constructor() {
     super()
     this.windowSize = {
@@ -860,6 +863,7 @@ export class TerminalView extends LitElement {
         )}
         ${when(
           (this.exitCode === undefined || this.exitCode === 0 || !this.platformId) &&
+            !this.isDaggerOutput &&
             features.isOn(FeatureName.Share, this.featureState$),
           () => {
             return html` <action-button
@@ -876,6 +880,7 @@ export class TerminalView extends LitElement {
         ${when(
           this.exitCode !== 0 &&
             this.platformId &&
+            !this.isDaggerOutput &&
             features.isOn(FeatureName.Escalate, this.featureState$),
           () => {
             return html` <action-button

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -150,6 +150,10 @@ export const activate: ActivationFunction<void> = (context) => {
             )
           }
 
+          if (payload.output.isDaggerOutput) {
+            terminalElement.setAttribute('isDaggerOutput', payload.output.isDaggerOutput.toString())
+          }
+
           element.appendChild(terminalElement)
           break
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -181,6 +181,7 @@ export enum NotebookMode {
 export const NOTEBOOK_AVAILABLE_CATEGORIES = 'notebookAvailableCategories'
 export const NOTEBOOK_HAS_CATEGORIES = 'notebookHasCategories'
 export const NOTEBOOK_AUTOSAVE_ON = 'notebookAutoSaveOn'
+export const NOTEBOOK_LIFECYCLE_ID = 'notebookLifecycleId'
 export const NOTEBOOK_OUTPUTS_MASKED = 'notebookOutputsMasked'
 export const NOTEBOOK_MODE = 'notebookMode'
 export const NOTEBOOK_HAS_OUTPUTS = 'notebookHasRunmeOutputs'

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -197,7 +197,7 @@ export class NotebookCellOutputManager {
         }
 
         return new NotebookCellOutput([NotebookCellOutputItem.json(payload, OutputType.dagger)], {
-          // deno: { deploy: true },
+          daggerCellId: cellId,
         })
       }
 
@@ -239,6 +239,10 @@ export class NotebookCellOutputManager {
         if (type === OutputType.terminal) {
           let terminalOutputItem: NotebookCellOutputItem | undefined
 
+          const daggerOutput = cell.outputs.find(
+            ({ metadata }) => metadata?.daggerCellId === cellId,
+          )
+
           const terminalStateStr = terminalState.serialize()
           if (!terminalOutputItem) {
             const terminalConfigurations = getNotebookTerminalConfigurations(cell.notebook.metadata)
@@ -258,6 +262,7 @@ export class NotebookCellOutputManager {
                 isAutoSaveEnabled: isSignedIn ? ContextState.getKey(NOTEBOOK_AUTOSAVE_ON) : false,
                 isPlatformAuthEnabled: isPlatformAuthEnabled(),
                 isSessionOutputsEnabled,
+                isDaggerOutput: !!daggerOutput,
                 ...terminalConfigurations,
               },
             }

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -47,6 +47,7 @@ import {
   NOTEBOOK_AUTHOR_MODE_ON,
   ClientMessages,
   TELEMETRY_EVENTS,
+  RUNME_FRONTMATTER_PARSED,
 } from '../../constants'
 import ContextState from '../contextState'
 import { createGist } from '../services/github/gist'
@@ -310,7 +311,7 @@ export async function askAlternativeOutputsAction(
   )
 
   const orig =
-    metadata['runme.dev/frontmatterParsed']?.['runme']?.['session']?.['document']?.['relativePath']
+    metadata[RUNME_FRONTMATTER_PARSED]?.['runme']?.['session']?.['document']?.['relativePath']
 
   switch (action) {
     case ASK_ALT_OUTPUTS_ACTION.ORIGINAL:

--- a/src/extension/executors/utils.ts
+++ b/src/extension/executors/utils.ts
@@ -12,7 +12,7 @@ import {
   NotebookDocument,
 } from 'vscode'
 
-import { DEFAULT_PROMPT_ENV, OutputType } from '../../constants'
+import { DEFAULT_PROMPT_ENV, OutputType, RUNME_FRONTMATTER_PARSED } from '../../constants'
 import type { CellOutputPayload, Serializer, ShellType } from '../../types'
 import { NotebookCellOutputManager } from '../cell'
 import { getAnnotations, getWorkspaceFolder } from '../utils'
@@ -137,7 +137,7 @@ export function getNotebookSkipPromptEnvSetting(
   notebook: NotebookData | Serializer.Notebook | NotebookDocument,
 ): boolean {
   const notebookMetadata = notebook.metadata as Serializer.Metadata | undefined
-  const frontmatter = notebookMetadata?.['runme.dev/frontmatterParsed']
+  const frontmatter = notebookMetadata?.[RUNME_FRONTMATTER_PARSED]
   return frontmatter?.skipPrompts || false
 }
 
@@ -148,7 +148,7 @@ export function getCellShellPath(
 ): string | undefined {
   const notebookMetadata = notebook.metadata as Serializer.Metadata | undefined
 
-  const frontmatter = notebookMetadata?.['runme.dev/frontmatterParsed']
+  const frontmatter = notebookMetadata?.[RUNME_FRONTMATTER_PARSED]
 
   if (frontmatter?.shell) {
     return frontmatter.shell
@@ -238,7 +238,7 @@ export async function getCellCwd(
     getWorkspaceFolder(notebookFile)?.uri.fsPath,
     getParent(notebookFile?.fsPath),
     // TODO: support windows here
-    (notebook?.metadata as Serializer.Metadata | undefined)?.['runme.dev/frontmatterParsed']?.cwd,
+    (notebook?.metadata as Serializer.Metadata | undefined)?.[RUNME_FRONTMATTER_PARSED]?.cwd,
     getAnnotations(cell.metadata as Serializer.Metadata | undefined).cwd,
   ]
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -19,7 +19,9 @@ import {
   getDocsUrlFor,
   getForceNewWindowConfig,
   getRunmeAppUrl,
+  getServerConfigurationValue,
   getSessionOutputs,
+  ServerLifecycleIdentity,
 } from '../utils/configuration'
 import {
   AuthenticationProviders,
@@ -452,9 +454,14 @@ export class RunmeExtension {
         e.provider.id === AuthenticationProviders.Stateful
       ) {
         getPlatformAuthSession(false, true).then(async (session) => {
-          const b = !!session
-          if (b) {
+          if (!!session) {
             await ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.ALL)
+          } else {
+            const current = getServerConfigurationValue<ServerLifecycleIdentity>(
+              'lifecycleIdentity',
+              RunmeIdentity.ALL,
+            )
+            await ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, current)
           }
           kernel.updateFeatureContext('statefulAuth', !!session)
         })

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -21,7 +21,12 @@ import {
   getRunmeAppUrl,
   getSessionOutputs,
 } from '../utils/configuration'
-import { AuthenticationProviders, TELEMETRY_EVENTS, WebViews } from '../constants'
+import {
+  AuthenticationProviders,
+  NOTEBOOK_LIFECYCLE_ID,
+  TELEMETRY_EVENTS,
+  WebViews,
+} from '../constants'
 
 import { Kernel } from './kernel'
 import KernelServer from './server/kernelServer'
@@ -85,6 +90,8 @@ import { GrpcReporter } from './reporter'
 import * as manager from './ai/manager'
 import getLogger from './logger'
 import { EnvironmentManager } from './environment/manager'
+import ContextState from './contextState'
+import { RunmeIdentity } from './grpc/serializerTypes'
 
 export class RunmeExtension {
   protected serializer?: SerializerBase
@@ -444,7 +451,11 @@ export class RunmeExtension {
         kernel.isFeatureOn(FeatureName.RequireStatefulAuth) &&
         e.provider.id === AuthenticationProviders.Stateful
       ) {
-        getPlatformAuthSession(false, true).then((session) => {
+        getPlatformAuthSession(false, true).then(async (session) => {
+          const b = !!session
+          if (b) {
+            await ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.ALL)
+          }
           kernel.updateFeatureContext('statefulAuth', !!session)
         })
       }

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -190,8 +190,12 @@ export default async function saveCellExecution(
       let fmParsed = editor.notebook.metadata['runme.dev/frontmatterParsed'] as Frontmatter
 
       if (!fmParsed) {
-        const yamlDocs = YAML.parseAllDocuments(editor.notebook.metadata['runme.dev/frontmatter'])
-        fmParsed = yamlDocs[0].toJS?.()
+        try {
+          const yamlDocs = YAML.parseAllDocuments(editor.notebook.metadata['runme.dev/frontmatter'])
+          fmParsed = yamlDocs[0].toJS?.() || {}
+        } catch (e) {
+          log.warn('failed to parse frontmatter')
+        }
       }
 
       let notebookInput: CreateNotebookInput | undefined

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -52,7 +52,6 @@ export default async function saveCellExecution(
   }
 
   const cacheId = GrpcSerializer.getDocumentCacheId(metadata) as string
-  console.log('saveCellExecution:CacheId: ', cacheId)
   const plainSessionOutput = await kernel.getPlainCache(cacheId)
   const maskedSessionOutput = await kernel.getMaskedCache(cacheId)
 

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -23,7 +23,7 @@ import {
   CreateNotebookInput,
   ReporterFrontmatterInput,
 } from '../../__generated-platform__/graphql'
-import { Cell, Frontmatter, FrontmatterRunme } from '../../grpc/serializerTypes'
+import { Cell, Frontmatter } from '../../grpc/serializerTypes'
 import { getCellById } from '../../cell'
 export type APIRequestMessage = IApiMessage<ClientMessage<ClientMessages.platformApiRequest>>
 
@@ -90,17 +90,6 @@ export default async function saveCellExecution(
         kernel,
         marshalFrontmatter: true,
       })
-
-      // Fallback to Ephemeral ID if there is no frontmatter
-      if (!notebook?.frontmatter?.runme?.id) {
-        notebook.frontmatter = {
-          ...(notebook?.frontmatter || ({} as Frontmatter)),
-          runme: {
-            ...(notebook?.frontmatter?.runme || {}),
-            id: cacheId,
-          } as FrontmatterRunme,
-        }
-      }
 
       const cell = notebook?.cells.find((c) => c.metadata.id === message.output.id) as Cell
 

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -193,8 +193,8 @@ export default async function saveCellExecution(
         try {
           const yamlDocs = YAML.parseAllDocuments(editor.notebook.metadata['runme.dev/frontmatter'])
           fmParsed = yamlDocs[0].toJS?.() || {}
-        } catch (e) {
-          log.warn('failed to parse frontmatter')
+        } catch (error: any) {
+          log.warn('failed to parse frontmatter, reason: ', error.message)
         }
       }
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -71,8 +71,6 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
   protected abstract readonly ready: ReadyPromise
   protected readonly languages: Languages
   protected disposables: Disposable[] = []
-  //protected readonly lifecycleIdentity: ServerLifecycleIdentity =
-  //getServerConfigurationValue<ServerLifecycleIdentity>('lifecycleIdentity', RunmeIdentity.ALL)
 
   constructor(
     protected context: ExtensionContext,
@@ -195,7 +193,6 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
 
     // Prune any ghost cells when saving.
     const cellsToSave = []
-
     for (let i = 0; i < cells.length; i++) {
       if (SerializerBase.isGhostCell(cells[i])) {
         continue

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -835,8 +835,8 @@ export class GrpcSerializer extends SerializerBase {
       try {
         const yamlDocs = YAML.parseAllDocuments(metadata['runme.dev/frontmatter'])
         data = (yamlDocs[0].toJS?.() || {}) as typeof data
-      } catch (e) {
-        log.warn('failed to parse frontmatter')
+      } catch (error: any) {
+        log.warn('failed to parse frontmatter, reason: ', error.message)
       }
     }
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -60,9 +60,11 @@ import { getCellById } from './cell'
 import { IProcessInfoState } from './terminal/terminalState'
 import ContextState from './contextState'
 import * as ghost from './ai/ghost'
+import getLogger from './logger'
 
 declare var globalThis: any
 const DEFAULT_LANG_ID = 'text'
+const log = getLogger('serializer')
 
 type NotebookCellOutputWithProcessInfo = NotebookCellOutput & {
   processInfo?: IProcessInfoState
@@ -830,11 +832,11 @@ export class GrpcSerializer extends SerializerBase {
     } = { runme: {} }
 
     if (rawFrontmatter) {
-      const yamlDocs = YAML.parseAllDocuments(metadata['runme.dev/frontmatter'])
       try {
+        const yamlDocs = YAML.parseAllDocuments(metadata['runme.dev/frontmatter'])
         data = (yamlDocs[0].toJS?.() || {}) as typeof data
       } catch (e) {
-        // Do nothing if the frontmatter is not valid
+        log.warn('failed to parse frontmatter')
       }
     }
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -89,7 +89,7 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
     this.disposables.forEach((d) => d.dispose())
   }
 
-  protected lifecycleIdentity() {
+  protected get lifecycleIdentity() {
     return ContextState.getKey<ServerLifecycleIdentity>(NOTEBOOK_LIFECYCLE_ID)
   }
 
@@ -110,7 +110,7 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
 
         const notebookEdit = NotebookEdit.updateCellMetadata(
           cellAdded.index,
-          SerializerBase.addCellId(cellAdded.metadata, this.lifecycleIdentity()),
+          SerializerBase.addCellId(cellAdded.metadata, this.lifecycleIdentity),
         )
         const edit = new WorkspaceEdit()
         edit.set(cellAdded.notebook.uri, [notebookEdit])
@@ -325,7 +325,7 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
     notebook.metadata ??= {}
     notebook.metadata[RUNME_FRONTMATTER_PARSED] = notebook.frontmatter
 
-    const notebookData = new NotebookData(SerializerBase.revive(notebook, this.lifecycleIdentity()))
+    const notebookData = new NotebookData(SerializerBase.revive(notebook, this.lifecycleIdentity))
     if (notebook.metadata) {
       notebookData.metadata = notebook.metadata
     } else {
@@ -640,7 +640,7 @@ export class GrpcSerializer extends SerializerBase {
   }
 
   protected applyIdentity(data: Notebook): Notebook {
-    const identity = this.lifecycleIdentity()
+    const identity = this.lifecycleIdentity
     switch (identity) {
       case RunmeIdentity.UNSPECIFIED:
       case RunmeIdentity.DOCUMENT:
@@ -687,7 +687,7 @@ export class GrpcSerializer extends SerializerBase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     token: CancellationToken,
   ): Promise<Uint8Array> {
-    const marshalFrontmatter = this.lifecycleIdentity() === RunmeIdentity.ALL
+    const marshalFrontmatter = this.lifecycleIdentity === RunmeIdentity.ALL
 
     const notebook = GrpcSerializer.marshalNotebook(data, { marshalFrontmatter })
 
@@ -919,7 +919,7 @@ export class GrpcSerializer extends SerializerBase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     token: CancellationToken,
   ): Promise<Serializer.Notebook> {
-    const identity = this.lifecycleIdentity()
+    const identity = this.lifecycleIdentity
     const deserialRequest = DeserializeRequest.create({ source: content, options: { identity } })
     const request = await this.client!.deserialize(deserialRequest)
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -691,9 +691,9 @@ export function suggestCategories(categories: string[], title: string, placehold
 export async function handleNotebookAutosaveSettings() {
   const configAutoSaveSetting = getNotebookAutoSave()
   const defaultSetting = configAutoSaveSetting === NotebookAutoSaveSetting.Yes
-  const storedSetting = ContextState.getKey(NOTEBOOK_AUTOSAVE_ON)
+  const contextSetting = ContextState.getKey(NOTEBOOK_AUTOSAVE_ON)
 
-  await ContextState.addKey(NOTEBOOK_AUTOSAVE_ON, storedSetting ?? defaultSetting)
+  await ContextState.addKey(NOTEBOOK_AUTOSAVE_ON, contextSetting ?? defaultSetting)
 }
 
 export async function resetNotebookSettings() {

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -45,6 +45,7 @@ import {
   NOTEBOOK_AUTOSAVE_ON,
   GITHUB_USER_SIGNED_IN,
   NOTEBOOK_OUTPUTS_MASKED,
+  NOTEBOOK_LIFECYCLE_ID,
 } from '../constants'
 import {
   getBinaryPath,
@@ -54,9 +55,11 @@ import {
   getMaskOutputs,
   getNotebookAutoSave,
   getPortNumber,
+  getServerConfigurationValue,
   getServerRunnerVersion,
   getTLSDir,
   getTLSEnabled,
+  ServerLifecycleIdentity,
 } from '../utils/configuration'
 
 import features from './features'
@@ -69,6 +72,7 @@ import { setCurrentCellExecutionDemo } from './handler/utils'
 import ContextState from './contextState'
 import { GCPResolver } from './resolvers/gcpResolver'
 import { AWSResolver } from './resolvers/awsResolver'
+import { RunmeIdentity } from './grpc/serializerTypes'
 
 declare var globalThis: any
 
@@ -697,6 +701,12 @@ export async function resetNotebookSettings() {
   const configAutoSaveSetting = getNotebookAutoSave()
   const autoSaveIsOn = configAutoSaveSetting === NotebookAutoSaveSetting.Yes
   await ContextState.addKey(NOTEBOOK_AUTOSAVE_ON, autoSaveIsOn)
+
+  const current = getServerConfigurationValue<ServerLifecycleIdentity>(
+    'lifecycleIdentity',
+    RunmeIdentity.ALL,
+  )
+  await ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, current)
 }
 
 export function asWorkspaceRelativePath(documentPath: string): {

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -685,19 +685,16 @@ export function suggestCategories(categories: string[], title: string, placehold
 
 export async function handleNotebookAutosaveSettings() {
   const configAutoSaveSetting = getNotebookAutoSave()
-  const extensionSettingAutoSaveIsOn =
-    configAutoSaveSetting === NotebookAutoSaveSetting.Yes ? true : false
-  const notebookAutoSaveIsOn = ContextState.getKey(NOTEBOOK_AUTOSAVE_ON)
-  await ContextState.addKey(
-    NOTEBOOK_AUTOSAVE_ON,
-    notebookAutoSaveIsOn !== undefined ? notebookAutoSaveIsOn : extensionSettingAutoSaveIsOn,
-  )
+  const defaultSetting = configAutoSaveSetting === NotebookAutoSaveSetting.Yes
+  const storedSetting = ContextState.getKey(NOTEBOOK_AUTOSAVE_ON)
+
+  await ContextState.addKey(NOTEBOOK_AUTOSAVE_ON, storedSetting ?? defaultSetting)
 }
 
 export async function resetNotebookSettings() {
   await ContextState.addKey(NOTEBOOK_OUTPUTS_MASKED, getMaskOutputs())
   const configAutoSaveSetting = getNotebookAutoSave()
-  const autoSaveIsOn = configAutoSaveSetting === NotebookAutoSaveSetting.Yes ? true : false
+  const autoSaveIsOn = configAutoSaveSetting === NotebookAutoSaveSetting.Yes
   await ContextState.addKey(NOTEBOOK_AUTOSAVE_ON, autoSaveIsOn)
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,6 +381,7 @@ interface Payload {
     isAutoSaveEnabled: boolean
     isSessionOutputsEnabled: boolean
     isPlatformAuthEnabled: boolean
+    isDaggerOutput: boolean
   }
   [OutputType.github]?: GitHubState
   [OutputType.stdout]: object

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -609,9 +609,11 @@ describe('GrpcSerializer', () => {
 
   describe('apply cell lifecycle identity', () => {
     it('skips cells if identity does not require it', async () => {
-      const serializer: any = new GrpcSerializer(context, new Server(), new Kernel())
-      serializer.lifecycleIdentity = vi.fn().mockReturnValue(2)
+      // make serializer.lifecycleIdentity return 2
+      ContextState.getKey = vi.fn().mockImplementation(() => 2)
       const fixture = deepCopyFixture()
+
+      const serializer: any = new GrpcSerializer(context, new Server(), new Kernel())
 
       fixture.cells.forEach((cell: { kind: number; metadata: { [x: string]: any } }) => {
         cell.metadata['runme.dev/id'] = cell.metadata['id']
@@ -653,6 +655,9 @@ describe('GrpcSerializer', () => {
         delete cell.metadata['id']
         expect(cell.metadata['id']).toBeUndefined()
       })
+
+      // make serializer.lifecycleIdentity return 3
+      ContextState.getKey = vi.fn().mockImplementation(() => 3)
 
       const applied = serializer.applyIdentity(fixture)
 

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -14,6 +14,7 @@ import { RunmeIdentity } from '../../src/extension/grpc/serializerTypes'
 import type { Kernel } from '../../src/extension/kernel'
 import { EventEmitter, Uri } from '../../__mocks__/vscode'
 import { Serializer } from '../../src/types'
+import ContextState from '../../src/extension/contextState'
 
 import fixtureMarshalNotebook from './fixtures/marshalNotebook.json'
 
@@ -68,6 +69,8 @@ vi.mock('../../src/extension/utils', () => ({
 }))
 
 vi.mock('../../src/extension/features')
+
+vi.mock('../../src/extension/contextState')
 
 function newKernel(): Kernel {
   return {} as unknown as Kernel
@@ -510,6 +513,7 @@ describe('GrpcSerializer', () => {
           fixture.metadata['runme.dev/frontmatterParsed'].runme.id,
           fakeSrcDocUri,
         )
+        ContextState.getKey = vi.fn().mockImplementation(() => true)
         GrpcSerializer.sessionOutputsEnabled = vi.fn().mockReturnValue(true)
         GrpcSerializer.getOutputsUri = vi.fn().mockImplementation(() => fakeSrcDocUri)
 
@@ -525,7 +529,7 @@ describe('GrpcSerializer', () => {
         })
 
         expect(workspace.fs.writeFile).toBeCalledWith(fakeSrcDocUri, fakeCachedBytes)
-        expect(workspace.fs.writeFile).toHaveBeenCalledTimes(3)
+        expect(workspace.fs.writeFile).toHaveBeenCalledTimes(2)
       })
     })
 

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -610,7 +610,7 @@ describe('GrpcSerializer', () => {
   describe('apply cell lifecycle identity', () => {
     it('skips cells if identity does not require it', async () => {
       const serializer: any = new GrpcSerializer(context, new Server(), new Kernel())
-      serializer.lifecycleIdentity = 2 // DOC identity which excludes cells
+      serializer.lifecycleIdentity = vi.fn().mockReturnValue(2)
       const fixture = deepCopyFixture()
 
       fixture.cells.forEach((cell: { kind: number; metadata: { [x: string]: any } }) => {


### PR DESCRIPTION
Enables support to Save Cells in the Stateful Platform.

Updates the validation that skips writing session file, now it considers if auto-save is on/off to resolve it.

In Runme the Lifecycle ID is configured by default at Cell level, so the experiment **reporter** `(runme.experiments.reporter)` fails due to it needs the Frontmatter, which is not available. To solve this issue, this PR uses the Ephemeral ID as fallback.

#### Runme extension known bugs:

- Dagger terminal outputs are not working with the Save button. I disable it for this kind of outputs. 
