### PR TITLE
Adds support to manually refresh launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,6 +265,12 @@
         "icon": "$(debug-collapse-all)"
       },
       {
+        "command": "runme.refreshTasks",
+        "category": "Runme",
+        "title": "Refresh tasks",
+        "icon": "$(sync)"
+      },
+      {
         "command": "runme.expandTreeView",
         "category": "Runme",
         "title": "Expand all items",
@@ -491,6 +497,10 @@
           "when": "false"
         },
         {
+          "command": "runme.refreshTasks",
+          "when": "false"
+        },
+        {
           "command": "runme.expandTreeView",
           "when": "false"
         },
@@ -572,6 +582,11 @@
         {
           "command": "runme.tasksExcludeUnnamed",
           "when": "view == runme.launcher && runme.launcher.includeUnnamed",
+          "group": "navigation"
+        },
+        {
+          "command": "runme.refreshTasks",
+          "when": "view == runme.launcher",
           "group": "navigation"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -259,16 +259,17 @@
         "title": "Dispose terminal session to stop background task."
       },
       {
+        "command": "runme.refreshTasks",
+        "category": "Runme",
+        "title": "Refresh tasks",
+        "shortTitle": "Refresh",
+        "icon": "$(extensions-refresh)"
+      },
+      {
         "command": "runme.collapseTreeView",
         "category": "Runme",
         "title": "Collapse all items",
         "icon": "$(debug-collapse-all)"
-      },
-      {
-        "command": "runme.refreshTasks",
-        "category": "Runme",
-        "title": "Refresh tasks",
-        "icon": "$(sync)"
       },
       {
         "command": "runme.expandTreeView",
@@ -565,29 +566,29 @@
       ],
       "view/title": [
         {
+          "command": "runme.refreshTasks",
+          "when": "view == runme.launcher",
+          "group": "navigation@0"
+        },
+        {
           "command": "runme.collapseTreeView",
           "when": "view == runme.launcher && runme.launcher.isExpanded",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "runme.expandTreeView",
           "when": "view == runme.launcher && !runme.launcher.isExpanded",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "runme.tasksIncludeUnnamed",
           "when": "view == runme.launcher && !runme.launcher.includeUnnamed",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "runme.tasksExcludeUnnamed",
           "when": "view == runme.launcher && runme.launcher.includeUnnamed",
-          "group": "navigation"
-        },
-        {
-          "command": "runme.refreshTasks",
-          "when": "view == runme.launcher",
-          "group": "navigation"
+          "group": "navigation@1"
         }
       ],
       "explorer/context": [

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -160,6 +160,12 @@ export class RunmeExtension {
           treeViewer.openCell.bind(treeViewer),
         )
       }
+      if (treeViewer.refreshTasks) {
+        RunmeExtension.registerCommand(
+          'runme.refreshTasks',
+          treeViewer.refreshTasks.bind(treeViewer),
+        )
+      }
     } else {
       treeViewer = new RunmeLauncherProvider(getDefaultWorkspace())
     }

--- a/src/extension/provider/launcher.ts
+++ b/src/extension/provider/launcher.ts
@@ -88,6 +88,8 @@ export interface RunmeTreeProvider extends TreeDataProvider<RunmeFile>, Disposab
   openNotebook?(runmeFile: RunmeFile): Promise<void>
   openCell?(runmeFile: RunmeFile): Promise<void>
   runCell?(runmeFile: RunmeFile): Promise<void>
