### PR TITLE
Make lifecycle identity truly optional in Runme

### DIFF
--- a/package.json
+++ b/package.json
@@ -767,7 +767,7 @@
           "runme.server.lifecycleIdentity": {
             "type": "number",
             "scope": "window",
-            "default": 3,
+            "default": 0,
             "enum": [
               0,
               1,

--- a/package.json
+++ b/package.json
@@ -389,6 +389,12 @@
         "description": "Lifecycle Identity - Cell"
       },
       {
+        "command": "runme.lifecycleIdentitySelection",
+        "title": "Lifecycle Identity by Selection",
+        "category": "Runme",
+        "description": "Lifecycle Identity by Selection"
+      },
+      {
         "command": "runme.openCloudPanel",
         "title": "Open Cloud Panel",
         "category": "Runme",
@@ -397,6 +403,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "runme.lifecycleIdentitySelection",
+          "when": "false"
+        },
         {
           "command": "runme.toggleTerminal",
           "when": "false"

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -381,7 +381,7 @@ export class RunmeExtension {
 
           await Promise.all(
             workspace.notebookDocuments.map((doc) =>
-              serializer.switchNotebookIdentity(doc, identity),
+              serializer.switchLifecycleIdentity(doc, identity),
             ),
           )
         },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -20,9 +20,8 @@ import {
   getForceNewWindowConfig,
   getRunmeAppUrl,
   getServerRunnerVersion,
-  getServerConfigurationValue,
   getSessionOutputs,
-  ServerLifecycleIdentity,
+  getServerLifecycleIdentity,
 } from '../utils/configuration'
 import {
   AuthenticationProviders,
@@ -349,19 +348,43 @@ export class RunmeExtension {
       }),
 
       RunmeExtension.registerCommand('runme.lifecycleIdentityNone', () =>
-        ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.UNSPECIFIED),
+        commands.executeCommand('runme.lifecycleIdentitySelection', RunmeIdentity.UNSPECIFIED),
       ),
 
       RunmeExtension.registerCommand('runme.lifecycleIdentityAll', () =>
-        ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.ALL),
+        commands.executeCommand('runme.lifecycleIdentitySelection', RunmeIdentity.ALL),
       ),
 
       RunmeExtension.registerCommand('runme.lifecycleIdentityDoc', () =>
-        ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.DOCUMENT),
+        commands.executeCommand('runme.lifecycleIdentitySelection', RunmeIdentity.DOCUMENT),
       ),
 
       RunmeExtension.registerCommand('runme.lifecycleIdentityCell', () =>
-        ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.CELL),
+        commands.executeCommand('runme.lifecycleIdentitySelection', RunmeIdentity.CELL),
+      ),
+
+      RunmeExtension.registerCommand(
+        'runme.lifecycleIdentitySelection',
+        async (identity?: RunmeIdentity) => {
+          if (identity === undefined) {
+            window.showErrorMessage('Cannot run command without identity selection')
+            return
+          }
+
+          // skip if lifecycle identity selection didn't change
+          const current = ContextState.getKey(NOTEBOOK_LIFECYCLE_ID)
+          if (current === identity) {
+            return
+          }
+
+          await ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, identity)
+
+          await Promise.all(
+            workspace.notebookDocuments.map((doc) =>
+              serializer.switchNotebookIdentity(doc, identity),
+            ),
+          )
+        },
       ),
 
       RunmeExtension.registerCommand('runme.openCloudPanel', () =>
@@ -478,13 +501,10 @@ export class RunmeExtension {
       ) {
         getPlatformAuthSession(false, true).then(async (session) => {
           if (!!session) {
-            await ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, RunmeIdentity.ALL)
+            await commands.executeCommand('runme.lifecycleIdentitySelection', RunmeIdentity.ALL)
           } else {
-            const current = getServerConfigurationValue<ServerLifecycleIdentity>(
-              'lifecycleIdentity',
-              RunmeIdentity.ALL,
-            )
-            await ContextState.addKey(NOTEBOOK_LIFECYCLE_ID, current)
+            const current = getServerLifecycleIdentity()
+            await commands.executeCommand('runme.lifecycleIdentitySelection', current)
           }
           kernel.updateFeatureContext('statefulAuth', !!session)
         })

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -503,8 +503,8 @@ export class RunmeExtension {
           if (!!session) {
             await commands.executeCommand('runme.lifecycleIdentitySelection', RunmeIdentity.ALL)
           } else {
-            const current = getServerLifecycleIdentity()
-            await commands.executeCommand('runme.lifecycleIdentitySelection', current)
+            const settingsDefault = getServerLifecycleIdentity()
+            await commands.executeCommand('runme.lifecycleIdentitySelection', settingsDefault)
           }
           kernel.updateFeatureContext('statefulAuth', !!session)
         })

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -41,7 +41,7 @@ export default async function saveCellExecution(
 
   log.info('Saving cell execution')
 
-  const frontmatter = GrpcSerializer.marshallFrontmatter(
+  const frontmatter = GrpcSerializer.marshalFrontmatter(
     editor.notebook.metadata as { ['runme.dev/frontmatter']: string },
     kernel,
   )

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -6,12 +6,7 @@ import getMAC from 'getmac'
 import YAML from 'yaml'
 import { FetchResult } from '@apollo/client'
 
-import {
-  ClientMessages,
-  NOTEBOOK_AUTOSAVE_ON,
-  NOTEBOOK_LIFECYCLE_ID,
-  RUNME_FRONTMATTER_PARSED,
-} from '../../../constants'
+import { ClientMessages, NOTEBOOK_AUTOSAVE_ON, RUNME_FRONTMATTER_PARSED } from '../../../constants'
 import { ClientMessage, FeatureName, IApiMessage } from '../../../types'
 import { postClientMessage } from '../../../utils/messaging'
 import ContextState from '../../contextState'
@@ -77,7 +72,6 @@ export default async function saveCellExecution(
       })
     }
 
