### PR TITLE
Dependabot config to pin `@types/node` to `v20`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,14 @@ updates:
       - dependency-name: "vscode-uri"
       # Deprecated
       - dependency-name: "@vercel/client"
+
     groups:
+      types-node:
+        patterns:
+          - "@types/node"
+        update-types:
+          - minor
+          - patch
       aws-sdk:
         patterns:
           - "@aws-sdk/client-ec2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@graphql-codegen/client-preset": "^4.4.0",
         "@graphql-codegen/typescript": "4.1.0",
         "@octokit/rest": "^19.0.13",
-        "@types/node": "^18.19.14",
+        "@types/node": "^20.17.2",
         "@types/node-fetch": "^2.6.11",
         "@types/semver": "^7.5.8",
         "@types/uuid": "^10.0.0",
@@ -4580,11 +4580,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-    },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -7042,11 +7037,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "version": "20.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.2.tgz",
+      "integrity": "sha512-OOHK4sjXqkL7yQ7VEEHcf6+0jSvKjWqwnaCtY7AKD/VLEvRHMsxxu7eI8ErnjxHS8VwmekD4PeVCpu4qZEZSxg==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -8370,12 +8366,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@wdio/cli/node_modules/undici-types": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
-      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==",
-      "dev": true
-    },
     "node_modules/@wdio/config": {
       "version": "8.40.6",
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.40.6.tgz",
@@ -8455,12 +8445,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/@wdio/local-runner/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
-    },
     "node_modules/@wdio/logger": {
       "version": "8.38.0",
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.38.0.tgz",
@@ -8514,12 +8498,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/@wdio/mocha-framework/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
-    },
     "node_modules/@wdio/protocols": {
       "version": "8.40.3",
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.40.3.tgz",
@@ -8546,12 +8524,6 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
-    },
-    "node_modules/@wdio/repl/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
     },
     "node_modules/@wdio/reporter": {
       "version": "8.40.6",
@@ -8587,12 +8559,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/@wdio/reporter/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
-    },
     "node_modules/@wdio/runner": {
       "version": "8.40.6",
       "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-8.40.6.tgz",
@@ -8623,12 +8589,6 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
-    },
-    "node_modules/@wdio/runner/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
     },
     "node_modules/@wdio/spec-reporter": {
       "version": "8.40.6",
@@ -8678,12 +8638,6 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
-    },
-    "node_modules/@wdio/types/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
     },
     "node_modules/@wdio/utils": {
       "version": "8.40.6",
@@ -22503,9 +22457,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.0",
@@ -23414,12 +23369,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/webdriver/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
-    },
     "node_modules/webdriverio": {
       "version": "8.40.6",
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.40.6.tgz",
@@ -23484,12 +23433,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/webdriverio/node_modules/undici-types": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
-      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==",
-      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1226,7 +1226,7 @@
     "@graphql-codegen/client-preset": "^4.4.0",
     "@graphql-codegen/typescript": "4.1.0",
     "@octokit/rest": "^19.0.13",
-    "@types/node": "^18.19.14",
+    "@types/node": "^20.17.2",
     "@types/node-fetch": "^2.6.11",
     "@types/semver": "^7.5.8",
     "@types/uuid": "^10.0.0",


### PR DESCRIPTION
Pins the module `@types/node` to the v20.x in order to be consistent with the Node version.