+  refreshTasks?(): Promise<void>
+  onDidRefresh(callback: VoidFunction): Promise<void>
 }
 
 export class RunmeLauncherProvider implements RunmeTreeProvider {
@@ -97,6 +99,7 @@ export class RunmeLauncherProvider implements RunmeTreeProvider {
 
   private filesTree: Map<string, TreeFile> = new Map()
   private defaultItemState: TreeItemCollapsibleState = TreeItemCollapsibleState.Collapsed
+  private _onDidRefresh: EventEmitter<void> = new EventEmitter<void>()
 
   constructor(private workspaceRoot?: string | undefined) {
     const watcher = workspace.createFileSystemWatcher(GLOB_PATTERN, false, true, false)
@@ -104,6 +107,12 @@ export class RunmeLauncherProvider implements RunmeTreeProvider {
       watcher.onDidCreate((file) => this.#onFileChange(file, true)),
       watcher.onDidDelete((file) => this.#onFileChange(file)),
     )
+  }
+
+  onDidRefresh(_callback: VoidFunction): Promise<void> {
+    return new Promise<void>((resolve) => {
+      resolve()
+    })
   }
 
   public get includeAllTasks(): boolean {

--- a/src/extension/provider/launcherBeta.ts
+++ b/src/extension/provider/launcherBeta.ts
@@ -32,6 +32,7 @@ export class RunmeLauncherProvider implements RunmeTreeProvider {
   private defaultItemState = TreeItemCollapsibleState.Collapsed
   private _onDidChangeTreeData = new EventEmitter<RunmeFile | undefined>()
   private notebooks: RunmeFile[] = []
+  private _onDidRefresh: EventEmitter<void> = new EventEmitter<void>()
 
   constructor(
     private kernel: Kernel,
@@ -54,6 +55,21 @@ export class RunmeLauncherProvider implements RunmeTreeProvider {
     this.notebooks = []
     await commands.executeCommand('setContext', 'runme.launcher.includeUnnamed', this.allowUnnamed)
     this._onDidChangeTreeData.fire(undefined)
+  }
+
+  onDidRefresh(callback: VoidFunction): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this._onDidRefresh.event(() => {
+        callback()
+        this._onDidChangeTreeData.fire(undefined)
+        resolve()
+      })
+    })
+  }
+
+  async refreshTasks() {
+    this.notebooks = []
+    this._onDidRefresh.fire(undefined)
   }
 
   async excludeUnnamed() {
@@ -80,7 +96,6 @@ export class RunmeLauncherProvider implements RunmeTreeProvider {
   }
 
   getTreeItem(element: RunmeFile): TreeItem {
-    console.log(`Node contextValue: ${element.contextValue}`)
     return element
   }
 

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -104,6 +104,9 @@ export class RunmeTaskProvider implements TaskProvider {
     })
 
     this.tasks = lastValueFrom(this.loadProjectTasks())
+    treeView.onDidRefresh(() => {
+      this.tasks = lastValueFrom(this.loadProjectTasks())
+    })
   }
 
   private async initProjectClient(transport?: GrpcTransport) {

--- a/src/extension/provider/runmeTask.ts
+++ b/src/extension/provider/runmeTask.ts
@@ -23,9 +23,11 @@ import {
   from,
   map,
   firstValueFrom,
-  lastValueFrom,
   isObservable,
   toArray,
+  mergeMap,
+  delayWhen,
+  finalize,
 } from 'rxjs'
 
 import getLogger from '../logger'
@@ -103,9 +105,11 @@ export class RunmeTaskProvider implements TaskProvider {
       })
     })
 
-    this.tasks = lastValueFrom(this.loadProjectTasks())
+    // returns this.tasks to conform to non-null
+    this.tasks = this.refreshTasks()
+
     treeView.onDidRefresh(() => {
-      this.tasks = lastValueFrom(this.loadProjectTasks())
+      this.refreshTasks()
     })
   }
 
@@ -113,63 +117,95 @@ export class RunmeTaskProvider implements TaskProvider {
     this.client = initProjectClient(transport ?? (await this.server.transport()))
   }
 
