### PR TITLE
Add support to perform copy to clipboard on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,16 @@
   "main": "./out/extension.js",
   "runme": {
     "features": {
+      "CopySelectionToClipboard": {
+        "enabled": true,
+        "conditions": {
+          "os": "linux",
+          "enabledForExtensions": {
+            "stateful.platform": true,
+            "stateful.runme": true
+          }
+        }
+      },
       "RequireStatefulAuth": {
         "enabled": true,
         "conditions": {

--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -442,6 +442,17 @@ export class TerminalView extends LitElement {
     this.terminal.loadAddon(this.serializer)
     this.terminal.loadAddon(new Unicode11Addon())
     this.terminal.loadAddon(new WebLinksAddon(this.#onWebLinkClick.bind(this)))
+
+    this.terminal.attachCustomKeyEventHandler((event) => {
+      if (event.shiftKey && event.ctrlKey && event.key === 'C') {
+        const selection = this?.terminal?.getSelection()
+        if (selection) {
+          navigator.clipboard.writeText(selection)
+          return false
+        }
+      }
+      return true
+    })
     this.terminal.unicode.activeVersion = '11'
     this.terminal.options.drawBoldTextInBrightColors
 

--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -444,7 +444,7 @@ export class TerminalView extends LitElement {
     this.terminal.loadAddon(new WebLinksAddon(this.#onWebLinkClick.bind(this)))
 
     this.terminal.attachCustomKeyEventHandler((event) => {
-      if (!features.isOn(FeatureName.CopySelectionToClipboard)) {
+      if (!features.isOn(FeatureName.CopySelectionToClipboard, this.featureState$)) {
         return true
       }
 

--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -443,16 +443,19 @@ export class TerminalView extends LitElement {
     this.terminal.loadAddon(new Unicode11Addon())
     this.terminal.loadAddon(new WebLinksAddon(this.#onWebLinkClick.bind(this)))
 
-    this.terminal.attachCustomKeyEventHandler((event) => {
-      if (event.shiftKey && event.ctrlKey && event.key === 'C') {
-        const selection = this?.terminal?.getSelection()
-        if (selection) {
-          navigator.clipboard.writeText(selection)
-          return false
+    if (features.isOn(FeatureName.CopySelectionToClipboard)) {
+      this.terminal.attachCustomKeyEventHandler((event) => {
+        if (event.shiftKey && event.ctrlKey && event.key === 'C') {
+          const selection = this?.terminal?.getSelection()
+          if (selection) {
+            navigator.clipboard.writeText(selection)
+            return false
+          }
         }
-      }
-      return true
-    })
+        return true
+      })
+    }
+
     this.terminal.unicode.activeVersion = '11'
     this.terminal.options.drawBoldTextInBrightColors
 

--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -443,19 +443,20 @@ export class TerminalView extends LitElement {
     this.terminal.loadAddon(new Unicode11Addon())
     this.terminal.loadAddon(new WebLinksAddon(this.#onWebLinkClick.bind(this)))
 
-    if (features.isOn(FeatureName.CopySelectionToClipboard)) {
-      this.terminal.attachCustomKeyEventHandler((event) => {
-        if (event.shiftKey && event.ctrlKey && event.code === 'KeyC') {
-          const selection = this?.terminal?.getSelection()
-          if (selection) {
-            navigator.clipboard.writeText(selection)
-            return false
-          }
-        }
+    this.terminal.attachCustomKeyEventHandler((event) => {
+      if (!features.isOn(FeatureName.CopySelectionToClipboard)) {
         return true
-      })
-    }
+      }
 
+      if (event.shiftKey && event.ctrlKey && event.code === 'KeyC') {
+        const selection = this?.terminal?.getSelection()
+        if (selection) {
+          navigator.clipboard.writeText(selection)
+          return false
+        }
+      }
+      return true
+    })
     this.terminal.unicode.activeVersion = '11'
     this.terminal.options.drawBoldTextInBrightColors
 

--- a/src/client/components/terminal/index.ts
+++ b/src/client/components/terminal/index.ts
@@ -445,7 +445,7 @@ export class TerminalView extends LitElement {
 
     if (features.isOn(FeatureName.CopySelectionToClipboard)) {
       this.terminal.attachCustomKeyEventHandler((event) => {
-        if (event.shiftKey && event.ctrlKey && event.key === 'C') {
+        if (event.shiftKey && event.ctrlKey && event.code === 'KeyC') {
           const selection = this?.terminal?.getSelection()
           if (selection) {
             navigator.clipboard.writeText(selection)

--- a/src/types.ts
+++ b/src/types.ts
@@ -770,6 +770,7 @@ export enum FeatureName {
   ForceLogin = 'ForceLogin',
   SignedIn = 'SignedIn',
   RequireStatefulAuth = 'RequireStatefulAuth',
+  CopySelectionToClipboard = 'CopySelectionToClipboard',
 }
 
 export type Feature = {


### PR DESCRIPTION
On Linux, the Notebook Terminal, it doesn't have the native capability to allow copy the selected text. Only works using the third mouse button to paste, I think this is a behavior of the X Server-Client.

This PR includes changes to allow copy to the clipboard using the most used keyboard shortcut, which is `SHIFT+CTRL+C`. It is designed to avoid conflicts with the `CTRL+C` (Terminate process).

