### PR TITLE
Fix escape sequences in prompts

### DIFF
--- a/src/extension/executors/runner/index.ts
+++ b/src/extension/executors/runner/index.ts
@@ -33,7 +33,12 @@ import {
   RunProgramOptions,
 } from '../../runner'
 import { IRunnerEnvironment } from '../../runner/environment'
-import { getAnnotations, getCellRunmeId, getTerminalByCell } from '../../utils'
+import {
+  getAnnotations,
+  getCellRunmeId,
+  getTerminalByCell,
+  unescapeShellLiteral,
+} from '../../utils'
 import { postClientMessage } from '../../../utils/messaging'
 import {
   getCloseTerminalOnSuccess,
@@ -609,9 +614,11 @@ export async function promptVariablesAsync(
     case UNRESOLVED_WITH_PLACEHOLDER:
     case UNRESOLVED_WITH_SECRET: {
       const key = variable.name
-      const placeHolder = variable.resolvedValue || variable.originalValue || 'Enter a value please'
       const hasStringValue = variable.status === UNRESOLVED_WITH_PLACEHOLDER
       const isPassword = variable.status === UNRESOLVED_WITH_SECRET
+      const placeHolder = unescapeShellLiteral(
+        variable.resolvedValue || variable.originalValue || 'Enter a value please',
+      )
 
       const userInput = await promptUserForVariable(key, placeHolder, hasStringValue, isPassword)
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -243,6 +243,16 @@ export function normalizeLanguage(l?: string) {
   }
 }
 
+export function unescapeShellLiteral(escaped: string) {
+  return escaped
+    .replace(/\\\(/g, '(')
+    .replace(/\\\)/g, ')')
+    .replace(/\\\{/g, '{')
+    .replace(/\\\}/g, '}')
+    .replace(/\\\[/g, '[')
+    .replace(/\\\]/g, ']')
+}
+
 export async function verifyCheckedInFile(filePath: string) {
   const fileDir = path.dirname(filePath)
   const workspaceFolder = vscode.workspace.workspaceFolders?.find((ws) =>

--- a/tests/extension/utils.test.ts
+++ b/tests/extension/utils.test.ts
@@ -29,6 +29,7 @@ import {
   asWorkspaceRelativePath,
   editJsonc,
   getGitContext,
+  unescapeShellLiteral,
 } from '../../src/extension/utils'
 import { ENV_STORE, DEFAULT_ENV } from '../../src/extension/constants'
 import { CellAnnotations } from '../../src/types'
@@ -249,6 +250,19 @@ test('getKeyInfo', () => {
     key: 'sh',
     resource: 'None',
   })
+})
+
+test('unescapeShellLiteral', () => {
+  expect(unescapeShellLiteral('echo "Hello World!"')).toBe('echo "Hello World!"')
+  expect(unescapeShellLiteral('echo "Hello ${name}!"')).toBe('echo "Hello ${name}!"')
+  expect(unescapeShellLiteral('[Guest type \\(hyperv,proxmox,openstack\\)]')).toBe(
+    '[Guest type (hyperv,proxmox,openstack)]',
+  )
+  expect(unescapeShellLiteral('[IP of waiting server \\{foo\\}]')).toBe(
+    '[IP of waiting server {foo}]',
+  )
+  expect(unescapeShellLiteral('[Guest\\ Type]')).toBe('[Guest\\ Type]')
+  expect(unescapeShellLiteral('\\[Guest Type\\]')).toBe('[Guest Type]')
 })
 
 suite('normalizeLanguage', () => {


### PR DESCRIPTION
Fixes https://github.com/stateful/runme/issues/709.

Prompt messages are unquoted which requires them to be valid shell. Once prompt resolution runs any "values" quoted or not are primarily being used for human-consumption. This is why we're removing backslashes from any form of parentheses.

Doing this on the client-side to keep the Program Resolver pure-shell.