### PR TITLE
Wait for authentication to complete before you can save a cell

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -327,4 +327,9 @@ export enum EndOfLine {
   CRLF = 2
 }
 
+export class CancellationTokenSource {
+  cancel = vi.fn()
+  dispose = vi.fn()
+}
+
 export const version = '9.9.9'

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -1,6 +1,15 @@
 import os from 'node:os'
 
-import { Uri, env, workspace, commands } from 'vscode'
+import {
+  Uri,
+  env,
+  workspace,
+  commands,
+  EventEmitter,
+  AuthenticationSessionsChangeEvent,
+  window,
+  CancellationTokenSource,
+} from 'vscode'
 import { TelemetryReporter } from 'vscode-telemetry'
 import getMAC from 'getmac'
 import YAML from 'yaml'
@@ -31,13 +40,22 @@ import {
 } from '../../__generated-platform__/graphql'
 import { Frontmatter } from '../../grpc/parser/tcp/types'
 import { getCellById } from '../../cell'
-import { StatefulAuthProvider } from '../../provider/statefulAuth'
+import {
+  AUTH_TIMEOUT,
+  StatefulAuthProvider,
+  StatefulAuthSession,
+} from '../../provider/statefulAuth'
 import features from '../../features'
+import AuthSessionChangeHandler from '../../authSessionChangeHandler'
+import { promiseFromEvent } from '../../../utils/promiseFromEvent'
 import { getDocumentCacheId } from '../../serializer/serializer'
 import { ConnectSerializer } from '../../serializer'
 export type APIRequestMessage = IApiMessage<ClientMessage<ClientMessages.platformApiRequest>>
 
 const log = getLogger('SaveCell')
+type SessionType = StatefulAuthSession | undefined
+
+let currentCts: CancellationTokenSource | undefined
 
 export default async function saveCellExecution(
   requestMessage: APIRequestMessage,
@@ -45,6 +63,13 @@ export default async function saveCellExecution(
 ): Promise<void | boolean> {
   const isReporterEnabled = features.isOnInContextState(FeatureName.ReporterAPI)
   const { messaging, message, editor } = requestMessage
+
+  if (currentCts) {
+    currentCts.cancel()
+  }
+
+  currentCts = new CancellationTokenSource()
+  const { token } = currentCts
 
   try {
     const autoSaveIsOn = ContextState.getKey<boolean>(NOTEBOOK_AUTOSAVE_ON)
@@ -58,12 +83,55 @@ export default async function saveCellExecution(
 
     if (!session && message.output.data.isUserAction) {
       await commands.executeCommand('runme.openCloudPanel')
-      return postClientMessage(messaging, ClientMessages.platformApiResponse, {
-        data: {
-          displayShare: false,
-        },
-        id: message.output.id,
-      })
+
+      const authenticationEvent = new EventEmitter<StatefulAuthSession | undefined>()
+
+      const callback = (_e: AuthenticationSessionsChangeEvent) => {
+        AuthSessionChangeHandler.instance.removeListener(callback)
+        StatefulAuthProvider.instance.currentSession().then((session) => {
+          authenticationEvent.fire(session)
+        })
+      }
+
+      AuthSessionChangeHandler.instance.addListener(callback)
+
+      if (token.isCancellationRequested) {
+        return
+      }
+
+      try {
+        session = await Promise.race([
+          promiseFromEvent<SessionType, SessionType>(authenticationEvent.event).promise,
+          new Promise<undefined>((resolve, reject) => {
+            const timeoutId = setTimeout(() => reject(undefined), AUTH_TIMEOUT)
+            token.onCancellationRequested(() => {
+              clearTimeout(timeoutId)
+              reject(new Error('Operation cancelled'))
+            })
+          }),
+        ])
+      } finally {
+        authenticationEvent.dispose()
+
+        if (token.isCancellationRequested) {
+          log.info('Cancelling authentication event')
+          return
+        }
+
+        if (!session) {
+          await postClientMessage(messaging, ClientMessages.platformApiResponse, {
+            data: {
+              displayShare: false,
+            },
+            id: message.output.id,
+          })
+
+          window.showErrorMessage(
+            'Login is required to save your cells. Please log in to continue.',
+          )
+          return
+        }
+      }
     }
 
     const graphClient = await InitializeCloudClient()
@@ -318,5 +386,10 @@ export default async function saveCellExecution(
       id: message.output.id,
       hasErrors: true,
     })
+  } finally {
+    if (currentCts?.token === token) {
+      currentCts.dispose()
+      currentCts = undefined
+    }
   }
 }

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -126,8 +126,8 @@ export default async function saveCellExecution(
             id: message.output.id,
           })
 
