### PR TITLE
Non-blocking event reporting

### DIFF
--- a/src/extension/ai/manager.ts
+++ b/src/extension/ai/manager.ts
@@ -12,7 +12,7 @@ import * as events from './events'
 import { SessionManager } from './sessions'
 
 // AIManager is a class that manages the AI services.
-export class AIManager {
+export class AIManager implements vscode.Disposable {
   log: ReturnType<typeof getLogger>
 
   subscriptions: vscode.Disposable[] = []
@@ -29,8 +29,11 @@ export class AIManager {
     if (autoComplete) {
       this.registerGhostCellEvents()
 
+      const reporter = new events.EventReporter(this.client)
+      this.subscriptions.push(reporter)
+
       // Update the global event reporter to use the AI service
-      events.setEventReporter(new events.EventReporter(this.client))
+      events.setEventReporter(reporter)
     }
   }
 

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -826,8 +826,7 @@ export class Kernel implements Disposable {
     }
 
     // todo(sebastian): rewrite to use non-blocking impl
-    const execCellReport = getEventReporter().reportExecution(cell, successfulCellExecution)
-    await execCellReport
+    getEventReporter().reportExecution(cell, successfulCellExecution)
 
     TelemetryReporter.sendTelemetryEvent('cell.endExecute', {
       'cell.success': successfulCellExecution?.toString(),


### PR DESCRIPTION
Use subject (special observable) to separate the producer from the consumer to keep the producer path unblocked.