### PR TITLE
Add tests for SignedIn operations

### DIFF
--- a/src/extension/signedIn.ts
+++ b/src/extension/signedIn.ts
@@ -25,8 +25,8 @@ export interface CellRun {
 const log = getLogger('SignedIn')
 
 export class SignedIn implements Disposable {
-  #subscriptions: Subscription[] = []
-  readonly #cellRuns = new Subject<CellRun>()
+  protected subscriptions: Subscription[] = []
+  protected cellRuns = new Subject<CellRun>()
 
   constructor(protected readonly kernel: Kernel) {
     const signedIn$ = new Observable<boolean>((observer) => {
@@ -42,7 +42,7 @@ export class SignedIn implements Disposable {
       nextSession(StatefulAuthProvider.instance.currentSession())
     })
 
-    const cellRuns$ = this.#cellRuns.pipe(
+    const cellRuns$ = this.cellRuns.pipe(
       withLatestFrom(signedIn$),
       mergeMap(([cellRun, active]) => {
         if (!active) {
@@ -71,7 +71,7 @@ export class SignedIn implements Disposable {
       }),
     )
 
-    this.#subscriptions.push(cellRuns$.subscribe())
+    this.subscriptions.push(cellRuns$.subscribe())
   }
 
   enqueueCellRun(
@@ -101,7 +101,7 @@ export class SignedIn implements Disposable {
       return
     }
 
-    this.#cellRuns.next({
+    this.cellRuns.next({
       cell: {
         id: cellRunmeId,
       },
@@ -123,6 +123,6 @@ export class SignedIn implements Disposable {
   }
 
   dispose() {
-    this.#subscriptions.forEach((sub) => sub.unsubscribe())
+    this.subscriptions.forEach((sub) => sub.unsubscribe())
   }
 }

--- a/tests/extension/signedin.test.ts
+++ b/tests/extension/signedin.test.ts
@@ -1,0 +1,132 @@
+import { vi, expect, describe, it, beforeEach, afterEach } from 'vitest'
+import { AuthenticationSessionsChangeEvent, NotebookCell, NotebookEditor } from 'vscode'
+import { Subject } from 'rxjs'
+
+import { CellRun, SignedIn } from '../../src/extension/signedIn'
+import { RunmeEventInputType } from '../../src/extension/__generated-platform__/graphql'
+import { APIMethod } from '../../src/types'
+import { ClientMessages } from '../../src/constants'
+import AuthSessionChangeHandler from '../../src/extension/authSessionChangeHandler'
+import { StatefulAuthProvider } from '../../src/extension/provider/statefulAuth'
+
+vi.mock('../../src/extension/logger', () => {
+  return {
+    default: vi.fn(),
+  }
+})
+
+vi.mock('../../src/extension/provider/statefulAuth', () => {
+  return {
+    StatefulAuthProvider: {
+      instance: {
+        currentSession: vi.fn().mockResolvedValue({}),
+      },
+    },
+  }
+})
+
+vi.mock('../../src/extension/authSessionChangeHandler', () => {
+  return {
+    default: {
+      instance: {
+        addListener: vi.fn(),
+      },
+    },
+  }
+})
+
+vi.mock('../../src/extension/serializer', () => {
+  return {
+    ConnectSerializer: {
+      marshalFrontmatter: vi.fn().mockImplementation(() => ({
+        runme: { id: 'notebook-id' },
+      })),
+    },
+  }
+})
+
+describe('SignedIn', () => {
+  let mockKernel: any
+  let signedIn: SignedIn | null
+
+  beforeEach(() => {
+    mockKernel = {
+      handleRendererMessage: vi.fn().mockResolvedValue(true),
+    }
+    signedIn = new SignedIn(mockKernel)
+  })
+
+  afterEach(() => {
+    signedIn?.dispose()
+    signedIn = null
+  })
+
+  it('should initialize observables correctly', () => {
+    expect(signedIn).toBeDefined()
+    expect(signedIn?.['cellRuns']).toBeDefined()
+    expect(signedIn?.['subscriptions']).toBeDefined()
+  })
+
+  it('should dispose subscriptions correctly', () => {
+    const subscription = { unsubscribe: vi.fn() }
+    signedIn?.['subscriptions'].push(subscription as any)
+    signedIn?.dispose()
+
+    expect(subscription.unsubscribe).toHaveBeenCalled()
+  })
+
+  it('should enqueue cell run correctly', async () => {
+    const mockCell = {
+      notebook: {
+        metadata: {},
+        uri: { path: '/path/to/notebook' },
+      },
+      metadata: { 'runme.dev/id': 'cell-id' },
+    } as unknown as NotebookCell
+    const mockEditor = {} as NotebookEditor
+    const startTime = 1000
+    const endTime = 2000
+    const success = true
+
+    const cellRunSubject = signedIn?.['cellRuns'] as Subject<CellRun>
+    await new Promise((resolve) => {
+      cellRunSubject.subscribe((cellRun) => {
+        expect(mockKernel.handleRendererMessage).toHaveBeenCalledWith({
+          editor: mockEditor,
+          message: {
+            output: {
+              data: {
+                type: RunmeEventInputType.RunCell,
+                cell: cellRun.cell,
+                notebook: cellRun.notebook,
+                executionSummary: cellRun.executionSummary,
+              },
+              id: '',
+              method: APIMethod.TrackRunmeEvent,
+            },
+            type: ClientMessages.platformApiRequest,
+          },
+        })
+
+        resolve(undefined)
+      })
+
+      signedIn?.enqueueCellRun(mockCell, mockEditor, success, startTime, endTime)
+    })
+  })
+
+  it('should call currentSession twice when auth session changes', async () => {
+    let listener: (event: AuthenticationSessionsChangeEvent) => void
+
+    vi.mocked(StatefulAuthProvider.instance.currentSession).mockReset()
+    vi.mocked(AuthSessionChangeHandler.instance.addListener).mockImplementationOnce((l) => {
+      listener = l
+    })
+
+    signedIn = new SignedIn(mockKernel)
+
+    listener!({ provider: { id: 'provider-id' } } as unknown as AuthenticationSessionsChangeEvent)
+
+    expect(StatefulAuthProvider.instance.currentSession).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
This pull request includes changes to the `SignedIn` class in `src/extension/signedIn.ts` to improve code accessibility and adds new tests for the `SignedIn` class in `tests/extension/signedin.test.ts`.

- [x] Ensure proper initialization of observables, correct disposal of subscriptions, and accurate enqueuing of cell runs.
- [x] Add unit tests to verify the right functionality on session changes.

Closes: #1933