### PR TITLE
Buffering for non-tty output (non-interactive) in the vscode-integrated terminal

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -500,7 +500,7 @@ export class RunmeExtension {
       kernel
         .runProgram('echo $SHELL')
         .then((output) => {
-          if (output === false) {
+          if (output === undefined) {
             return
           }
 

--- a/src/extension/runner/index.ts
+++ b/src/extension/runner/index.ts
@@ -6,6 +6,8 @@ import {
   EventEmitter,
 } from 'vscode'
 import stripAnsi from 'strip-ansi'
+import { Observable } from 'rxjs'
+import { bufferTime, map, endWith, startWith } from 'rxjs/operators'
 
 import type { DisposableAsync, Serializer } from '../../types'
 import {
@@ -430,13 +432,46 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
   ) {
     this.session = this.client.execute()
 
-    this.register(
-      this._onStdoutRaw.event((data) => {
-        // TODO: web compat
-        const stdout = Buffer.from(data).toString('utf-8')
-        this._onDidWrite.fire(stdout)
+    // unbufferd
+    const decoder = new TextDecoder()
+    let decodedStdout$: Observable<string> = new Observable<Uint8Array>((observer) => {
+      this.register(this._onStdoutRaw.event((bytes) => observer.next(bytes)))
+      this.register(
+        this._onDidClose.event(() => {
+          observer.complete()
+          this.dispose()
+        }),
+      )
+      this.register(
+        this._onInternalErr.event((err) => {
+          observer.error(err)
+          this.dispose()
+        }),
+      )
+    }).pipe(
+      map((bytes) => {
+        if (!this.isPseudoterminal()) {
+          return this.LFToCRLF(bytes)
+        }
+        return bytes
+      }),
+      map((bytes) => {
+        return decoder.decode(bytes)
       }),
     )
+
+    // buffered
+    if (!this.isPseudoterminal()) {
+      decodedStdout$ = decodedStdout$.pipe(
+        startWith('\r'),
+        endWith('\r\n'),
+        bufferTime(100),
+        map((chunks) => chunks.join('')),
+      )
+    }
+
+    const sub = decodedStdout$.subscribe((data) => this._onDidWrite.fire(data))
+    this.register({ dispose: () => sub.unsubscribe() })
 
     this.register(
       this._onStderrRaw.event((data) => {
@@ -453,9 +488,6 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
         this._onDidWrite.fire(yellowStderr)
       }),
     )
-
-    this.register(this._onDidClose.event(() => this.dispose()))
-    this.register(this._onInternalErr.event(() => this.dispose()))
 
     let detectedMimeType = ''
     this.session.responses.onMessage(({ stderrData, stdoutData, exitCode, pid, mimeType }) => {
@@ -520,24 +552,29 @@ export class GrpcRunnerProgramSession implements IRunnerProgramSession {
 
   protected write(channel: 'stdout' | 'stderr', mimeType: string, bytes: Uint8Array): void {
     if (this.convertEol(mimeType) && !this.isPseudoterminal()) {
-      const newBytes = new Array(bytes.byteLength)
-
-      let i = 0,
-        j = 0
-      while (j < bytes.byteLength) {
-        const byte = bytes[j++]
-
-        if (byte === 0x0a) {
-          newBytes[i++] = 0x0d
-        }
-
-        newBytes[i++] = byte
-      }
-
-      bytes = Buffer.from(newBytes)
+      bytes = this.LFToCRLF(bytes)
     }
 
     return this[GrpcRunnerProgramSession.WRITE_LISTENER[channel]].fire(bytes)
+  }
+
+  protected LFToCRLF(bytes: Uint8Array) {
+    const newBytes = new Array(bytes.byteLength)
+
+    let i = 0,
+      j = 0
+    while (j < bytes.byteLength) {
+      const byte = bytes[j++]
+
+      if (byte === 0x0a) {
+        newBytes[i++] = 0x0d
+      }
+
+      newBytes[i++] = byte
+    }
+
+    bytes = Buffer.from(newBytes)
+    return bytes
   }
 
   protected async init(opts?: RunProgramOptions) {

--- a/tests/e2e/specs/codelense.e2e.ts
+++ b/tests/e2e/specs/codelense.e2e.ts
@@ -26,7 +26,7 @@ describe('Runme Codelense Support', async () => {
 
     const workbench = await browser.getWorkbench()
     const text = await getTerminalText(workbench)
-    expect(text).toContain('Hello World!\n ')
+    expect(text).toContain('Hello World!\n\n *')
     await killAllTerminals(workbench)
   })
 


### PR DESCRIPTION
This mimics what we do in the notebook and makes the terminal output more readable. Especially if both `stdout` and `stderr` are interspersed.

The difference is **with buffering**:
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/2b878c00-d9bf-4b81-8f43-5e70e641f8de" />

Before the change **without buffering**:
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/2ec4be7e-6ead-4d77-bdf0-3abfee6d2936" />

Example cell (`interactive: false`): https://gist.github.com/sourishkrout/d61c3226473afdc030951bdc167d15cd#file-01jkvp47gcjh2s6mgysf16j06b-md