### PR TITLE
Separate out feature "OpenTerminalOnStartup" flag from hosted playgrounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,15 @@
           }
         }
       },
+      "OpenTerminalOnStartup": {
+        "enabled": false,
+        "conditions": {
+          "enabledForExtensions": {
+            "stateful.platform": false,
+            "stateful.runme": true
+          }
+        }
+      },
       "NewTreeProvider": {
         "enabled": false,
         "conditions": {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -556,6 +556,9 @@ export class RunmeExtension {
     // only ever enabled in hosted playground
     if (features.isOnInContextState(FeatureName.HostedPlayground)) {
       await features.addTrustedDomains()
+    }
+
+    if (features.isOnInContextState(FeatureName.OpenTerminalOnStartup)) {
       await features.autoOpenTerminal()
     }
   }

--- a/src/extension/features/autoOpenTerminal.ts
+++ b/src/extension/features/autoOpenTerminal.ts
@@ -6,12 +6,12 @@ import ContextState from '../contextState'
 import { isOnInContextState } from '.'
 
 export async function autoOpenTerminal() {
-  if (!isOnInContextState(FeatureName.HostedPlayground)) {
+  if (!isOnInContextState(FeatureName.OpenTerminalOnStartup)) {
     return
   }
 
-  if (!ContextState.getKey<boolean>(`${FeatureName.HostedPlayground}.autoOpenTerminal`)) {
+  if (!ContextState.getKey<boolean>(`${FeatureName.OpenTerminalOnStartup}.autoOpenTerminal`)) {
     await commands.executeCommand('workbench.action.terminal.new')
-    await ContextState.addKey(`${FeatureName.HostedPlayground}.autoOpenTerminal`, true)
+    await ContextState.addKey(`${FeatureName.OpenTerminalOnStartup}.autoOpenTerminal`, true)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -773,6 +773,7 @@ export enum FeatureName {
   RequireStatefulAuth = 'RequireStatefulAuth',
   CopySelectionToClipboard = 'CopySelectionToClipboard',
   NewTreeProvider = 'NewTreeProvider',
+  OpenTerminalOnStartup = 'OpenTerminalOnStartup',
   HostedPlayground = 'HostedPlayground',
   RecommendExtension = 'RecommendExtension',
 }


### PR DESCRIPTION
Provide a standalone toggle with the default `disabled`.