### PR TITLE
Use RingBuffer to prevent ever-growing buffer

### DIFF
--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -369,13 +369,19 @@ export class NotebookCellOutputManager {
     outputState.delete(cellId)
   }
 
-  registerCellTerminalState(type: NotebookTerminalType): ITerminalState {
+  registerCellTerminalState({
+    type,
+    scrollback,
+  }: {
+    type: NotebookTerminalType
+    scrollback: number
+  }): ITerminalState {
     let terminalState: ITerminalState
 
     switch (type) {
       case 'xterm':
         {
-          const _terminalState = new XTermState()
+          const _terminalState = new XTermState(scrollback)
           const _write = _terminalState.write
           const _input = _terminalState.input
 
@@ -394,7 +400,7 @@ export class NotebookCellOutputManager {
 
       case 'local':
         {
-          const _terminalState = new LocalBufferTermState()
+          const _terminalState = new LocalBufferTermState(scrollback)
           const _write = _terminalState.write
 
           _terminalState.write = (data) => {

--- a/src/extension/cell.ts
+++ b/src/extension/cell.ts
@@ -377,11 +377,14 @@ export class NotebookCellOutputManager {
     scrollback: number
   }): ITerminalState {
     let terminalState: ITerminalState
+    // Limit the number of emitted chunks which can include line-breaks
+    // to avoid excessive memory usage
+    const chunksLimit = scrollback
 
     switch (type) {
       case 'xterm':
         {
-          const _terminalState = new XTermState(scrollback)
+          const _terminalState = new XTermState(chunksLimit)
           const _write = _terminalState.write
           const _input = _terminalState.input
 
@@ -400,7 +403,7 @@ export class NotebookCellOutputManager {
 
       case 'local':
         {
-          const _terminalState = new LocalBufferTermState(scrollback)
+          const _terminalState = new LocalBufferTermState(chunksLimit)
           const _write = _terminalState.write
 
           _terminalState.write = (data) => {

--- a/src/extension/executors/runner/index.ts
+++ b/src/extension/executors/runner/index.ts
@@ -244,7 +244,7 @@ export const executeRunner: IKernelRunner = async ({
   let mimeType = cellMimeType
   if (interactive) {
     if (terminalState instanceof XTermState) {
-      terminalState.cleanBuffer()
+      terminalState.resetBuffer()
     }
 
     if (revealNotebookTerminal) {

--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -325,7 +325,8 @@ export class Kernel implements Disposable {
     type: NotebookTerminalType,
   ): Promise<ITerminalState> {
     const outputs = await this.cellManager.getNotebookOutputs(cell)
-    return outputs.registerCellTerminalState(type)
+    const { scrollback } = getNotebookTerminalConfigurations(cell.notebook.metadata)
+    return outputs.registerCellTerminalState({ type, scrollback })
   }
 
   async #setNotebookMode(notebookDocument: NotebookDocument): Promise<void> {

--- a/src/extension/runner/index.ts
+++ b/src/extension/runner/index.ts
@@ -854,7 +854,7 @@ export class GrpcRunnerTerminalSession
   }
 
   get data(): Promise<string> {
-    const term = new XTermSerializer()
+    const term = new XTermSerializer(100000)
     return this.raw.then((data) => {
       return term.write(data).then(() => {
         const serialized = term.serialize()

--- a/src/extension/terminal/terminalState.ts
+++ b/src/extension/terminal/terminalState.ts
@@ -66,7 +66,7 @@ export class XTermState implements ITerminalState {
   }
 
   resetBuffer(): RingBuffer<string> {
-    // capactiy is items vs lines because we don't handle line breaks
+    // capacity is items vs lines because we don't handle line breaks
     this.buffer = new RingBuffer<string>(this.capacity)
     return this.buffer
   }

--- a/src/ringBuffer.ts
+++ b/src/ringBuffer.ts
@@ -1,0 +1,36 @@
+export class RingBuffer<T> {
+  private buffer: T[]
+  private head: number
+  private tail: number
+  private size: number
+
+  constructor(capacity: number) {
+    this.buffer = new Array<T>(capacity)
+    this.head = 0
+    this.tail = 0
+    this.size = 0
+  }
+
+  push(line: T): void {
+    this.buffer[this.tail] = line
+    this.tail = (this.tail + 1) % this.buffer.length
+    if (this.size < this.buffer.length) {
+      this.size++
+    } else {
+      this.head = (this.head + 1) % this.buffer.length
+    }
+  }
+
+  get length(): number {
+    return this.size
+  }
+
+  getAll(): T[] {
+    const items: T[] = []
+    for (let i = 0; i < this.size; i++) {
+      const index = (this.head + i) % this.buffer.length
+      items.push(this.buffer[index])
+    }
+    return items
+  }
+}

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -48,7 +48,7 @@ const notebookTerminalSchema = {
   cursorBlink: z.boolean().default(true).optional(),
   cursorWidth: z.number().min(1).optional(),
   smoothScrollDuration: z.number().optional(),
-  scrollback: z.number().optional(),
+  scrollback: z.number(),
   closeOnSuccess: z.boolean().default(true),
 }
 

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -112,7 +112,7 @@ export async function assertDocumentContainsSpinner(
   matcher: string,
   exact: boolean = false,
   retries: number = 2, // three tries in total
-  interval: number = 100,
+  interval: number = 200,
 ) {
   try {
     await assertDocumentContains(absDocPath, matcher, exact)

--- a/tests/ringBuffer.test.ts
+++ b/tests/ringBuffer.test.ts
@@ -1,0 +1,32 @@
+import { suite, test, expect } from 'vitest'
+
+import { RingBuffer } from '../src/ringBuffer'
+
+suite('RingBuffer', () => {
+  test('should push items', () => {
+    const buffer = new RingBuffer<string>(5)
+
+    buffer.push('Line 1')
+    buffer.push('Line 2')
+    buffer.push('Line 3')
+    buffer.push('Line 4')
+    buffer.push('Line 5')
+
+    expect(buffer).toHaveLength(5)
+    expect(buffer.getAll()).toEqual(['Line 1', 'Line 2', 'Line 3', 'Line 4', 'Line 5'])
+  })
+
+  test('should overwrite oldest item on push over capacity', () => {
+    const buffer = new RingBuffer<string>(5)
+
+    buffer.push('Line 1')
+    buffer.push('Line 2')
+    buffer.push('Line 3')
+    buffer.push('Line 4')
+    buffer.push('Line 5')
+    buffer.push('Line 6') // overwrites "Line 1"
+
+    expect(buffer).toHaveLength(5)
+    expect(buffer.getAll()).toEqual(['Line 2', 'Line 3', 'Line 4', 'Line 5', 'Line 6'])
+  })
+})


### PR DESCRIPTION
Ever-growing buffers are dangerous for memory consumption and downstream API limits. To avoid running into API payload limits, use `scrollback` settings as a buffer limit.

I have encountered issues when a chatty background process runs inside a notebook terminal. After a while, it will experience both remote and kernel API size limitations.

Using the `scrollback` setting will put control into a user's hands.