### PR TITLE
Cut off outputs

### DIFF
--- a/src/extension/executors/runner/index.ts
+++ b/src/extension/executors/runner/index.ts
@@ -40,7 +40,7 @@ import {
   getServerRunnerVersion,
   isNotebookTerminalEnabledForCell,
 } from '../../../utils/configuration'
-import { ITerminalState } from '../../terminal/terminalState'
+import { ITerminalState, XTermState } from '../../terminal/terminalState'
 import { toggleTerminal } from '../../commands'
 import { closeTerminalByEnvID, openTerminalByEnvID } from '../task'
 import {
@@ -243,6 +243,10 @@ export const executeRunner: IKernelRunner = async ({
 
   let mimeType = cellMimeType
   if (interactive) {
+    if (terminalState instanceof XTermState) {
+      terminalState.cleanBuffer()
+    }
+
     if (revealNotebookTerminal) {
       program.registerTerminalWindow('notebook')
       await program.setActiveTerminalWindow('notebook')

--- a/src/extension/terminal/terminalState.ts
+++ b/src/extension/terminal/terminalState.ts
@@ -28,6 +28,7 @@ export class XTermState implements ITerminalState {
   protected xterm: XTerm
   private serializer: SerializeAddon
   private processInfo: IProcessInfoState | undefined
+  protected buffer: string = ''
 
   constructor() {
     // TODO: lines/cols
@@ -48,11 +49,24 @@ export class XTermState implements ITerminalState {
   }
 
   serialize(): string {
-    return this.serializer.serialize()
+    return this.buffer
   }
 
   write(data: string | Uint8Array): void {
     this.xterm.write(data)
+    this.addToBuffer(data)
+  }
+
+  addToBuffer(data: string | Uint8Array): void {
+    if (typeof data === 'string') {
+      this.buffer = this.buffer + data
+    } else {
+      this.buffer = this.buffer + new TextDecoder().decode(data)
+    }
+  }
+
+  cleanBuffer(): void {
+    this.buffer = ''
   }
 
   input(data: string, wasUserInput: boolean): void {

--- a/src/extension/terminal/terminalState.ts
+++ b/src/extension/terminal/terminalState.ts
@@ -1,5 +1,4 @@
 import { Terminal as XTerm } from '@xterm/headless'
-import { SerializeAddon } from '@xterm/addon-serialize'
 
 import { OutputType } from '../../constants'
 import { RunnerExitReason } from '../runner'
@@ -26,7 +25,6 @@ export class XTermState implements ITerminalState {
   readonly outputType = OutputType.terminal
 
   protected xterm: XTerm
-  private serializer: SerializeAddon
   private processInfo: IProcessInfoState | undefined
   protected buffer: string = ''
 
@@ -35,9 +33,6 @@ export class XTermState implements ITerminalState {
     this.xterm = new XTerm({
       allowProposedApi: true,
     })
-
-    this.serializer = new SerializeAddon()
-    this.xterm.loadAddon(this.serializer)
   }
 
   setProcessInfo(processInfo?: IProcessInfoState) {


### PR DESCRIPTION
Serialize the full cell output content when saving a notebook. This is needed because XTerm serialization only returns the content that's visible in the terminal, causing the cell outputs to be saved with "incomplete" content.