### PR TITLE
Added Command: `runme.authenticateWithStateful`

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,15 +304,15 @@
       },
       {
         "command": "runme.authenticateWithGitHub",
-        "title": "Authenticate Runme with GitHub",
+        "title": "Sign in with GitHub",
         "category": "Runme",
-        "description": "Give access to Runme to interact with GitHub API"
+        "description": "Give access to Runme to interact with GitHub's APIs"
       },
       {
         "command": "runme.authenticateWithStateful",
-        "title": "Authenticate Runme with Stateful",
+        "title": "Sign in with Stateful",
         "category": "Runme",
-        "description": "Give access to Runme to interact with Stateful"
+        "description": "Give access to Runme to interact with Stateful Cloud"
       },
       {
         "command": "runme.runCategory",

--- a/package.json
+++ b/package.json
@@ -309,6 +309,12 @@
         "description": "Give access to Runme to interact with GitHub API"
       },
       {
+        "command": "runme.authenticateWithStateful",
+        "title": "Authenticate Runme with Stateful",
+        "category": "Runme",
+        "description": "Give access to Runme to interact with Stateful"
+      },
+      {
         "command": "runme.runCategory",
         "category": "Runme",
         "title": "Execute by Tag",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -333,6 +333,9 @@ export class RunmeExtension {
         treeViewer.excludeUnnamed.bind(treeViewer),
       ),
       RunmeExtension.registerCommand('runme.authenticateWithGitHub', authenticateWithGitHub),
+      RunmeExtension.registerCommand('runme.authenticateWithStateful', () => {
+        StatefulAuthProvider.instance.newSession()
+      }),
       /**
        * Uri handler
        */

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -124,7 +124,7 @@ test('initializes all providers', async () => {
   await ext.initialize(context)
   expect(notebooks.registerNotebookCellStatusBarItemProvider).toBeCalledTimes(5)
   expect(workspace.registerNotebookSerializer).toBeCalledTimes(1)
-  expect(commands.registerCommand).toBeCalledTimes(49)
+  expect(commands.registerCommand).toBeCalledTimes(50)
   expect(window.registerTreeDataProvider).toBeCalledTimes(1)
   expect(window.registerUriHandler).toBeCalledTimes(1)
   expect(bootFile).toBeCalledTimes(1)


### PR DESCRIPTION
This update introduces the runme.authenticateWithStateful command, enabling authentication independently of the Cloud Panel.

Previously, users could not authenticate when the Cloud Panel was unavailable. This command resolves that limitation, providing a direct way to authenticate with Stateful.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/08265edc-e11a-46d4-ad9a-ed91b9e39c09" />