-    console.log('NOTEBOOK_LIFECYCLE_ID', ContextState.getKey(NOTEBOOK_LIFECYCLE_ID))
     // Save the file to ensure the serialization completes before saving the cell execution.
     // This guarantees we access the latest cache state of the serializer.
     await editor.notebook.save()

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -370,7 +370,7 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
     )
   }
 
-  public async switchNotebookIdentity(
+  public async switchLifecycleIdentity(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     doc: NotebookDocument,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -691,12 +691,12 @@ export class GrpcSerializer extends SerializerBase {
     return Boolean(sessionOutputId)
   }
 
-  public async switchNotebookIdentity(
+  public override async switchLifecycleIdentity(
     doc: NotebookDocument,
     identity: RunmeIdentity,
   ): Promise<boolean> {
     // skip session outputs files
-    if (!!doc.metadata['runme.dev/frontmatterParsed']?.runme.session.id) {
+    if (!!doc.metadata['runme.dev/frontmatterParsed']?.runme?.session?.id) {
       return false
     }
 

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -724,7 +724,7 @@ export class GrpcSerializer extends SerializerBase {
       if (!descell.metadata?.['id']) {
         return
       }
-      const metadata = { ...deserialized.metadata, ...cell.metadata }
+      const metadata = { ...descell.metadata, ...cell.metadata }
       metadata['id'] = metadata['runme.dev/id']
       edits.push(NotebookEdit.updateCellMetadata(cell.index, metadata))
     })

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -678,7 +678,6 @@ export class GrpcSerializer extends SerializerBase {
 
     // cacheId is always present, stays persistent across multiple de/-serialization cycles
     const cacheId = metadata['runme.dev/cacheId'] as string | undefined
-    console.log('ephemeralId', cacheId)
 
     return cacheId
   }

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -718,10 +718,14 @@ export class GrpcSerializer extends SerializerBase {
     const edits = [notebookEdit]
     doc.getCells().forEach((cell) => {
       const descell = notebook.cells[cell.index]
+      // skip if no IDs are present, means no cell identity required
       if (!descell.metadata?.['id']) {
         return
       }
-      edits.push(NotebookEdit.updateCellMetadata(cell.index, descell.metadata))
+      // copy ephemeral IDs instead of using newly deserialized ones
+      const metadata = { ...cell.metadata }
+      metadata['id'] = metadata['runme.dev/id']
+      edits.push(NotebookEdit.updateCellMetadata(cell.index, metadata))
     })
 
     const edit = new WorkspaceEdit()

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -210,6 +210,13 @@ const getPortNumber = (): number => {
   return SERVER_PORT
 }
 
+const getServerLifecycleIdentity = (): ServerLifecycleIdentity => {
+  return getServerConfigurationValue<ServerLifecycleIdentity>(
+    'lifecycleIdentity',
+    RunmeIdentity.ALL,
+  )
+}
+
 const getCustomServerAddress = (): string | undefined => {
   return getServerConfigurationValue<string | undefined>('customAddress', undefined)
 }
@@ -449,6 +456,7 @@ export {
   getCodeLensPasteIntoTerminalNewline,
   getNotebookExecutionOrder,
   getCustomServerAddress,
+  getServerLifecycleIdentity,
   getEnvLoadWorkspaceFiles,
   getEnvWorkspaceFileOrder,
   getForceNewWindowConfig,

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -213,7 +213,7 @@ const getPortNumber = (): number => {
 const getServerLifecycleIdentity = (): ServerLifecycleIdentity => {
   return getServerConfigurationValue<ServerLifecycleIdentity>(
     'lifecycleIdentity',
-    RunmeIdentity.ALL,
+    RunmeIdentity.UNSPECIFIED,
   )
 }
 

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -120,7 +120,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(5)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(47)
+  expect(commands.registerCommand).toBeCalledTimes(48)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)

--- a/tests/extension/fixtures/marshalNotebook.json
+++ b/tests/extension/fixtures/marshalNotebook.json
@@ -613,6 +613,7 @@
   ],
   "metadata": {
     "runme.dev/finalLineBreaks": "1",
+    "runme.dev/cacheId": "01J97S5FVEKBPD9GAH0AZBV0HB",
     "runme.dev/frontmatter": "---\nrunme:\n  id: 01HF7B0KJPF469EG9ZWDNKKACQ\n  version: v2.0\n---",
     "runme.dev/frontmatterParsed": {
       "shell": "",

--- a/tests/extension/fixtures/marshalNotebook.json
+++ b/tests/extension/fixtures/marshalNotebook.json
@@ -5,7 +5,7 @@
       "value": "$ date | tee /dev/stderr",
       "languageId": "sh",
       "metadata": {
-        "id": "01HF7B0KJPF469EG9ZVSTKPEZ6",
+        "runme.dev/id": "01HF7B0KJPF469EG9ZVSTKPEZ6",
         "interactive": "true",
         "name": "stdio-test"
       },
@@ -18,7 +18,7 @@
       "languageId": "sh",
       "metadata": {
         "background": "false",
-        "id": "01HF7B0KJPF469EG9ZVX256S75",
+        "runme.dev/id": "01HF7B0KJPF469EG9ZVX256S75",
         "interactive": "true"
       },
       "outputs": [

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -353,13 +353,14 @@ describe('GrpcSerializer', () => {
       expect(applied).toBeFalsy()
     })
 
-    it('should apply identity', async () => {
+    it('should apply lifecycle identity retaining initial ephemeral cell IDs', async () => {
       const fixture = deepCopyFixture()
-      // const lid = fixture.metadata['runme.dev/frontmatterParsed'].runme.id
       const descells = fixture.cells.map((cell, i) => {
         cell.index = i
         const c = { ...cell }
         c.metadata = { ...cell.metadata }
+        // simluate different ephemeral IDs here to make sure they are not used once applied
+        c.metadata['runme.dev/id'] = c.metadata['runme.dev/id'].toString().slice(0, 10)
         c.metadata['id'] = c.metadata['runme.dev/id']
         return c
       })
@@ -370,7 +371,6 @@ describe('GrpcSerializer', () => {
           response: { notebook: { cells: descells, metadata: fixture.metadata } },
         }),
       }
-      // vi.spyOn(GrpcSerializer, 'getOutputsUri').mockReturnValue(fakeSrcDocUri)
       vi.mocked(workspace.applyEdit).mockResolvedValue(true)
 
       const save = vi.fn()

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -330,7 +330,7 @@ describe('GrpcSerializer', () => {
     })
   })
 
-  describe.only('#switchLifecycleIdentity', () => {
+  describe('#switchLifecycleIdentity', () => {
     const fakeSrcDocUri = { fsPath: '/tmp/fake/source.md' } as any
 
     it('should not run for session outputs', async () => {

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -350,7 +350,7 @@ describe('GrpcSerializer', () => {
       expect(applied).toBeFalsy()
     })
 
-    it('should apply lifecycle identity retaining initial ephemeral cell IDs', async () => {
+    it('should apply lifecycle identity retaining initial IDs', async () => {
       const fixture = deepCopyFixture()
       const descells = fixture.cells.map((cell, i) => {
         cell.index = i
@@ -361,11 +361,13 @@ describe('GrpcSerializer', () => {
         c.metadata['id'] = c.metadata['runme.dev/id']
         return c
       })
+      const metadata = { ...fixture.metadata }
+      metadata['runme.dev/cacheId'] = metadata['runme.dev/cacheId'].toString().slice(0, 10)
 
       const serializer: any = new GrpcSerializer(context, new Server(), new Kernel())
       serializer.client = {
         deserialize: vi.fn().mockResolvedValue({
-          response: { notebook: { cells: descells, metadata: fixture.metadata } },
+          response: { notebook: { cells: descells, metadata } },
         }),
       }
       vi.mocked(workspace.applyEdit).mockResolvedValue(true)

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -336,11 +336,8 @@ describe('GrpcSerializer', () => {
     it('should not run for session outputs', async () => {
       const fixture = deepCopyFixture()
       fixture.metadata['runme.dev/frontmatterParsed'].runme.session = { id: 'FAKE-SESSION' }
-      // const lid = fixture.metadata['runme.dev/frontmatterParsed'].runme.id
 
       const serializer: any = new GrpcSerializer(context, new Server(), new Kernel())
-
-      // vi.spyOn(GrpcSerializer, 'getOutputsUri').mockReturnValue(fakeSrcDocUri)
 
       const applied = await serializer.switchLifecycleIdentity(
         {

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -765,7 +765,6 @@ describe('GrpcSerializer', () => {
       const fixture = deepCopyFixture()
 
       fixture.cells.forEach((cell: { metadata: { [x: string]: any } }) => {
-        cell.metadata['runme.dev/id'] = cell.metadata['id']
         delete cell.metadata['id']
         expect(cell.metadata['id']).toBeUndefined()
       })
@@ -778,7 +777,7 @@ describe('GrpcSerializer', () => {
       const ref = deepCopyFixture()
       applied.cells.forEach((cell: { metadata: { [x: string]: any } }, i: number) => {
         expect(cell.metadata['id']).toBeDefined()
-        expect(cell.metadata['id']).toStrictEqual(ref.cells[i].metadata['id'])
+        expect(cell.metadata['runme.dev/id']).toStrictEqual(ref.cells[i].metadata['runme.dev/id'])
       })
     })
   })


### PR DESCRIPTION
This means the default is to have neither cells nor document-level identity.

This PR requires https://github.com/stateful/runme/pull/677 and will now dynamically toggle lifecycle identity. It includes already opened docs that have passed the deserializer in the default off state.

PS: The document-level `runme.dev/id` was renamed to `runme.dev/cacheId` to be specific about its sole purpose.