### PR TITLE
Fully async to never block execution

### DIFF
--- a/src/extension/signedIn.ts
+++ b/src/extension/signedIn.ts
@@ -1,0 +1,118 @@
+import { Disposable, NotebookCell, NotebookEditor, authentication } from 'vscode'
+import { mergeMap, withLatestFrom } from 'rxjs/operators'
+import { Observable, Subject, Subscription, from, of } from 'rxjs'
+
+import { APIMethod } from '../types'
+import { ClientMessages } from '../constants'
+
+import { GrpcSerializer } from './serializer'
+import { Kernel } from './kernel'
+import { getPlatformAuthSession } from './utils'
+import './wasm/wasm_exec.js'
+import { RunmeEventInputType } from './__generated-platform__/graphql'
+import getLogger from './logger'
+
+export interface CellRun {
+  cell: { id: any }
+  editor: NotebookEditor
+  notebook: { id: string; path: string }
+  executionSummary: {
+    success: boolean
+    timing: { elapsedTime: number; startTime: string; endTime: string }
+  }
+}
+
+const log = getLogger('LoggedIn')
+
+export class SignedIn implements Disposable {
+  #subscriptions: Subscription[] = []
+  readonly #cellRuns = new Subject<CellRun>()
+
+  constructor(protected readonly kernel: Kernel) {
+    const signedIn$ = new Observable<boolean>((observer) => {
+      authentication.onDidChangeSessions(() => {
+        getPlatformAuthSession(false)
+          .then((session) => observer.next(!!session))
+          .catch(() => observer.next(false))
+      })
+    })
+
+    const cellRuns$ = this.#cellRuns.pipe(
+      withLatestFrom(signedIn$),
+      mergeMap(([cellRun, active]) => {
+        if (!active) {
+          log.info('Discarded cell run reporting because user is not signed in')
+          return of(false)
+        }
+
+        const p = this.kernel.handleRendererMessage({
+          editor: cellRun.editor,
+          message: {
+            output: {
+              data: {
+                type: RunmeEventInputType.RunCell,
+                cell: cellRun.cell,
+                notebook: cellRun.notebook,
+                executionSummary: cellRun.executionSummary,
+              },
+              id: '',
+              method: APIMethod.TrackRunmeEvent,
+            },
+            type: ClientMessages.platformApiRequest,
+          },
+        })
+
+        return from(p.then(() => true).catch(() => false))
+      }),
+    )
+
+    this.#subscriptions.push(cellRuns$.subscribe())
+  }
+
+  enqueueCellRun(
+    cell: NotebookCell,
+    editor: NotebookEditor | undefined,
+    successfulCellExecution: boolean,
+    startTime: number,
+    endTime: number,
+  ): void {
+    const frontmatter = GrpcSerializer.marshalFrontmatter(cell.notebook.metadata, this.kernel)
+
+    const notebookRunmeId = frontmatter.runme?.id
+    const cellRunmeId = cell.metadata['runme.dev/id']
+
+    if (!notebookRunmeId) {
+      log.warn('notebook runme ID not found')
+      return
+    }
+
+    if (!editor) {
+      log.warn('no active notebook editor')
+      return
+    }
+
+    this.#cellRuns.next({
+      cell: {
+        id: cellRunmeId,
+      },
+      editor: editor,
+      notebook: {
+        id: notebookRunmeId,
+        path: cell.notebook.uri.path,
+      },
+      executionSummary: {
+        success: successfulCellExecution,
+        timing: {
+          elapsedTime: endTime - startTime,
+          // Convert to string to handle integers larger than 32 bits
+          startTime: `${startTime}`,
+          endTime: `${endTime}`,
+        },
+      },
+    })
+  }
+
+  dispose() {
+    this.#subscriptions.forEach((sub) => sub.unsubscribe())
+  }
+}

--- a/tests/extension/kernel.test.ts
+++ b/tests/extension/kernel.test.ts
@@ -25,7 +25,8 @@ vi.mock('../../src/extension/ai/events', async () => {
 vi.mock('../../src/extension/signedIn', async () => {
   return {
     SignedIn: class {
-      enqueueCellRun() {}
+      enqueueCellRun = vi.fn()
+      dispose = vi.fn()
     },
   }
 })
@@ -348,7 +349,7 @@ suite('_executeAll', async () => {
   })
 })
 
-suite.only('_doExecuteCell', () => {
+suite('_doExecuteCell', () => {
   beforeEach(() => {
     vi.mocked(workspace.openTextDocument).mockReset()
     vi.mocked(TelemetryReporter.sendTelemetryEvent).mockClear()

--- a/tests/extension/kernel.test.ts
+++ b/tests/extension/kernel.test.ts
@@ -22,6 +22,13 @@ vi.mock('../../src/extension/ai/events', async () => {
     }),
   }
 })
+vi.mock('../../src/extension/signedIn', async () => {
+  return {
+    SignedIn: class {
+      enqueueCellRun() {}
+    },
+  }
+})
 vi.mock('../../src/extension/utils', async () => {
   return {
     getKeyInfo: vi.fn((cell) => ({ key: cell.languageId, uriResource: false })),
@@ -341,7 +348,7 @@ suite('_executeAll', async () => {
   })
 })
 
-suite('_doExecuteCell', () => {
+suite.only('_doExecuteCell', () => {
   beforeEach(() => {
     vi.mocked(workspace.openTextDocument).mockReset()
     vi.mocked(TelemetryReporter.sendTelemetryEvent).mockClear()


### PR DESCRIPTION
1. Break out code that only runs for logged in users
2. Enqueue cell runs (sync), immediately return to unblock execution
3. Report cell runs only for logged in users (async)