### PR TITLE
Update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please visit Runme's documentation to learn about its purpose, all its features,
 - [https://docs.runme.dev/](https://docs.runme.dev/)
 
 Feel free to submit any issues you may have via the
-[issue tracker](https://github.com/runmedev/vscode-runme/issues) or [tell us about it on Discord](https://discord.gg/runme).
+[issue tracker](https://github.com/runmedev/vscode-runme/issues) or [tell us about it on Discord](https://discord.gg/jFy92yxT).
 
 ## Guides
 
@@ -80,7 +80,7 @@ Runme is under active development. Please be aware of following known limitation
 
 We would love to hear feedback, appreciate your patience, as Runme continutes to harden. Get in touch please!
 
-- [Join our Discord](https://discord.gg/runme)
+- [Join our Discord](https://discord.gg/jFy92yxT)
 - [Submit an Issue](https://github.com/stateful/runme/issues)
 - [Contribute on GitHub](https://github.com/runmedev/vscode-runme/blob/main/CONTRIBUTING.md)
 - [Read the Docs](https://docs.runme.dev/)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "badges": [
     {
       "url": "https://img.shields.io/badge/Runme-Join%20our%20Community-blue?logo=discord&color=F62459",
-      "href": "https://discord.gg/runme",
+      "href": "https://discord.gg/jFy92yxT",
       "description": "Join the Runme Community"
     }
   ],

--- a/walkthroughs/3-learn-more.md
+++ b/walkthroughs/3-learn-more.md
@@ -6,7 +6,7 @@ Learn more about Runme by visiting the [official docs](https://docs.runme.dev) a
 
 Join the Runme community on:
 
-- [Discord](https://discord.gg/runme)
+- [Discord](https://discord.gg/jFy92yxT)
 - [X](https://x.com/runmedev) with `#runme`
 - [YouTube](https://www.youtube.com/@runmedev)
 


### PR DESCRIPTION
## Summary
- Replace `https://discord.gg/runme` with `https://discord.gg/jFy92yxT`

## Verification
- `rg --fixed-strings "https://discord.gg/runme" .` returned no matches
- Reviewed git diff for URL-only changes