### PR TITLE
Skip GitHub E2E Tests for Forked Repositories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
           RUNME_PROJECT: ${{ github.workspace }}
           SHELL: bash
           GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          FORK_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+          BASE_OWNER: ${{ github.repository_owner }}
       - name: 🔼 Upload Artifacts
         uses: actions/upload-artifact@v4
         if: failure()

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -25,8 +25,8 @@ describe('Runme GitHub Workflow Integration', async () => {
   }
 
   // Skip tests only if PR is from external fork
-  if (eventName === 'pull_request' && forkOwner && forkOwner !== baseOwner) {
-    console.log('Skipping tests for pull request from external fork.')
+  if (eventName === 'pull_request' && forkOwner !== baseOwner) {
+    console.log('Skipping GitHub Workflow Integration tests for pull request from external fork.')
     return
   }
 

--- a/tests/e2e/specs/githubAction.e2e.ts
+++ b/tests/e2e/specs/githubAction.e2e.ts
@@ -7,7 +7,11 @@ const UI_LATENCY_TIMEOUT_SECS = 2 * 60 * 1000
 
 describe('Runme GitHub Workflow Integration', async () => {
   const notebook = new RunmeNotebook()
-  const token = process.env.RUNME_TEST_TOKEN
+  const token = process.env.RUNME_TEST_TOKEN || ''
+  const actor = process.env.GITHUB_ACTOR
+  const eventName = process.env.GITHUB_EVENT_NAME
+  const baseOwner = process.env.BASE_OWNER || ''
+  const forkOwner = process.env.FORK_OWNER || ''
 
   /**
    * Skip GitHub Action tests for local testing due to missing token
@@ -15,8 +19,14 @@ describe('Runme GitHub Workflow Integration', async () => {
   if (
     (!token && !process.env.CI) ||
     process.env.NODE_ENV === 'production' ||
-    process.env.GITHUB_ACTOR === 'dependabot[bot]'
+    actor === 'dependabot[bot]'
   ) {
+    return
+  }
+
+  // Skip tests only if PR is from external fork
+  if (eventName === 'pull_request' && forkOwner && forkOwner !== baseOwner) {
+    console.log('Skipping tests for pull request from external fork.')
     return
   }
 


### PR DESCRIPTION
This E2E test requires organization-level access and can only be properly verified by organization members or after a PR is merged into the main branch.

To streamline the workflow and avoid unnecessary failures, this test is now disabled for forked repositories, similar to how Dependabot PRs are handled.