### PR TITLE
Adds additional headers to support better debugging in the cloud platform

### DIFF
--- a/src/extension/api/client.ts
+++ b/src/extension/api/client.ts
@@ -4,6 +4,7 @@ import fetch from 'cross-fetch'
 import { Uri } from 'vscode'
 
 import { getRunmeAppUrl } from '../../utils/configuration'
+import { getFeaturesContext } from '../features'
 
 export function InitializeClient({
   uri,
@@ -13,11 +14,16 @@ export function InitializeClient({
   runmeToken: string
 }) {
   const authLink = setContext((_, { headers }) => {
+    const context = getFeaturesContext()
     return {
       headers: {
         ...headers,
         'Auth-Provider': 'platform',
         authorization: runmeToken ? `Bearer ${runmeToken}` : '',
+        'X-Extension-Id': context?.extensionId,
+        'X-Extension-Os': context?.os,
+        'X-Extension-Version': context?.extensionVersion,
+        'X-Code-Version': context?.vsCodeVersion,
       },
     }
   })

--- a/src/extension/features.ts
+++ b/src/extension/features.ts
@@ -17,3 +17,14 @@ export function isOnInContextState(featureName: FeatureName): boolean {
 export default {
   isOnInContextState,
 }
+
+export function getFeaturesContext() {
+  const snapshot = ContextState.getKey<string>(FEATURES_CONTEXT_STATE_KEY)
+  if (!snapshot) {
+    return
+  }
+
+  const featureState$ = features.loadSnapshot(snapshot)
+
+  return featureState$.getValue().context
+}


### PR DESCRIPTION
The user agent header is incorrectly set to `node-fetch/1.0 (+https://github.com/bitinn/node-fetch)`, instead of reflecting the actual VS Code platform.


New headers example:

![image](https://github.com/user-attachments/assets/938e1db3-96fa-4e2e-8743-7855b4ffb6c3)