### PR TITLE
ANSI sequences need to be interpreted for TUIs

### DIFF
--- a/src/extension/executors/runner/index.ts
+++ b/src/extension/executors/runner/index.ts
@@ -40,7 +40,7 @@ import {
   getServerRunnerVersion,
   isNotebookTerminalEnabledForCell,
 } from '../../../utils/configuration'
-import { ITerminalState, XTermState } from '../../terminal/terminalState'
+import { ITerminalState } from '../../terminal/terminalState'
 import { toggleTerminal } from '../../commands'
 import { closeTerminalByEnvID, openTerminalByEnvID } from '../task'
 import {
@@ -280,10 +280,6 @@ export const executeRunner: IKernelRunner = async ({
 
   let mimeType = cellMimeType
   if (interactive) {
-    if (terminalState instanceof XTermState) {
-      terminalState.resetBuffer()
-    }
-
     if (revealNotebookTerminal) {
       program.registerTerminalWindow('notebook')
       await program.setActiveTerminalWindow('notebook')


### PR DESCRIPTION
We're coming full circle here. While the `RingBuffer` worked well to manage capacity, it lacks the interpretation of TUI-like ANSI sequences. TUIs ncurses-like UIs that aren't just growing text output, they use the screen more like a canvas.

This PR handles TUIs better (still needs to capture notebook terminal dimensions), especially when saved as Gist or into the Cloud.

Compare https://gist.github.com/sourishkrout/dbc9037bce8fcf17ba283db939ddc804 (no term emu) vs https://gist.github.com/sourishkrout/7d382f162313d01cc9b1ae0120d93e49 (with term emu).