### PR TITLE
Render markup cells as ghost cells

### DIFF
--- a/src/extension/ai/ghost.ts
+++ b/src/extension/ai/ghost.ts
@@ -187,15 +187,6 @@ export class GhostCellGenerator implements stream.CompletionHandlers {
       }
     })
 
-    // DO NOT COMMIT hardcode a markup cell as the response
-    newCellData = [
-      new vscode.NotebookCellData(
-        vscode.NotebookCellKind.Markup,
-        'This is a generated cell',
-        'markdown',
-      ),
-    ]
-
     // Mark all newCells as ghost cells
     newCellData.forEach((cell) => {
       if (cell.metadata === undefined) {


### PR DESCRIPTION
To support rendering markup cells as ghost cells we use the following hack

1. Insert the markup cells as code cells with languageId "markdown"
2. Replace the cells with a markup cell when the cell is accepted and ghost rendering is removed

To render ghost cells we rely on text decorations to change the font color to the grey color denoting ghost text. Text decorations only show up when a cell is in edit mode. Code cells get inserted in edit mode but markup cells are inserted in rendered mode. As a result the markup cells don't show up as ghost cells (jlewi/foyle#168). Unfortunately, there doesn't seem to be a public API that allows changing the cell mode to edit mode. It seems like putting the markup cell into edit mode requires changing the focus to that cell. I don't think we want to change the focus of the current cell because the user is continuing to type into the current cell and changing the focus would likely cause problems. 

So we use the work around above which is to insert them as code cells and then change them to markup cells on acceptance.

* Fix jlewi/foyle#168