### PR TITLE
Add a Foyle status bar in the lower right corner

### DIFF
--- a/src/extension/ai/manager.ts
+++ b/src/extension/ai/manager.ts
@@ -9,6 +9,8 @@ import * as ghost from './ghost'
 import * as stream from './stream'
 import * as generate from './generate'
 import * as events from './events'
+import { SessionManager } from './sessions'
+
 // AIManager is a class that manages the AI services.
 export class AIManager {
   log: ReturnType<typeof getLogger>
@@ -69,6 +71,29 @@ export class AIManager {
       vscode.window.onDidChangeActiveTextEditor(cellGenerator.handleOnDidChangeActiveTextEditor),
       // vscode.window.onDidChangeActiveTextEditor(localOnDidChangeActiveTextEditor),
     )
+
+    // Create a new status bar item aligned to the right
+    let statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
+    statusBarItem.text = 'Session: <None>'
+    statusBarItem.tooltip = 'Foyle Session ID; click to copy to clipboard.'
+
+    // Attach a command to the status bar item
+    statusBarItem.command = 'extension.copyStatusBarText'
+    // Command to copy the status bar text to the clipboard
+    const copyTextCommand = vscode.commands.registerCommand('extension.copyStatusBarText', () => {
+      // Copy the status bar text to the clipboard
+      const pieces = statusBarItem.text.split(' ')
+      let id = '<no session>'
+      if (pieces.length >= 1) {
+        id = pieces[pieces.length - 1]
+      }
+      vscode.env.clipboard.writeText(id)
+    })
+    statusBarItem.show()
+    this.subscriptions.push(copyTextCommand)
+    this.subscriptions.push(statusBarItem)
+
+    SessionManager.resetManager(statusBarItem)
   }
 
   // Cleanup method. We will use this to clean up any resources when extension is closed.

--- a/src/extension/ai/sessions.ts
+++ b/src/extension/ai/sessions.ts
@@ -1,5 +1,6 @@
 import { LogEvent, LogEventType } from '@buf/jlewi_foyle.bufbuild_es/foyle/v1alpha1/agent_pb'
 import { ulid } from 'ulidx'
+import * as vscode from 'vscode'
 
 import { getEventReporter } from './events'
 
@@ -25,17 +26,25 @@ export class SessionManager {
   static instance: SessionManager
 
   sessionID: string
+  statusBar: vscode.StatusBarItem | null
 
-  constructor() {
+  constructor(statusBar: vscode.StatusBarItem | null) {
     this.sessionID = ulid()
+    this.statusBar = statusBar
   }
 
   public static getManager(): SessionManager {
     if (!SessionManager.instance) {
-      SessionManager.instance = new SessionManager()
+      // N.B. This shouldn't be triggered because we should initialize the manager
+      // in the AIManager
+      SessionManager.instance = new SessionManager(null)
     }
 
     return SessionManager.instance
+  }
+
+  public static resetManager(statusBar: vscode.StatusBarItem) {
+    SessionManager.instance = new SessionManager(statusBar)
   }
 
   // getID returns the current session id
@@ -56,6 +65,10 @@ export class SessionManager {
     const openEvent = new LogEvent()
     openEvent.type = LogEventType.SESSION_START
     openEvent.contextId = this.sessionID
+
+    if (this.statusBar !== null) {
+      this.statusBar.text = `Session: ${this.sessionID}`
+    }
 
     getEventReporter().reportEvents([closeEvent, openEvent])
     return this.sessionID


### PR DESCRIPTION
* Use the status bar to display the session id
* The session id is used to track all the AI generations associated with a particular context

* Surfacing the session id makes it easy to fetch the relevant Foyle logs to understand why the AI made a particular suggestion.

Fix: jlewi/foyle#322