-  protected loadProjectTasks(): Observable<ProjectTask[]> {
+  public refreshTasks(): Promise<ProjectTask[]> {
+    if (!workspace.workspaceFolders?.length) {
+      return Promise.resolve([])
+    }
+
+    this.tasks = firstValueFrom(this.loadProjectTasks())
+
+    return this.tasks
+  }
+
+  private loadProjectTasks(): Observable<ProjectTask[]> {
     if (!workspace.workspaceFolders?.length) {
       return of([])
     }
 
-    const separator = workspace.workspaceFolders[0].uri.fsPath.indexOf('/') > -1 ? '/' : '\\'
-
-    const requests = (workspace.workspaceFolders ?? []).map((folder) => {
-      return <LoadRequest>{
-        kind: {
-          oneofKind: 'directory',
-          directory: {
-            path: workspace.asRelativePath(folder.uri),
-            skipGitignore: false,
-            ignoreFilePatterns: [],
-            skipRepoLookupUpward: false,
-          },
-        },
-        identity: RunmeIdentity.ALL,
-      }
-    })
-
-    log.info(`Walking ${requests.length} directories/repos...`)
-
-    const task$ = new Observable<ProjectTask>((observer) => {
-      this.ready.then(() =>
-        Promise.all(
-          requests.map((request) => {
-            const session: LoadStream = this.client!.load(request)
-            session.responses.onMessage((msg) => {
-              if (msg.data.oneofKind !== 'foundTask') {
-                return
-              }
-              observer.next(msg.data.foundTask)
-            })
-            return session
+    const folders$ = of(workspace.workspaceFolders).pipe(
+      mergeMap((folders) => {
+        log.info(`Walking ${folders.length} directories/repos...`)
+        return from(folders).pipe(
+          map((folder) => {
+            return <LoadRequest>{
+              kind: {
+                oneofKind: 'directory',
+                directory: {
+                  path: workspace.asRelativePath(folder.uri),
+                  skipGitignore: false,
+                  ignoreFilePatterns: [],
+                  skipRepoLookupUpward: false,
+                },
+              },
+              identity: RunmeIdentity.ALL,
+            }
           }),
-        ).then(() => {
-          log.info('Finished walk.')
-          observer.complete()
-        }),
-      )
-    })
+        )
+      }),
+    )
 
-    const dirProx = (pt: ProjectTask) => {
-      const { relativePath, outside } = asWorkspaceRelativePath(pt.documentPath)
+    const task$ = folders$.pipe(
+      delayWhen(() => from(this.ready)),
+      mergeMap((folder) => {
+        return new Observable<ProjectTask>((observer) => {
+          const session: LoadStream = this.client!.load(folder)
+          session.responses.onMessage((msg) => {
+            if (msg.data.oneofKind !== 'foundTask') {
+              return
+            }
+            observer.next(msg.data.foundTask)
+          })
+          session.responses.onError((err) => observer.error(err))
+          session.responses.onComplete(() => observer.complete())
+        }).pipe(
+          finalize(() => {
+            if (folder.kind.oneofKind !== 'directory') {
+              return
+            }
+            log.info(`Finished walk ${folder.kind.directory.path}.`)
+          }),
+        )
+      }),
+    )
+
+    const dirProx = RunmeTaskProvider.directoryPromximityComp()
+    return task$.pipe(
+      toArray(),
+      map((tasks) =>
+        tasks.sort((a, b) => {
+          const delta = dirProx(a.documentPath) - dirProx(b.documentPath)
+          if (delta === 0) {
+            return a.documentPath.localeCompare(b.documentPath)
+          }
+          return delta
+        }),
+      ),
+    )
+  }
+
+  public static directoryPromximityComp = () => {
+    let separator = '/'
+    if (!!workspace.workspaceFolders?.length) {
+      separator = workspace.workspaceFolders[0].uri.fsPath.indexOf('/') > -1 ? '/' : '\\'
+    }
+    return function (path: string) {
+      const { relativePath, outside } = asWorkspaceRelativePath(path)
       const len = relativePath.split(separator).length
       if (outside) {
         return 100 * len
       }
       return len
     }
-
-    return task$.pipe(
-      toArray(),
-      map((tasks) => tasks.sort((a, b) => dirProx(a) - dirProx(b))),
-    )
   }
 
   public async provideTasks(token: CancellationToken): Promise<Task[]> {


### PR DESCRIPTION
The new launcher doesn't have a way to synchronize new, updated, or removed cells/notebooks. For now, this PR introduces a button to manually update the content of the panel. However, in a next iteration, a file system watcher would be considered.

![image](https://github.com/user-attachments/assets/a016104d-667d-441c-bea9-d37956f62dbd)