-          window.showErrorMessage(
-            'Login is required to save your cells. Please log in to continue.',
+          window.showWarningMessage(
+            'Saving timed out. Sign in to save your cells. Please try again.',
           )
           return
         }

--- a/src/utils/promiseFromEvent.ts
+++ b/src/utils/promiseFromEvent.ts
@@ -1,0 +1,70 @@
+import { Disposable, Event, EventEmitter } from 'vscode'
+
+// Interface declaration for a PromiseAdapter
+export interface PromiseAdapter<T, U> {
+  // Function signature of the PromiseAdapter
+  (
+    // Input value of type T that the adapter function will process
+    value: T,
+    // Function to resolve the promise with a value of type U or a promise that resolves to type U
+    resolve: (value: U | PromiseLike<U>) => void,
+    // Function to reject the promise with a reason of any type
+    reject: (reason: any) => void,
+  ): any // The function can return a value of any type
+}
+
+const passthrough = (value: any, resolve: (value?: any) => void) => resolve(value)
+
+/**
+ * Return a promise that resolves with the next emitted event, or with some future
+ * event as decided by an adapter.
+ *
+ * If specified, the adapter is a function that will be called with
+ * `(event, resolve, reject)`. It will be called once per event until it resolves or
+ * rejects.
+ *
+ * The default adapter is the passthrough function `(value, resolve) => resolve(value)`.
+ *
+ * @param event the event
+ * @param adapter controls resolution of the returned promise
+ * @returns a promise that resolves or rejects as specified by the adapter
+ */
+export function promiseFromEvent<T, U>(
+  event: Event<T>,
+  adapter: PromiseAdapter<T, U> = passthrough,
+): { promise: Promise<U>; cancel: EventEmitter<void> } {
+  let subscription: Disposable
+  let cancel = new EventEmitter<void>()
+
+  // Return an object containing a promise and a cancel EventEmitter
+  return {
+    // Creating a new Promise
+    promise: new Promise<U>((resolve, reject) => {
+      // Listening for the cancel event and rejecting the promise with 'Cancelled' when it occurs
+      cancel.event((_) => reject('Cancelled'))
+      // Subscribing to the event
+      subscription = event((value: T) => {
+        try {
+          // Resolving the promise with the result of the adapter function
+          Promise.resolve(adapter(value, resolve, reject)).catch(reject)
+        } catch (error) {
+          // Rejecting the promise if an error occurs during execution
+          reject(error)
+        }
+      })
+    }).then(
+      // Disposing the subscription and returning the result when the promise resolves
+      (result: U) => {
+        subscription.dispose()
+        return result
+      },
+      // Disposing the subscription and re-throwing the error when the promise rejects
+      (error) => {
+        subscription.dispose()
+        throw error
+      },
+    ),
+    // Returning the cancel EventEmitter
+    cancel,
+  }
+}


### PR DESCRIPTION
This update ensures that users must complete the authentication process before saving a cell. It improves reliability by handling authentication state transitions seamlessly during cell run, enhancing the user experience.

It now makes its best effort to wait for the user to complete the happy path, keeping the save button in a loading state. If authentication is completed within a minute, the cell is saved automatically without requiring the user to press save again. If authentication fails, the user is notified, and the save button returns to its initial state.


- [x] Event to wait until login finishes. 
- [x] Handle login timeout.
- [x] Edge case: Running cells again while it is waiting for login.

https://github.com/user-attachments/assets/fe879d71-28d3-4b29-83e0-2252ec1bd6f7


