### PR TITLE
Turn on "Fork" button by default

### DIFF
--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -36,6 +36,7 @@ import {
   getTerminalByCell,
   openFileAsRunmeNotebook,
   promptUserSession,
+  warnBetaRequired,
 } from '../utils'
 import { NotebookToolbarCommand, NotebookUiEvent, FeatureName } from '../../types'
 import getLogger from '../logger'
@@ -181,6 +182,10 @@ async function runStatusCommand(cell: NotebookCell): Promise<boolean> {
 
 export function runForkCommand(kernel: Kernel, extensionBaseUri: Uri, _grpcRunner: boolean) {
   return async function (cell: NotebookCell) {
+    if (!warnBetaRequired("Please switch to Runme's runner v2 (beta) to fork into terminals.")) {
+      return
+    }
+
     if (!(await runStatusCommand(cell))) {
       return
     }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -19,6 +19,7 @@ import {
   getDocsUrlFor,
   getForceNewWindowConfig,
   getRunmeAppUrl,
+  getServerRunnerVersion,
   getSessionOutputs,
 } from '../utils/configuration'
 import { AuthenticationProviders, TELEMETRY_EVENTS, WebViews } from '../constants'
@@ -344,6 +345,8 @@ export class RunmeExtension {
         aiManager.completionGenerator.generateCompletion,
       ),
     )
+
+    TelemetryReporter.sendTelemetryEvent('config', { runnerVersion: getServerRunnerVersion() })
 
     await bootFile(context)
 

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -52,11 +52,7 @@ import {
 } from '../constants'
 import { API } from '../utils/deno/api'
 import { postClientMessage } from '../utils/messaging'
-import {
-  getNotebookExecutionOrder,
-  getServerRunnerVersion,
-  registerExtensionEnvVarsMutation,
-} from '../utils/configuration'
+import { getNotebookExecutionOrder, registerExtensionEnvVarsMutation } from '../utils/configuration'
 import features, { FEATURES_CONTEXT_STATE_KEY } from '../features'
 
 import getLogger from './logger'
@@ -80,6 +76,7 @@ import {
   getWorkspaceFolder,
   getRunnerSessionEnvs,
   getEnvProps,
+  warnBetaRequired,
 } from './utils'
 import { getEventReporter } from './ai/events'
 import { getSystemShellPath, isShellLanguage } from './executors/utils'
@@ -1102,21 +1099,7 @@ export class Kernel implements Disposable {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         token: CancellationToken,
       ) {
-        if (getServerRunnerVersion() === 'v1') {
-          const action = 'Configure Runner'
-          window
-            .showWarningMessage(
-              // eslint-disable-next-line max-len
-              "Please switch to Runme's runner v2 (available in beta) to use Runme Terminal. Please restart VS Code after configuration changes.",
-              action,
-            )
-            .then((selected) => {
-              if (selected !== action) {
-                return
-              }
-              return commands.executeCommand('runme.openSettings', 'runme.server.runnerVersion')
-            })
-
+        if (!warnBetaRequired("Please switch to Runme's runner v2 (beta) to use Runme Terminal.")) {
           throw new Error('Runme terminal requires runner v2')
         }
 

--- a/src/extension/provider/cellStatusBar/notebook.ts
+++ b/src/extension/provider/cellStatusBar/notebook.ts
@@ -7,12 +7,10 @@ import {
 
 import { Kernel } from '../../kernel'
 import { GrpcSerializer } from '../../serializer'
-import { getServerRunnerVersion } from '../../../utils/configuration'
 
 import { AnnotationsStatusBarItem } from './items/annotations'
 import { CopyStatusBarItem } from './items/copy'
 import CellStatusBarItem from './items/cellStatusBarItem'
-import { CLIStatusBarItem } from './items/cli'
 import { ForkStatusBarItem } from './items/fork'
 import { NamedStatusBarItem } from './items/named'
 
@@ -27,15 +25,9 @@ export class NotebookCellStatusBarProvider implements NotebookCellStatusBarItemP
     this.#cellStatusBarItems.add(new AnnotationsStatusBarItem(this.kernel))
     this.#cellStatusBarItems.add(new CopyStatusBarItem(this.kernel))
     this.#cellStatusBarItems.add(new NamedStatusBarItem(this.kernel))
-
-    switch (getServerRunnerVersion()) {
-      case 'v1':
-        this.#cellStatusBarItems.add(new CLIStatusBarItem(this.kernel))
-        break
-      default:
-        this.#cellStatusBarItems.add(new ForkStatusBarItem(this.kernel))
-        break
-    }
+    // todo(sebastian): disable for Fork; retire it?
+    // this.#cellStatusBarItems.add(new CLIStatusBarItem(this.kernel))
+    this.#cellStatusBarItems.add(new ForkStatusBarItem(this.kernel))
 
     this.#registerCommands()
   }

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -54,6 +54,7 @@ import {
   getMaskOutputs,
   getNotebookAutoSave,
   getPortNumber,
+  getServerRunnerVersion,
   getTLSDir,
   getTLSEnabled,
 } from '../utils/configuration'
@@ -857,4 +858,26 @@ export function getEnvProps(extension: { id: string; version: string }) {
   }
 
   return extProps
+}
+
+export function warnBetaRequired(message: string): boolean {
+  if (getServerRunnerVersion() !== 'v1') {
+    return true
+  }
+
+  const action = 'Configure Runner'
+  window
+    .showWarningMessage(
+      // eslint-disable-next-line max-len
+      `${message.length ? message + ' ' : ''}Please restart VS Code after configuration changes.`,
+      action,
+    )
+    .then((selected) => {
+      if (selected !== action) {
+        return
+      }
+      return commands.executeCommand('runme.openSettings', 'runme.server.runnerVersion')
+    })
+
+  return false
 }


### PR DESCRIPTION
Display a warning message and encourage users to switch to the `v2` (beta) version to take advantage of the feature.

This will make it more self-explanatory how to get started while still in beta.