### PR TITLE
Exclude heredoc from normalization

### DIFF
--- a/src/extension/executors/runner/index.ts
+++ b/src/extension/executors/runner/index.ts
@@ -618,10 +618,12 @@ export function prepareCommandSeq(cellText: string, languageId: string): string[
     return cellText ? cellText.split('\n') : []
   }
 
-  return cellText.split('\n').map((l) => {
+  const isHeredoc = cellText.indexOf('<<') !== -1
+
+  return cellText.split('\n').map((l: string) => {
     const stripped = l.trimStart()
 
-    if (stripped.startsWith('$')) {
+    if (stripped.startsWith('$') && !isHeredoc) {
       return stripped.slice(1).trimStart()
     }
 

--- a/tests/extension/executors/runner.test.ts
+++ b/tests/extension/executors/runner.test.ts
@@ -282,6 +282,14 @@ suite('prepareCmdSeq', () => {
       'echo 4',
     ])
   })
+
+  test('should not remove leading dollar signs from heredoc', () => {
+    const heredoc = `Foo="bar"
+cat << EOF
+$Foo
+EOF`
+    expect(prepareCommandSeq(heredoc, 'sh')).toStrictEqual(heredoc.split('\n'))
+  })
 })
 
 suite('promptVariablesAsync function', () => {


### PR DESCRIPTION
Fixes https://github.com/stateful/runme/issues/710.

Moving to `runnerv2`, we should move all normalization into the `ProgramResolve` API.