### PR TITLE
Disable deactivate-panels workflow for edge releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,7 @@ jobs:
         uses: stateful/runme-action@v2
         with:
           workflows: deactivate-panels
+        if: ${{ github.event.inputs.releaseChannel != 'edge'}}
 
       - name: Deactivate smart env store for stable
         uses: stateful/runme-action@v2


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/release.yml` file. The update adds a condition to ensure that the deactivate-panels workflow only runs if the releaseChannel is not set to 'edge'.

This change is necessary to enable and test the Cloud Search and Chat features within the Edge Release channel.