### PR TITLE
Fix Preview Outputs when Life Cycle Id is disabled

### DIFF
--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -584,10 +584,12 @@ export class NotebookCellOutputManager {
         // mark document as dirty instead (prompt user to hit save) to avoid data-loss
         const revision = this.cell.metadata[RUNME_TRANSIENT_REVISION] ?? 1
 
-        const notebookEdits = NotebookEdit.updateCellMetadata(this.cell.index, {
+        const metadata = {
           ...(this.cell.metadata || {}),
           [RUNME_TRANSIENT_REVISION]: revision + 1,
-        } as Serializer.Metadata)
+        } as Serializer.Metadata
+
+        const notebookEdits = NotebookEdit.updateCellMetadata(this.cell.index, metadata)
 
         const edit = new WorkspaceEdit()
         edit.set(this.cell.notebook.uri, [notebookEdits])

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -604,16 +604,24 @@ export function notebookSessionOutputs(kernel: Kernel, serializer: SerializerBas
     }
 
     const { notebookUri } = e.notebookEditor
-    const outputFilePath = GrpcSerializer.getOutputsUri(notebookUri, sessionId)
-
-    try {
-      await workspace.fs.stat(outputFilePath)
-    } catch (e) {
-      await commands.executeCommand('workbench.action.files.save')
-    }
-
-    await ContextState.addKey(NOTEBOOK_PREVIEW_OUTPUTS, true)
-    await serializer.saveNotebookOutputs(notebookUri)
-    await openFileAsRunmeNotebook(outputFilePath)
+    await openPreviewOutputs(notebookUri, sessionId, serializer)
   }
+}
+
+export async function openPreviewOutputs(
+  notebookUri: Uri,
+  sessionId: string,
+  serializer: SerializerBase,
+) {
+  const outputFilePath = GrpcSerializer.getOutputsUri(notebookUri, sessionId)
+
+  try {
+    await workspace.fs.stat(outputFilePath)
+  } catch (e) {
+    await commands.executeCommand('workbench.action.files.save')
+  }
+
+  await ContextState.addKey(NOTEBOOK_PREVIEW_OUTPUTS, true)
+  await serializer.saveNotebookOutputs(notebookUri)
+  await openFileAsRunmeNotebook(outputFilePath)
 }

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -603,7 +603,6 @@ export function notebookSessionOutputs(kernel: Kernel, serializer: SerializerBas
       return
     }
 
-    await ContextState.addKey(NOTEBOOK_PREVIEW_OUTPUTS, true)
     const { notebookUri } = e.notebookEditor
     const outputFilePath = GrpcSerializer.getOutputsUri(notebookUri, sessionId)
 
@@ -613,6 +612,7 @@ export function notebookSessionOutputs(kernel: Kernel, serializer: SerializerBas
       await commands.executeCommand('workbench.action.files.save')
     }
 
+    await ContextState.addKey(NOTEBOOK_PREVIEW_OUTPUTS, true)
     await serializer.saveNotebookOutputs(notebookUri)
     await openFileAsRunmeNotebook(outputFilePath)
   }

--- a/src/extension/commands/index.ts
+++ b/src/extension/commands/index.ts
@@ -422,6 +422,10 @@ export async function toggleMasking(maskingIsOn: boolean): Promise<void> {
   ContextState.addKey(NOTEBOOK_OUTPUTS_MASKED, maskingIsOn)
 }
 
