### PR TITLE
Allowing runing all cells in parallel

### DIFF
--- a/src/extension/kernel.ts
+++ b/src/extension/kernel.ts
@@ -749,6 +749,8 @@ export class Kernel implements Disposable {
           default:
             break outer
         }
+      } else {
+        cellsToRunSerial = [cell]
       }
 
       for (const cell of cellsToRunSerial) {


### PR DESCRIPTION
This introduces a new option to run all cells sequentially and in parallel based on the user's preference.

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/afa100ba-62f9-4acd-ad5a-5d4ff94e30ae" />

Solves https://github.com/stateful/runme/issues/737.