### PR TITLE
Setting for direnv that's default disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@buf/jlewi_foyle.bufbuild_es": "^1.10.0-20241219050144-856e893555b3.1",
         "@buf/jlewi_foyle.connectrpc_es": "^1.6.1-20241219050144-856e893555b3.2",
         "@buf/stateful_runme.bufbuild_es": "^1.10.0-20250206174444-18b490372055.1",
-        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.4-20250206174444-18b490372055.4",
+        "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.4-20250307183813-2cbd47eaf1cf.4",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-node": "^1.6.1",
         "@google-cloud/compute": "^4.9.0",
@@ -2375,15 +2375,15 @@
       }
     },
     "node_modules/@buf/stateful_runme.bufbuild_es": {
-      "version": "1.10.0-20250206174444-18b490372055.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.bufbuild_es/-/stateful_runme.bufbuild_es-1.10.0-20250206174444-18b490372055.1.tgz",
+      "version": "1.10.0-20250307183813-2cbd47eaf1cf.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.bufbuild_es/-/stateful_runme.bufbuild_es-1.10.0-20250307183813-2cbd47eaf1cf.1.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts": {
-      "version": "2.9.4-20250206174444-18b490372055.4",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.4-20250206174444-18b490372055.4.tgz",
+      "version": "2.9.4-20250307183813-2cbd47eaf1cf.4",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/stateful_runme.community_timostamm-protobuf-ts/-/stateful_runme.community_timostamm-protobuf-ts-2.9.4-20250307183813-2cbd47eaf1cf.4.tgz",
       "peerDependencies": {
         "@protobuf-ts/runtime": "^2.9.4",
         "@protobuf-ts/runtime-rpc": "^2.9.4"

--- a/package.json
+++ b/package.json
@@ -1436,7 +1436,7 @@
     "@buf/jlewi_foyle.bufbuild_es": "^1.10.0-20241219050144-856e893555b3.1",
     "@buf/jlewi_foyle.connectrpc_es": "^1.6.1-20241219050144-856e893555b3.2",
     "@buf/stateful_runme.bufbuild_es": "^1.10.0-20250206174444-18b490372055.1",
-    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.4-20250206174444-18b490372055.4",
+    "@buf/stateful_runme.community_timostamm-protobuf-ts": "^2.9.4-20250307183813-2cbd47eaf1cf.4",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-node": "^1.6.1",
     "@google-cloud/compute": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -1031,6 +1031,19 @@
             "default": true,
             "markdownDescription": "Load environment files from workspace into all scripts"
           },
+          "runme.env.dirEnv": {
+            "type": "number",
+            "default": 3,
+            "enum": [
+              1,
+              3
+            ],
+            "enumItemLabels": [
+              "Enabled",
+              "Disabled"
+            ],
+            "markdownDescription": "Specifies if and how direnv should be loaded"
+          },
           "runme.cli.useIntegratedRunme": {
             "type": "boolean",
             "default": false,

--- a/src/extension/runner/index.ts
+++ b/src/extension/runner/index.ts
@@ -32,7 +32,7 @@ import { IRunnerServiceClient, RpcError } from '../grpc/tcpClient'
 import { getSystemShellPath } from '../executors/utils'
 import { IServer } from '../server/kernelServer'
 import { convertEnvList } from '../utils'
-import { getEnvWorkspaceFileOrder } from '../../utils/configuration'
+import { getEnvDirEnv, getEnvWorkspaceFileOrder } from '../../utils/configuration'
 import getLogger from '../logger'
 import { XTermSerializer } from '../terminal/terminalState'
 
@@ -271,6 +271,7 @@ export default class GrpcRunner implements IRunner {
     metadata?: { [index: string]: string }
   }) {
     const envLoadOrder = getEnvWorkspaceFileOrder()
+    const envDirenv = getEnvDirEnv()
     // v1 calls it envs, whereas v2 calls it env - send both
     const req = <any>{
       metadata,
@@ -279,6 +280,7 @@ export default class GrpcRunner implements IRunner {
       project: {
         root: workspaceRoot,
         envLoadOrder,
+        envDirenv,
       },
       envStoreType,
       config: {

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -76,6 +76,7 @@ const configurationSchema = {
   env: {
     workspaceFileOrder: z.array(z.string()).default(DEFAULT_WORKSPACE_FILE_ORDER),
     loadWorkspaceFiles: z.boolean().default(true),
+    dirEnv: z.number().default(3),
   },
   cli: {
     useIntegratedRunme: z.boolean().default(false),
@@ -373,6 +374,10 @@ const getEnvLoadWorkspaceFiles = (): boolean => {
   return getEnvConfigurationValue('loadWorkspaceFiles', true)
 }
 
+const getEnvDirEnv = (): number => {
+  return getEnvConfigurationValue('dirEnv', 3)
+}
+
 const getCLIUseIntegratedRunme = (): boolean => {
   return getCLIConfigurationValue('useIntegratedRunme', false)
 }
@@ -496,6 +501,7 @@ export {
   getDocsUrl,
   getDocsUrlFor,
   getEnvLoadWorkspaceFiles,
+  getEnvDirEnv,
   getEnvWorkspaceFileOrder,
   getForceNewWindowConfig,
   getLoginPrompt,


### PR DESCRIPTION
This setting remains disabled by default disabled during a soft rollout.

- [x] Requires kernel binary including https://github.com/stateful/runme/pull/757.
- [x] Requires protobufs to be published and linked.