### PR TITLE
Fix Feature Flag runtime overrides

### DIFF
--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -201,19 +201,19 @@ export class Kernel implements Disposable {
       extensionId: context?.extension?.id as ExtensionName,
     }
 
+    const runmeFeatureSettings = workspace.getConfiguration('runme.features')
+    const featureNames = Object.keys(FeatureName)
+
+    featureNames.forEach((feature) => {
+      if (runmeFeatureSettings.has(feature)) {
+        const result = runmeFeatureSettings.get<boolean>(feature, false)
+        this.#featuresSettings.set(feature, result)
+      }
+    })
+
     this.featuresState$ = features.loadState(packageJSON, featContext, this.#featuresSettings)
 
     if (this.featuresState$) {
-      const runmeFeatures = workspace.getConfiguration('runme.features')
-      const featureNames = Object.keys(FeatureName).map((f) => f.toLowerCase())
-      if (features) {
-        featureNames.forEach((feature) => {
-          if (runmeFeatures.has(feature)) {
-            this.#featuresSettings.set(feature, runmeFeatures.get<boolean>(feature, false))
-          }
-        })
-      }
-
       const subscription = this.featuresState$
         .pipe(map((_state) => features.getSnapshot(this.featuresState$)))
         .subscribe((snapshot) => {

--- a/src/features.ts
+++ b/src/features.ts
@@ -100,7 +100,7 @@ function isActive(
     enabledForExtensions,
   } = feature.conditions
 
-  if (!checkEnabled(feature.enabled, overrides.get(featureName.toLowerCase()))) {
+  if (!checkEnabled(feature.enabled, overrides.get(featureName))) {
     console.log(`Feature "${featureName}" is inactive due to checkEnabled.`)
     return false
   }


### PR DESCRIPTION
- Loads settings before Feature-Flag instance.
- Avoids lower casing to have consistency in the Feature Names (convention).