### PR TITLE
Use workspace folders as cwd for remote notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1233,6 +1233,10 @@
       {
         "view": "runme.launcher",
         "contents": "Open a workspace/folder to display Runme files here"
+      },
+      {
+        "view": "runme.remoteNotebooks",
+        "contents": "Displays Cloud Notebooks"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -1236,7 +1236,7 @@
       },
       {
         "view": "runme.remoteNotebooks",
-        "contents": "Displays Cloud Notebooks"
+        "contents": "Explore Cloud Notebooks"
       }
     ],
     "keybindings": [

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -92,7 +92,7 @@ import { RunmeIdentity } from './grpc/parser/tcp/types'
 import * as features from './features'
 import AuthSessionChangeHandler from './authSessionChangeHandler'
 import { CloudNotebooks } from './provider/cloudNotebooks'
-import RunmeFS from './provider/runmeFs'
+import RunmeFS, { RunmeFsScheme } from './provider/runmeFs'
 
 export class RunmeExtension {
   protected serializer?: ISerializer
@@ -107,7 +107,7 @@ export class RunmeExtension {
       await ContextState.addKey(FeatureName.RemoteNotebooks, true)
       const runmeFs = new RunmeFS()
       context.subscriptions.push(
-        workspace.registerFileSystemProvider('runmefs', runmeFs, {
+        workspace.registerFileSystemProvider(RunmeFsScheme, runmeFs, {
           isReadonly: false,
         }),
         commands.registerCommand('runme.addRemoteNotebooks', (_) => {

--- a/src/extension/provider/runmeFs.ts
+++ b/src/extension/provider/runmeFs.ts
@@ -30,6 +30,8 @@ const excludedPaths = [
   '.runme_bootstrap_demo',
 ]
 
+export const RunmeFsScheme = 'runmefs'
+
 export function mergeUriPaths(uri: Uri, newPath: string): Uri {
   const isAbsolutePath = newPath.startsWith('/')
 
@@ -54,11 +56,11 @@ export default class RunmeFS implements FileSystemProvider {
   #pathTree: PathTree = {}
 
   get root() {
-    return Uri.parse('runmefs:///')
+    return Uri.parse(`${RunmeFsScheme}:///`)
   }
 
   static resolveUri(path: string) {
-    return Uri.parse(`runmefs:///${path}`)
+    return Uri.parse(`${RunmeFsScheme}:///${path}`)
   }
 
   async readFile(uri: Uri): Promise<Uint8Array> {


### PR DESCRIPTION
Workspace folders now serve as the current working directory for remote notebooks. This is necessary for shebang cell runs.

When no workspace is detected, it defaults to using a temporary directory.