### PR TITLE
Open Cloud Panel only when the Save button is clicked

### DIFF
--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -43,7 +43,7 @@ export default async function saveCellExecution(
     const createIfNone = !message.output.data.isUserAction && autoSaveIsOn ? false : true
 
     const session = await getPlatformAuthSession(createIfNone && forceLogin, silent)
-    if (!session) {
+    if (!session && message.output.data.isUserAction) {
       await commands.executeCommand('runme.openCloudPanel')
       return postClientMessage(messaging, ClientMessages.platformApiResponse, {
         data: {


### PR DESCRIPTION
The Cloud Panel was being opened automatically for auto-saving, which is unnecessary. This change ensures it only opens when explicitly required.