+export async function togglePreviewOutputs(previewOutputsIsOn: boolean): Promise<void> {
+  await ContextState.addKey(NOTEBOOK_PREVIEW_OUTPUTS, previewOutputsIsOn)
+}
+
 export async function runCellWithPrompts(cell: NotebookCell, kernel: Kernel) {
   await ContextState.addKey(NOTEBOOK_RUN_WITH_PROMPTS, true)
   await kernel.executeAndFocusNotebookCell(cell)
@@ -621,7 +625,7 @@ export async function openPreviewOutputs(
     await commands.executeCommand('workbench.action.files.save')
   }
 
-  await ContextState.addKey(NOTEBOOK_PREVIEW_OUTPUTS, true)
+  await togglePreviewOutputs(true)
   await serializer.saveNotebookOutputs(notebookUri)
   await openFileAsRunmeNotebook(outputFilePath)
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -66,6 +66,7 @@ import {
   runForkCommand,
   selectEnvironment,
   notebookSessionOutputs,
+  togglePreviewOutputs,
 } from './commands'
 import { WasmSerializer, GrpcSerializer, SerializerBase } from './serializer'
 import { RunmeLauncherProvider, RunmeTreeProvider } from './provider/launcher'
@@ -593,12 +594,12 @@ export class RunmeExtension {
       }
 
       await toggleMasking(maskingIsOn)
+      await togglePreviewOutputs(true)
       const written = (await this.serializer?.saveNotebookOutputs(uri)) ?? -1
       if (written > -1) {
         // success early return
         return
       }
-
       await toggleMasking(!maskingIsOn)
       await showSessionExpiryErrMessage()
     }

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -622,6 +622,7 @@ export class Kernel implements Disposable {
       TelemetryReporter.sendRawTelemetryEvent(message.output.telemetryEvent)
       return handleGistMessage({
         kernel: this,
+        serializer: this.serializer!,
         editor,
         message,
       })

--- a/src/extension/messages/platformRequest/saveCellExecution.ts
+++ b/src/extension/messages/platformRequest/saveCellExecution.ts
@@ -6,7 +6,12 @@ import getMAC from 'getmac'
 import YAML from 'yaml'
 import { FetchResult } from '@apollo/client'
 
-import { ClientMessages, NOTEBOOK_AUTOSAVE_ON, RUNME_FRONTMATTER_PARSED } from '../../../constants'
+import {
+  ClientMessages,
+  NOTEBOOK_AUTOSAVE_ON,
+  OutputType,
+  RUNME_FRONTMATTER_PARSED,
+} from '../../../constants'
 import { ClientMessage, FeatureName, IApiMessage } from '../../../types'
 import { postClientMessage } from '../../../utils/messaging'
 import ContextState from '../../contextState'
@@ -177,7 +182,7 @@ export default async function saveCellExecution(
                   outputs: (cell?.outputs || [])?.map((output) => ({
                     ...output,
                     items: (output?.items || [])?.filter((item) => {
-                      if (item.mime === 'application/vnd.code.notebook.stdout') {
+                      if (item.mime === OutputType.stdout) {
                         return item
                       }
                     }),

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -60,6 +60,7 @@ import ContextState from './contextState'
 import * as ghost from './ai/ghost'
 import getLogger from './logger'
 import features from './features'
+import { togglePreviewOutputs } from './commands'
 
 declare var globalThis: any
 const DEFAULT_LANG_ID = 'text'
@@ -610,7 +611,7 @@ export class GrpcSerializer extends SerializerBase {
     const isPreview = GrpcSerializer.isPreviewOutput()
 
     if (isPreview) {
-      await ContextState.addKey(NOTEBOOK_PREVIEW_OUTPUTS, false)
+      await togglePreviewOutputs(false)
     }
 
     const showWriteOutputs = await GrpcSerializer.shouldWriteOutputs(sessionFilePath, isPreview)

--- a/src/extension/serializer.ts
+++ b/src/extension/serializer.ts
@@ -220,15 +220,12 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
   public static async addExecInfo(data: NotebookData, kernel: Kernel): Promise<NotebookCellData[]> {
     return Promise.all(
       data.cells.map(async (cell) => {
-        /**
-         * The NotebookData structure doesn't include transient metadata,
-         * but We need the cell ID to properly track terminal outputs.
-         * I extract the cell ID from the terminal output metadata
-         * since this preserves the connection between cells and their outputs.
-         * This is particularly problematic when lifecycleIdentity is NONE
-         * since cells won't have IDs assigned directly.
-         */
-
+        // The NotebookData structure doesn't include transient metadata,
+        // but We need the cell ID to properly track terminal outputs.
+        // I extract the cell ID from the terminal output metadata
+        // since this preserves the connection between cells and their outputs.
+        // This is particularly problematic when lifecycleIdentity is NONE
+        // since cells won't have IDs assigned directly.
         const cellOutputs: NotebookCellOutput[] = cell.outputs || []
         const terminalOutputs = cellOutputs.reduce(
           (acc, curr) => {
@@ -251,17 +248,6 @@ export abstract class SerializerBase implements NotebookSerializer, Disposable {
         // so we only take the first entry
         const entries = Object.entries(terminalOutputs)
         const [id, terminalOutput] = entries.length > 0 ? entries[0] : ['', undefined]
-
-        // let id: string = ''
-        // let terminalOutput: NotebookCellOutputWithProcessInfo | undefined
-        // for (const cellOutput of cell.outputs || []) {
-        //   const terminalMime = cellOutput.items.find((item) => item.mime === OutputType.terminal)
-        //   id = cell.metadata?.['runme.dev/id'] || cell.metadata?.['id'] || ''
-        //   if (terminalMime && id) {
-        //     terminalOutput = cellOutput
-        //     break
-        //   }
-        // }
 
         const notebookCell = await getCellById({ id })
         if (notebookCell && terminalOutput) {

--- a/src/extension/signedIn.ts
+++ b/src/extension/signedIn.ts
@@ -88,6 +88,11 @@ export class SignedIn implements Disposable {
       return
     }
 
+    if (!cellRunmeId) {
+      log.warn('cell runme ID not found')
+      return
+    }
+
     if (!editor) {
       log.warn('no active notebook editor')
       return

--- a/tests/extension/serializer.test.ts
+++ b/tests/extension/serializer.test.ts
@@ -75,6 +75,10 @@ vi.mock('../../src/extension/features')
 
 vi.mock('../../src/extension/contextState')
 
+vi.mock('../../src/extension/commands', () => ({
+  togglePreviewOutputs: vi.fn(),
+}))
+
 function newKernel(): Kernel {
   return {} as unknown as Kernel
 }


### PR DESCRIPTION
The NotebookData structure doesn't include transient metadata, but I need the cell ID to properly track terminal outputs.

I extract the cell ID from the terminal output metadata, which is always available when the cell has a terminal output. This is a more reliable way to get the cell ID

This is particularly problematic when lifecycleIdentity is NONE since cells won't have IDs assigned directly.

Closes: stateful/runme#728

- [x] Ensure session outputs when Life Cycle Id is NONE
- [x] Unmask / Mask is still linked with the Auto-Save
- [x] Preview & Gist is still linked with the Auto-Save